### PR TITLE
blob-gateway: Bearer-token auth + SS58 coexistence (pre-mainnet security hardening)

### DIFF
--- a/services/blob-gateway/Dockerfile
+++ b/services/blob-gateway/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json ./
 RUN npm install --production
 
 COPY dist/ ./dist/
+COPY bin/ ./bin/
 
 USER node
 

--- a/services/blob-gateway/README.md
+++ b/services/blob-gateway/README.md
@@ -45,15 +45,99 @@ SDK / Operator  -->  Blob Gateway  -->  Disk storage (/data/blobs)
 | `POST` | `/batches/:anchorId` | Create batch metadata |
 | `PUT` | `/batches/:anchorId` | Update batch metadata |
 
+### Admin-only (x-admin-token)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/auth/token` | Mint a new Bearer token for an operator (returns plaintext ONCE) |
+| `DELETE` | `/auth/token/:hash` | Revoke a token by its sha256 hash |
+| `GET` | `/auth/tokens` | List all tokens (hashes + metadata; never raw tokens) |
+
+All three require `x-admin-token: <DAEMON_NOTIFY_TOKEN>` in headers.
+
 ## Authentication
 
-Three-tier auth model resolved by `resolveAuth()` in `src/auth.ts`:
+Four-tier auth model resolved by `resolveAuth()` in `src/auth.ts`:
 
 | Tier | Auth mechanism | Upload quota |
 |------|----------------|-------------|
+| **bearer** | `Authorization: Bearer matra_<token>` (preferred, revocable, hashed) | Same as api-key |
 | **sig-only** | sr25519 signature + funded on-chain account | 10 receipts/day, 256 MB/day, 3 concurrent |
-| **api-key** | `x-api-key` header | Per-key (default 100/day, 1 GB/day, 5 concurrent) |
+| **api-key** | `x-api-key` header (legacy random-hex key) | Per-key (default 100/day, 1 GB/day, 5 concurrent) |
+| **api-key-legacy-ss58** | `x-api-key` header containing the operator's SS58 address (**deprecated**; each call is warn-logged) | Per-key quotas |
 | **registered-validator** | Signature + committee registry membership | API-key-level quotas |
+
+### Bearer Tokens (Preferred)
+
+Bearer tokens are the new default. They are:
+
+- **Opaque** — `matra_<43 base62 chars>`, 256 bits of entropy from `crypto.randomBytes`.
+- **Hashed at rest** — only `sha256(token)` is stored in `operators.db:api_tokens`.
+- **Shown once** — returned by `POST /auth/token` and never again. Lost token => mint a new one.
+- **Revocable** — `DELETE /auth/token/:hash` marks `revoked_at`; the middleware rejects subsequent requests.
+- **Auditable** — every successful verify updates `last_used_at`; `listTokens()` exposes activity.
+
+#### How to get a token
+
+Ask an admin (someone with `x-admin-token` access) to mint one for your SS58:
+
+```bash
+curl -X POST https://materios.fluxpointstudios.com/preprod-blobs/auth/token \
+  -H "x-admin-token: <shared-admin-secret>" \
+  -H "content-type: application/json" \
+  -d '{"account":"5YourSs58Address...","label":"penny-macbook"}'
+# {
+#   "status": "created",
+#   "token": "matra_AbCdEf...",         <-- store NOW, only shown once
+#   "tokenHash": "3fa8...64 hex...",
+#   ...
+# }
+```
+
+Or from inside the gateway container:
+
+```bash
+docker exec materios-node-blob-gateway-preprod-1 \
+  node /app/bin/issue-token.mjs --account 5Your... --label "penny-macbook"
+```
+
+#### How to use a token
+
+```bash
+curl -H "Authorization: Bearer matra_AbCdEf..." \
+     https://materios.fluxpointstudios.com/preprod-blobs/blobs/<hash>/status
+```
+
+For clients built on `@fluxpointstudios/orynq-sdk-anchors-materios`, set the
+`apiKey` field of `BlobGatewayConfig` to the raw Bearer token. The SDK already
+forwards via `x-api-key` today; until the SDK is upgraded (follow-up PR), wrap
+your own fetch call that sends `Authorization: Bearer ...`.
+
+#### How to rotate
+
+1. Mint a new token with a fresh label (e.g. `"penny-macbook-2026-05"`).
+2. Update the client config / env var (`MATERIOS_BLOB_GATEWAY_TOKEN`).
+3. Restart the client, confirm it works.
+4. Revoke the old token: `curl -X DELETE .../auth/token/<old-hash> -H "x-admin-token: ..."`.
+
+### Legacy SS58-as-API-key (Deprecated)
+
+Historically operators sent their SS58 address as the API key (`x-api-key: <ss58>`).
+This is still accepted for backwards compatibility but:
+
+- Every such call emits a structured warn log — grep for `deprecated-ss58-auth`
+  in blob-gateway logs to track clients that haven't migrated.
+- The secret is an operator's public on-chain identity — anyone watching the
+  explorer can guess it. It will be removed in a future PR after all clients
+  have migrated.
+
+Sample migration-tracking grep:
+
+```bash
+docker logs materios-node-blob-gateway-preprod-1 2>&1 \
+  | grep deprecated-ss58-auth \
+  | awk '{print $4}' | sort | uniq -c | sort -rn
+```
 
 ### Upload Signing Protocol
 
@@ -104,7 +188,9 @@ Clock skew tolerance: 120 seconds (configurable via `UPLOAD_SIG_MAX_AGE_SEC`).
 ```
 src/
   index.ts            Express app entry, route mounting
-  auth.ts             Unified resolveAuth() for write endpoints
+  auth.ts             Unified resolveAuth() for write endpoints (Bearer > api-key > sig)
+  bearer-auth.ts      bearerAuth() middleware + adminGuard()
+  api-tokens.ts       Issue/verify/revoke/list Bearer tokens (sha256 at rest)
   upload-auth.ts      verifyUploadSig() for sr25519 signatures
   rpc-client.ts       Lazy @polkadot/api singleton, checkFunded(), checkReceiptStatus()
   quota.ts            API key + account quota management (SQLite)
@@ -120,11 +206,32 @@ src/
     heartbeats.ts     Validator heartbeat dual-auth
     chunks.ts         Chunk download
     locators.ts       Receipt-to-blob locator resolution
+    operators.ts      Invite-only operator registration
+    tokens.ts         Admin: /auth/token mint/revoke/list
     status.ts         System status endpoint
+bin/
+  issue-token.mjs     Admin CLI: mint a Bearer token (JSON stdout)
+  revoke-token.mjs    Admin CLI: revoke a Bearer token by hash
 k8s/
   configmap.yaml      Environment configuration
   deployment.yaml     K8s Deployment spec
   secret.yaml         Sensitive config (API keys, etc.)
+```
+
+## Admin CLI
+
+```bash
+# Mint a new token for an operator (inside the container)
+docker exec materios-node-blob-gateway-preprod-1 \
+  node /app/bin/issue-token.mjs \
+    --account 5YourSs58Address... \
+    --label "penny-macbook"
+
+# Revoke a token by its sha256 hash
+docker exec materios-node-blob-gateway-preprod-1 \
+  node /app/bin/revoke-token.mjs \
+    --hash 3fa8...<64 hex>... \
+    --reason "lost laptop"
 ```
 
 ## Build and Deploy

--- a/services/blob-gateway/bin/issue-token.mjs
+++ b/services/blob-gateway/bin/issue-token.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Mint a new Bearer auth token for a Materios operator.
+ *
+ * Usage (inside the blob-gateway container):
+ *   node /app/bin/issue-token.mjs --account 5... --label "penny-macbook"
+ *
+ * The raw token is printed to stdout EXACTLY ONCE. The DB stores only
+ * sha256(token). If lost, mint a new one and revoke the old hash.
+ */
+
+import BetterSqlite3 from "better-sqlite3";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import {
+  initApiTokensDb,
+  issueToken,
+} from "../dist/api-tokens.js";
+
+function usage(err) {
+  if (err) console.error(`error: ${err}`);
+  console.error(
+    "usage: issue-token.mjs --account <SS58> [--label <text>] [--db /path/operators.db]",
+  );
+  process.exit(err ? 2 : 0);
+}
+
+const { values } = parseArgs({
+  options: {
+    account: { type: "string", short: "a" },
+    label: { type: "string", short: "l" },
+    db: { type: "string" },
+    help: { type: "boolean", short: "h" },
+  },
+  allowPositionals: false,
+});
+
+if (values.help) usage(null);
+const account = (values.account || "").trim();
+const label = (values.label || "").trim();
+if (!account) usage("--account is required");
+if (!/^[15][a-zA-Z0-9]{45,47}$/.test(account)) {
+  usage(`invalid SS58 address: ${account}`);
+}
+
+const dbPath =
+  (typeof values.db === "string" && values.db) ||
+  join(process.env.STORAGE_PATH || "/data/blobs", "operators.db");
+
+const handle = new BetterSqlite3(dbPath);
+handle.pragma("busy_timeout = 5000");
+initApiTokensDb(handle);
+
+const issued = issueToken(handle, {
+  accountSs58: account,
+  label: label || undefined,
+});
+
+process.stdout.write(
+  JSON.stringify(
+    {
+      status: "created",
+      token: issued.token, // SHOWN ONCE
+      tokenHash: issued.tokenHash,
+      account: issued.accountSs58,
+      label: issued.label,
+      createdAt: issued.createdAt,
+      message:
+        "Store this token now. Only its sha256 is persisted. Lost token => mint a new one.",
+    },
+    null,
+    2,
+  ) + "\n",
+);

--- a/services/blob-gateway/bin/revoke-token.mjs
+++ b/services/blob-gateway/bin/revoke-token.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Revoke a Materios Bearer auth token by its sha256 hash.
+ *
+ * Usage (inside the blob-gateway container):
+ *   node /app/bin/revoke-token.mjs --hash <sha256-hex> [--reason "lost laptop"]
+ */
+
+import BetterSqlite3 from "better-sqlite3";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { initApiTokensDb, revokeToken } from "../dist/api-tokens.js";
+
+function usage(err) {
+  if (err) console.error(`error: ${err}`);
+  console.error(
+    "usage: revoke-token.mjs --hash <sha256-hex> [--reason <text>] [--db /path/operators.db]",
+  );
+  process.exit(err ? 2 : 0);
+}
+
+const { values } = parseArgs({
+  options: {
+    hash: { type: "string" },
+    reason: { type: "string" },
+    db: { type: "string" },
+    help: { type: "boolean", short: "h" },
+  },
+  allowPositionals: false,
+});
+
+if (values.help) usage(null);
+const hash = (values.hash || "").trim().toLowerCase();
+if (!hash) usage("--hash is required");
+if (!/^[0-9a-f]{64}$/.test(hash)) usage(`invalid token hash (expected 64 hex): ${hash}`);
+
+const dbPath =
+  (typeof values.db === "string" && values.db) ||
+  join(process.env.STORAGE_PATH || "/data/blobs", "operators.db");
+
+const handle = new BetterSqlite3(dbPath);
+handle.pragma("busy_timeout = 5000");
+initApiTokensDb(handle);
+
+const result = revokeToken(handle, {
+  tokenHash: hash,
+  reason: values.reason || "cli-revoke",
+});
+
+if (!result.revoked) {
+  console.error(
+    JSON.stringify(
+      { status: "noop", tokenHash: hash, reason: "not found or already revoked" },
+      null,
+      2,
+    ),
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  JSON.stringify(
+    { status: "revoked", tokenHash: hash, reason: values.reason || "cli-revoke" },
+    null,
+    2,
+  ) + "\n",
+);

--- a/services/blob-gateway/src/__tests__/api-tokens.test.ts
+++ b/services/blob-gateway/src/__tests__/api-tokens.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for api-tokens.ts (Bearer-token auth for blob-gateway).
+ *
+ * Uses an in-memory SQLite database so tests are isolated and run without
+ * touching any real /data/blobs/*.db file.
+ */
+
+import { describe, test, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { createHash } from "crypto";
+import {
+  initApiTokensDb,
+  issueToken,
+  verifyToken,
+  revokeToken,
+  listTokens,
+  hashToken,
+  TOKEN_PREFIX,
+} from "../api-tokens.js";
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = WAL");
+  initApiTokensDb(db);
+  return db;
+}
+
+describe("api-tokens: token generation", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  test("token_generation_returns_prefixed_base62_of_correct_length", () => {
+    const { token } = issueToken(db, {
+      accountSs58: "5EXAMPLE1111111111111111111111111111111111111",
+      label: "unit-test",
+    });
+    // Format: matra_<base62 43 chars> — total ≈ 49 chars
+    expect(token.startsWith(TOKEN_PREFIX)).toBe(true);
+    expect(token.length).toBe(TOKEN_PREFIX.length + 43);
+    expect(token.slice(TOKEN_PREFIX.length)).toMatch(/^[0-9A-Za-z]+$/);
+  });
+
+  test("token_stored_as_sha256_hash_not_raw", () => {
+    const { token } = issueToken(db, {
+      accountSs58: "5EXAMPLE1111111111111111111111111111111111111",
+      label: "unit-test-hash",
+    });
+    // The raw token must NOT be anywhere in the DB.
+    const rows = db.prepare("SELECT * FROM api_tokens").all() as Array<{
+      token_hash: string;
+    }>;
+    expect(rows.length).toBe(1);
+    const expectedHash = createHash("sha256").update(token).digest("hex");
+    expect(rows[0]!.token_hash).toBe(expectedHash);
+    const serialized = JSON.stringify(rows);
+    expect(serialized).not.toContain(token);
+  });
+
+  test("issuing_two_tokens_for_same_account_produces_distinct_tokens", () => {
+    const a = issueToken(db, {
+      accountSs58: "5EXAMPLE1111111111111111111111111111111111111",
+      label: "one",
+    });
+    const b = issueToken(db, {
+      accountSs58: "5EXAMPLE1111111111111111111111111111111111111",
+      label: "two",
+    });
+    expect(a.token).not.toBe(b.token);
+    expect(a.tokenHash).not.toBe(b.tokenHash);
+  });
+});
+
+describe("api-tokens: verifyToken", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  test("bearer_token_auth_success_sets_account_from_db", () => {
+    const { token } = issueToken(db, {
+      accountSs58: "5OperatorAddress123456789012345678901234567",
+      label: "happy-path",
+    });
+    const result = verifyToken(db, token);
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error("unreachable");
+    expect(result.accountSs58).toBe("5OperatorAddress123456789012345678901234567");
+    expect(result.label).toBe("happy-path");
+  });
+
+  test("bearer_token_auth_fails_on_unknown_hash", () => {
+    const bogus = `${TOKEN_PREFIX}zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz`;
+    const result = verifyToken(db, bogus);
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error("unreachable");
+    expect(result.reason).toBe("unknown");
+  });
+
+  test("bearer_token_auth_fails_on_revoked_token", () => {
+    const { token, tokenHash } = issueToken(db, {
+      accountSs58: "5Revoked1111111111111111111111111111111111111",
+      label: "to-be-revoked",
+    });
+    const ok = verifyToken(db, token);
+    expect(ok.valid).toBe(true);
+
+    revokeToken(db, { tokenHash, reason: "test-revoke" });
+
+    const after = verifyToken(db, token);
+    expect(after.valid).toBe(false);
+    if (after.valid) throw new Error("unreachable");
+    expect(after.reason).toBe("revoked");
+  });
+
+  test("bearer_token_auth_updates_last_used_at", async () => {
+    const { token, tokenHash } = issueToken(db, {
+      accountSs58: "5UsageTracking1111111111111111111111111111111",
+      label: "usage",
+    });
+
+    // Freshly issued: last_used_at is NULL
+    const before = db
+      .prepare("SELECT last_used_at FROM api_tokens WHERE token_hash = ?")
+      .get(tokenHash) as { last_used_at: number | null };
+    expect(before.last_used_at).toBeNull();
+
+    const fixedNow = 1_700_000_000;
+    const result = verifyToken(db, token, { now: fixedNow });
+    expect(result.valid).toBe(true);
+
+    const after = db
+      .prepare("SELECT last_used_at FROM api_tokens WHERE token_hash = ?")
+      .get(tokenHash) as { last_used_at: number | null };
+    expect(after.last_used_at).toBe(fixedNow);
+  });
+
+  test("verifyToken_rejects_token_without_prefix", () => {
+    const result = verifyToken(db, "not-a-matra-token");
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error("unreachable");
+    expect(result.reason).toBe("malformed");
+  });
+});
+
+describe("api-tokens: revoke + list", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  test("admin_revoke_marks_token_inactive", () => {
+    const { tokenHash } = issueToken(db, {
+      accountSs58: "5Revoke222222222222222222222222222222222222222",
+      label: "admin-revoke",
+    });
+    const res = revokeToken(db, { tokenHash, reason: "lost-laptop" });
+    expect(res.revoked).toBe(true);
+
+    const row = db
+      .prepare(
+        "SELECT revoked_at, revoked_reason FROM api_tokens WHERE token_hash = ?",
+      )
+      .get(tokenHash) as { revoked_at: number | null; revoked_reason: string | null };
+    expect(row.revoked_at).not.toBeNull();
+    expect(row.revoked_reason).toBe("lost-laptop");
+  });
+
+  test("revokeToken_returns_false_for_unknown_hash", () => {
+    const res = revokeToken(db, { tokenHash: "deadbeef", reason: "nope" });
+    expect(res.revoked).toBe(false);
+  });
+
+  test("revoking_twice_is_idempotent_and_preserves_first_reason", () => {
+    const { tokenHash } = issueToken(db, {
+      accountSs58: "5Idempotent11111111111111111111111111111111111",
+      label: "double-revoke",
+    });
+    revokeToken(db, { tokenHash, reason: "first" });
+    const res2 = revokeToken(db, { tokenHash, reason: "second" });
+    // second revoke is a no-op (token already revoked)
+    expect(res2.revoked).toBe(false);
+
+    const row = db
+      .prepare("SELECT revoked_reason FROM api_tokens WHERE token_hash = ?")
+      .get(tokenHash) as { revoked_reason: string };
+    expect(row.revoked_reason).toBe("first");
+  });
+
+  test("listTokens_returns_hashes_and_metadata_never_the_raw", () => {
+    const a = issueToken(db, {
+      accountSs58: "5ListOneaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      label: "a",
+    });
+    const b = issueToken(db, {
+      accountSs58: "5ListTwobbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      label: "b",
+    });
+
+    const list = listTokens(db);
+    expect(list.length).toBe(2);
+    for (const row of list) {
+      expect(row).toHaveProperty("tokenHash");
+      expect(row).toHaveProperty("accountSs58");
+      expect(row).toHaveProperty("label");
+      expect(row).toHaveProperty("createdAt");
+      // The listing MUST NEVER include raw tokens
+      const serialized = JSON.stringify(row);
+      expect(serialized).not.toContain(a.token);
+      expect(serialized).not.toContain(b.token);
+    }
+  });
+
+  test("hashToken_matches_issueToken_storage", () => {
+    const { token, tokenHash } = issueToken(db, {
+      accountSs58: "5HashMatch11111111111111111111111111111111111",
+      label: "hash-match",
+    });
+    expect(hashToken(token)).toBe(tokenHash);
+  });
+});

--- a/services/blob-gateway/src/__tests__/bearer-auth.test.ts
+++ b/services/blob-gateway/src/__tests__/bearer-auth.test.ts
@@ -242,6 +242,33 @@ describe("bearer auth middleware", () => {
     expect(body.token.startsWith(TOKEN_PREFIX)).toBe(true);
   });
 
+  test("admin_guard_rejects_wrong_length_admin_token_without_leaking_length", async () => {
+    // A candidate shorter than the real admin token used to short-circuit
+    // on `!==`, which leaks length via timing. With constant-time compare
+    // all rejections take the same code path; we only assert on the
+    // observable behaviour (401 + no side effect).
+    const tooShort = await fetchJson(ctx.app, "POST", "/auth/token", {
+      headers: { "x-admin-token": "a" },
+      body: { account: "5ShouldNotBeCreated11111111111111111111111111", label: "x" },
+    });
+    expect(tooShort.status).toBe(401);
+
+    const tooLong = await fetchJson(ctx.app, "POST", "/auth/token", {
+      headers: {
+        "x-admin-token": ctx.adminToken + "extra-suffix-that-should-fail",
+      },
+      body: { account: "5ShouldNotBeCreated11111111111111111111111112", label: "x" },
+    });
+    expect(tooLong.status).toBe(401);
+
+    // And an empty header too.
+    const empty = await fetchJson(ctx.app, "POST", "/auth/token", {
+      headers: { "x-admin-token": "" },
+      body: { account: "5ShouldNotBeCreated11111111111111111111111113", label: "x" },
+    });
+    expect(empty.status).toBe(401);
+  });
+
   test("admin_revoke_marks_token_inactive", async () => {
     const mintRes = await fetchJson(ctx.app, "POST", "/auth/token", {
       headers: { "x-admin-token": ctx.adminToken },

--- a/services/blob-gateway/src/__tests__/bearer-auth.test.ts
+++ b/services/blob-gateway/src/__tests__/bearer-auth.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Integration tests for the unified Bearer / x-api-key / SS58-as-API-key auth path.
+ *
+ * Builds a minimal Express app around resolveKey() + the Bearer middleware,
+ * with an in-memory SQLite DB, so we can exercise header parsing and
+ * deprecated-SS58 warn-logging end-to-end.
+ */
+
+import { describe, test, expect, beforeEach, vi, afterEach } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import { createHash, randomBytes } from "crypto";
+import { initApiTokensDb, issueToken, setApiTokensDb, TOKEN_PREFIX } from "../api-tokens.js";
+import { setQuotaDbForTests, resolveKey } from "../quota.js";
+import { mintAdminTokenForTests, registerTokenRoutes, setOperatorsDbForTests } from "../routes/tokens.js";
+import { bearerAuth } from "../bearer-auth.js";
+
+type MountedApp = {
+  app: express.Express;
+  ss58: string;
+  /** Raw API key derived directly from an SS58 (legacy behaviour). */
+  legacyApiKey: string;
+  /** Plaintext Bearer token for the same SS58. */
+  bearerToken: string;
+  adminToken: string;
+  tokensDb: Database.Database;
+  quotaDb: Database.Database;
+  operatorsDb: Database.Database;
+};
+
+function setupApp(): MountedApp {
+  // Unique per-test DBs
+  const quotaDb = new Database(":memory:");
+  quotaDb.pragma("journal_mode = WAL");
+  quotaDb.exec(`
+    CREATE TABLE api_keys (
+      key_hash TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+      max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+      max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+      validator_id TEXT DEFAULT NULL
+    );
+  `);
+  setQuotaDbForTests(quotaDb);
+
+  const tokensDb = new Database(":memory:");
+  tokensDb.pragma("journal_mode = WAL");
+  initApiTokensDb(tokensDb);
+  setApiTokensDb(tokensDb);
+
+  const operatorsDb = new Database(":memory:");
+  operatorsDb.pragma("journal_mode = WAL");
+  operatorsDb.exec(`
+    CREATE TABLE registrations (
+      ss58_address TEXT PRIMARY KEY,
+      public_key TEXT,
+      label TEXT NOT NULL,
+      api_key_hash TEXT NOT NULL,
+      invite_token_hash TEXT NOT NULL,
+      registered_at TEXT NOT NULL,
+      approved_at TEXT,
+      status TEXT NOT NULL DEFAULT 'registered',
+      session_keys TEXT,
+      peer_id TEXT
+    );
+  `);
+  setOperatorsDbForTests(operatorsDb);
+
+  // Create a known operator with a known API key derived from SS58
+  // (legacy path: `x-api-key: <ss58>` works). SS58 shape: ^[15][a-zA-Z0-9]{45,47}$
+  const ss58 = "5OperatorTestaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab";
+  const legacyKeyHash = createHash("sha256").update(ss58).digest("hex");
+  quotaDb
+    .prepare(
+      `INSERT INTO api_keys (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id)
+       VALUES (?, ?, 1, 100, 1073741824, 5, ?)`,
+    )
+    .run(legacyKeyHash, "operator-legacy", ss58);
+
+  // Mint a Bearer token for the same account.
+  const { token: bearerToken } = issueToken(tokensDb, {
+    accountSs58: ss58,
+    label: "bearer-token",
+  });
+
+  const adminToken = `admin-${randomBytes(16).toString("hex")}`;
+
+  const app = express();
+  app.use(express.json());
+
+  // Protected probe: mirrors the pattern upload routes will use.
+  app.post("/echo", bearerAuth({ required: true }), (req, res) => {
+    res.json({
+      account: (req as unknown as { account?: string }).account ?? null,
+      tier: (req as unknown as { authTier?: string }).authTier ?? null,
+    });
+  });
+
+  registerTokenRoutes(app, { adminToken });
+
+  return {
+    app,
+    ss58,
+    legacyApiKey: ss58,
+    bearerToken,
+    adminToken,
+    tokensDb,
+    quotaDb,
+    operatorsDb,
+  };
+}
+
+async function fetchJson(
+  app: express.Express,
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const port = 0; // ephemeral
+    const server = app.listen(port, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { "content-type": "application/json", ...(opts.headers || {}) },
+      };
+      if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let body: unknown;
+          try {
+            body = text ? JSON.parse(text) : null;
+          } catch {
+            body = text;
+          }
+          server.close();
+          resolve({ status: res.status, body });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+describe("bearer auth middleware", () => {
+  let ctx: MountedApp;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let warnSpy: any;
+  beforeEach(() => {
+    ctx = setupApp();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation((() => {}) as (...args: unknown[]) => void);
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("bearer_token_auth_success_sets_account_from_db", async () => {
+    const res = await fetchJson(ctx.app, "POST", "/echo", {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      body: {},
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ account: ctx.ss58, tier: "bearer" });
+  });
+
+  test("bearer_token_auth_fails_on_unknown_hash", async () => {
+    const bogus = `${TOKEN_PREFIX}aAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa`;
+    const res = await fetchJson(ctx.app, "POST", "/echo", {
+      headers: { authorization: `Bearer ${bogus}` },
+      body: {},
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("bearer_token_auth_fails_on_revoked_token", async () => {
+    // Revoke via the admin route
+    const list = await fetchJson(ctx.app, "GET", "/auth/tokens", {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(list.status).toBe(200);
+    const tokens = (list.body as { tokens: Array<{ tokenHash: string }> }).tokens;
+    const th = tokens[0]!.tokenHash;
+
+    const rev = await fetchJson(ctx.app, "DELETE", `/auth/token/${th}`, {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { reason: "testing" },
+    });
+    expect(rev.status).toBe(200);
+
+    const after = await fetchJson(ctx.app, "POST", "/echo", {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      body: {},
+    });
+    expect(after.status).toBe(401);
+  });
+
+  test("ss58_legacy_auth_still_works_but_emits_warn_log", async () => {
+    // Legacy pattern: send SS58 as the x-api-key
+    const res = await fetchJson(ctx.app, "POST", "/echo", {
+      headers: { "x-api-key": ctx.legacyApiKey },
+      body: {},
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ account: ctx.ss58, tier: "api-key-legacy-ss58" });
+
+    // warn-log must have fired
+    const calls = (warnSpy.mock.calls as unknown[][]).map((c) => c.join(" "));
+    const deprecationLog = calls.find((m: string) => m.includes("deprecated-ss58-auth"));
+    expect(deprecationLog, `warn log not emitted: ${JSON.stringify(calls)}`).toBeTruthy();
+    expect(deprecationLog).toContain(ctx.ss58);
+  });
+
+  test("invalid_auth_returns_401", async () => {
+    const res = await fetchJson(ctx.app, "POST", "/echo", { body: {} });
+    expect(res.status).toBe(401);
+  });
+
+  test("admin_mint_requires_elevated_auth", async () => {
+    // No admin token → 401
+    const unauth = await fetchJson(ctx.app, "POST", "/auth/token", {
+      body: { account: "5NewOperator111111111111111111111111111111111", label: "x" },
+    });
+    expect(unauth.status).toBe(401);
+
+    // With admin token → 200 + returned token is prefixed
+    const good = await fetchJson(ctx.app, "POST", "/auth/token", {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { account: "5NewOperator1111111111111111111111111111111111", label: "x" },
+    });
+    expect(good.status).toBe(200);
+    const body = good.body as { token: string; tokenHash: string };
+    expect(body.token.startsWith(TOKEN_PREFIX)).toBe(true);
+  });
+
+  test("admin_revoke_marks_token_inactive", async () => {
+    const mintRes = await fetchJson(ctx.app, "POST", "/auth/token", {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { account: "5RevokeViaApi1111111111111111111111111111111111", label: "revoke-me" },
+    });
+    expect(mintRes.status).toBe(200);
+    const { token, tokenHash } = mintRes.body as { token: string; tokenHash: string };
+
+    // Works pre-revoke
+    const pre = await fetchJson(ctx.app, "POST", "/echo", {
+      headers: { authorization: `Bearer ${token}` },
+      body: {},
+    });
+    expect(pre.status).toBe(200);
+
+    const rev = await fetchJson(ctx.app, "DELETE", `/auth/token/${tokenHash}`, {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { reason: "testing" },
+    });
+    expect(rev.status).toBe(200);
+
+    const post = await fetchJson(ctx.app, "POST", "/echo", {
+      headers: { authorization: `Bearer ${token}` },
+      body: {},
+    });
+    expect(post.status).toBe(401);
+  });
+
+  test("bearer_beats_legacy_when_both_headers_present", async () => {
+    // Bearer (new) must take priority: good Bearer + bogus SS58 → 200 on Bearer
+    const { token } = issueToken(ctx.tokensDb, {
+      accountSs58: "5Priority1111111111111111111111111111111111111",
+      label: "priority",
+    });
+    const res = await fetchJson(ctx.app, "POST", "/echo", {
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-api-key": "5BogusSs58222222222222222222222222222222222",
+      },
+      body: {},
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ account: "5Priority1111111111111111111111111111111111111", tier: "bearer" });
+  });
+});
+
+describe("admin CLI helper", () => {
+  test("mintAdminTokenForTests_issues_a_token_and_inserts_a_row", () => {
+    const db = new Database(":memory:");
+    db.pragma("journal_mode = WAL");
+    initApiTokensDb(db);
+
+    const { token, tokenHash } = mintAdminTokenForTests(db, {
+      account: "5CliTest11111111111111111111111111111111111111",
+      label: "cli-test",
+    });
+    expect(token.startsWith(TOKEN_PREFIX)).toBe(true);
+    const row = db
+      .prepare("SELECT token_hash, account_ss58 FROM api_tokens WHERE token_hash = ?")
+      .get(tokenHash) as { token_hash: string; account_ss58: string };
+    expect(row.account_ss58).toBe("5CliTest11111111111111111111111111111111111111");
+  });
+});
+
+// Smoke-test the quota db injection so other tests don't rot silently
+describe("quota db test hook", () => {
+  test("resolveKey_returns_null_for_unknown", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE api_keys (
+        key_hash TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+        max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+        max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+        validator_id TEXT DEFAULT NULL
+      );
+    `);
+    setQuotaDbForTests(db);
+    expect(resolveKey("no-such-key")).toBeNull();
+  });
+});

--- a/services/blob-gateway/src/api-tokens.ts
+++ b/services/blob-gateway/src/api-tokens.ts
@@ -1,0 +1,252 @@
+/**
+ * Opaque Bearer tokens for blob-gateway authentication.
+ *
+ * Replaces the legacy "SS58-as-API-key" pattern in which operators sent
+ * their on-chain address (public info) as the secret. Tokens here are
+ * cryptographically random, prefixed with `matra_`, displayed ONCE at mint,
+ * and stored only as sha256(token_hash) in the `api_tokens` table.
+ *
+ * Storage lives in the same SQLite file as operators.db — these tokens
+ * are identity-scoped (one token authorizes as one SS58 account), and the
+ * registration pipeline already writes to operators.db.
+ */
+
+import Database from "better-sqlite3";
+import { createHash, randomBytes } from "crypto";
+import { join } from "path";
+import { config } from "./config.js";
+
+export const TOKEN_PREFIX = "matra_";
+/** Random bytes per token before base62-encoding. 32 = 256 bits of entropy. */
+export const TOKEN_RANDOM_BYTES = 32;
+
+/** Shared DB handle, set by initApiTokensDb() at boot (or by tests). */
+let db: Database.Database | null = null;
+
+export function setApiTokensDb(database: Database.Database): void {
+  db = database;
+}
+
+export function getApiTokensDb(): Database.Database {
+  if (!db) throw new Error("api-tokens db not initialised — call initApiTokensDb() first");
+  return db;
+}
+
+/**
+ * Initialise the api_tokens table on the supplied SQLite handle.
+ * Safe to call repeatedly (CREATE IF NOT EXISTS).
+ *
+ * When called with no arg, opens (or creates) operators.db at the canonical
+ * path and stores the handle as the module default. Tests pass an in-memory
+ * handle instead.
+ */
+export function initApiTokensDb(database?: Database.Database): Database.Database {
+  const handle = database ?? new Database(join(config.storagePath, "operators.db"));
+  handle.pragma("journal_mode = WAL");
+  handle.pragma("busy_timeout = 5000");
+  handle.exec(`
+    CREATE TABLE IF NOT EXISTS api_tokens (
+      token_hash TEXT PRIMARY KEY,
+      account_ss58 TEXT NOT NULL,
+      label TEXT,
+      created_at INTEGER NOT NULL,
+      last_used_at INTEGER,
+      revoked_at INTEGER,
+      revoked_reason TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_api_tokens_account ON api_tokens(account_ss58);
+  `);
+  if (!db) db = handle;
+  return handle;
+}
+
+/**
+ * sha256-hex of a plaintext token. Stable, one-way, never reversed.
+ */
+export function hashToken(plaintext: string): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}
+
+/**
+ * Encode a Buffer as base62. 32 random bytes → 43 chars
+ * (ceil(log62(2^256)) = 43). Keeps tokens ASCII-safe for any transport.
+ */
+const BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+function toBase62(buf: Uint8Array): string {
+  // Treat the input as a big-endian bignum. For 32 bytes this is a BigInt of
+  // up to 256 bits; base62 encoding is log_62(2^256) ≈ 42.99 → always 43 chars
+  // after left-padding.
+  let n = 0n;
+  for (const b of buf) n = (n << 8n) | BigInt(b);
+  let out = "";
+  if (n === 0n) out = "0";
+  while (n > 0n) {
+    const rem = Number(n % 62n);
+    out = BASE62_ALPHABET[rem] + out;
+    n = n / 62n;
+  }
+  return out.padStart(43, "0");
+}
+
+export interface IssueTokenInput {
+  accountSs58: string;
+  label?: string | undefined;
+  /** Unix seconds override; used by tests for determinism. */
+  now?: number;
+}
+
+export interface IssuedToken {
+  /** Plaintext token — SHOWN ONCE, never persisted. */
+  token: string;
+  /** sha256(token) — what's actually in the DB. */
+  tokenHash: string;
+  accountSs58: string;
+  label: string | null;
+  createdAt: number;
+}
+
+/**
+ * Generate a new random token and insert the hashed row.
+ * Returns the plaintext token to the caller — caller MUST forward it to
+ * the operator immediately; we will never be able to reconstruct it.
+ */
+export function issueToken(
+  database: Database.Database,
+  input: IssueTokenInput,
+): IssuedToken {
+  const raw = randomBytes(TOKEN_RANDOM_BYTES);
+  const token = `${TOKEN_PREFIX}${toBase62(raw)}`;
+  const tokenHash = hashToken(token);
+  const label = input.label ?? null;
+  const createdAt = input.now ?? Math.floor(Date.now() / 1000);
+
+  database
+    .prepare(
+      `INSERT INTO api_tokens (token_hash, account_ss58, label, created_at) VALUES (?, ?, ?, ?)`,
+    )
+    .run(tokenHash, input.accountSs58, label, createdAt);
+
+  return { token, tokenHash, accountSs58: input.accountSs58, label, createdAt };
+}
+
+export interface VerifyTokenOptions {
+  /** Unix seconds override; used by tests. */
+  now?: number;
+}
+
+export type VerifyResult =
+  | { valid: true; accountSs58: string; label: string | null; tokenHash: string }
+  | { valid: false; reason: "malformed" | "unknown" | "revoked" };
+
+/**
+ * Verify a plaintext Bearer token against the DB.
+ * On success, bumps last_used_at atomically.
+ */
+export function verifyToken(
+  database: Database.Database,
+  plaintext: string,
+  opts: VerifyTokenOptions = {},
+): VerifyResult {
+  if (typeof plaintext !== "string" || !plaintext.startsWith(TOKEN_PREFIX)) {
+    return { valid: false, reason: "malformed" };
+  }
+  const tokenHash = hashToken(plaintext);
+  const row = database
+    .prepare(
+      `SELECT account_ss58, label, revoked_at FROM api_tokens WHERE token_hash = ?`,
+    )
+    .get(tokenHash) as
+    | { account_ss58: string; label: string | null; revoked_at: number | null }
+    | undefined;
+
+  if (!row) return { valid: false, reason: "unknown" };
+  if (row.revoked_at !== null) return { valid: false, reason: "revoked" };
+
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  database
+    .prepare(`UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?`)
+    .run(now, tokenHash);
+
+  return { valid: true, accountSs58: row.account_ss58, label: row.label, tokenHash };
+}
+
+export interface RevokeTokenInput {
+  tokenHash: string;
+  reason?: string | undefined;
+  /** Unix seconds override; used by tests. */
+  now?: number;
+}
+
+export interface RevokeResult {
+  /** true iff this call flipped an active token to revoked. */
+  revoked: boolean;
+}
+
+/**
+ * Mark a token as revoked. Idempotent: no-op if already revoked or unknown.
+ */
+export function revokeToken(
+  database: Database.Database,
+  input: RevokeTokenInput,
+): RevokeResult {
+  const now = input.now ?? Math.floor(Date.now() / 1000);
+  const info = database
+    .prepare(
+      `UPDATE api_tokens SET revoked_at = ?, revoked_reason = ?
+       WHERE token_hash = ? AND revoked_at IS NULL`,
+    )
+    .run(now, input.reason ?? null, input.tokenHash);
+  return { revoked: info.changes > 0 };
+}
+
+export interface ListedToken {
+  tokenHash: string;
+  accountSs58: string;
+  label: string | null;
+  createdAt: number;
+  lastUsedAt: number | null;
+  revokedAt: number | null;
+  revokedReason: string | null;
+}
+
+/**
+ * List tokens (hashes + metadata only). Filter by account or include revoked.
+ */
+export function listTokens(
+  database: Database.Database,
+  opts: { account?: string; includeRevoked?: boolean } = {},
+): ListedToken[] {
+  const where: string[] = [];
+  const params: (string | number)[] = [];
+  if (opts.account) {
+    where.push("account_ss58 = ?");
+    params.push(opts.account);
+  }
+  if (!opts.includeRevoked) {
+    where.push("revoked_at IS NULL");
+  }
+  const sql = `
+    SELECT token_hash, account_ss58, label, created_at, last_used_at, revoked_at, revoked_reason
+    FROM api_tokens
+    ${where.length ? "WHERE " + where.join(" AND ") : ""}
+    ORDER BY created_at DESC
+  `;
+  const rows = database.prepare(sql).all(...params) as Array<{
+    token_hash: string;
+    account_ss58: string;
+    label: string | null;
+    created_at: number;
+    last_used_at: number | null;
+    revoked_at: number | null;
+    revoked_reason: string | null;
+  }>;
+  return rows.map((r) => ({
+    tokenHash: r.token_hash,
+    accountSs58: r.account_ss58,
+    label: r.label,
+    createdAt: r.created_at,
+    lastUsedAt: r.last_used_at,
+    revokedAt: r.revoked_at,
+    revokedReason: r.revoked_reason,
+  }));
+}

--- a/services/blob-gateway/src/auth.ts
+++ b/services/blob-gateway/src/auth.ts
@@ -1,7 +1,8 @@
 /**
  * Unified auth helper for all write routes (Phase 4).
  *
- * Three tiers:
+ * Four tiers:
+ * - bearer: `Authorization: Bearer matra_<token>` — opaque random token (preferred)
  * - api-key: Backwards-compatible API key auth (highest quotas)
  * - registered-validator: sr25519 sig from registered committee member (API-key-level quotas)
  * - sig-only: sr25519 sig from any funded account (default quotas)
@@ -11,8 +12,18 @@ import type { Request } from "express";
 import { resolveKey, lookupValidatorInfo, type KeyInfo } from "./quota.js";
 import { verifyUploadSig } from "./upload-auth.js";
 import { checkFunded } from "./rpc-client.js";
+import {
+  getApiTokensDb,
+  verifyToken,
+  TOKEN_PREFIX,
+} from "./api-tokens.js";
 
-export type AuthTier = "sig-only" | "api-key" | "registered-validator";
+export type AuthTier =
+  | "bearer"
+  | "sig-only"
+  | "api-key"
+  | "api-key-legacy-ss58"
+  | "registered-validator";
 
 export interface AuthResult {
   authenticated: boolean;
@@ -22,16 +33,65 @@ export interface AuthResult {
   error?: string;
 }
 
+/** SS58 address shape check — mirrors the one in routes/operators.ts. */
+const SS58_SHAPE = /^[15][a-zA-Z0-9]{45,47}$/;
+
 /**
  * Resolve auth for any request.
  * @param contentHash — required for upload sig verification (manifest/chunk/batch routes)
  */
 export async function resolveAuth(req: Request, contentHash?: string): Promise<AuthResult> {
+  // Priority 0: Bearer token (preferred, opaque, revocable, hashed-at-rest)
+  const authHeader = (req.headers.authorization || (req.headers as Record<string, unknown>)[
+    "Authorization"
+  ]) as string | undefined;
+  if (typeof authHeader === "string" && authHeader.startsWith("Bearer ")) {
+    const token = authHeader.slice("Bearer ".length).trim();
+    if (token.startsWith(TOKEN_PREFIX)) {
+      try {
+        const verify = verifyToken(getApiTokensDb(), token);
+        if (verify.valid) {
+          return {
+            authenticated: true,
+            tier: "bearer",
+            identity: verify.accountSs58,
+          };
+        }
+        return {
+          authenticated: false,
+          error: `Invalid bearer token: ${verify.reason}`,
+        };
+      } catch (err) {
+        // api-tokens DB not yet initialized — fall through to legacy paths
+        // so we fail closed only when there's no other valid credential.
+        console.error(
+          `[blob-gateway] bearer-auth error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
   // Priority 1: API key (highest trust, backwards compatible)
   const apiKey = req.headers["x-api-key"] as string | undefined;
   if (apiKey) {
     const keyInfo = resolveKey(apiKey);
     if (!keyInfo) return { authenticated: false, error: "Invalid or disabled API key" };
+
+    // Emit a warn-log whenever the header is an SS58 address bound to the
+    // same address (the deprecated "SS58-as-API-key" pattern). This lets
+    // us grep `deprecated-ss58-auth` to track migration progress.
+    if (SS58_SHAPE.test(apiKey) && keyInfo.validatorId === apiKey) {
+      console.warn(
+        `[blob-gateway] deprecated-ss58-auth account=${apiKey} route=${req.path} method=${req.method}`,
+      );
+      return {
+        authenticated: true,
+        tier: "api-key-legacy-ss58",
+        identity: keyInfo.validatorId ?? keyInfo.name,
+        keyInfo,
+      };
+    }
+
     return { authenticated: true, tier: "api-key", identity: keyInfo.name, keyInfo };
   }
 

--- a/services/blob-gateway/src/bearer-auth.ts
+++ b/services/blob-gateway/src/bearer-auth.ts
@@ -16,6 +16,7 @@
  *   - req.keyInfo  — KeyInfo from quota.ts if path 2/3
  */
 
+import { timingSafeEqual } from "node:crypto";
 import type { Request, Response, NextFunction, RequestHandler } from "express";
 import { verifyToken, getApiTokensDb, TOKEN_PREFIX } from "./api-tokens.js";
 import { resolveKey, type KeyInfo } from "./quota.js";
@@ -115,13 +116,24 @@ export function bearerAuth(opts: BearerAuthOptions = {}): RequestHandler {
  * admin token (same env var as the rest of our admin endpoints).
  */
 export function adminGuard(expectedAdminToken: string): RequestHandler {
+  const expectedBuf = Buffer.from(expectedAdminToken, "utf8");
   return function (req: Request, res: Response, next: NextFunction): void {
     const provided = req.headers["x-admin-token"];
-    if (
-      typeof provided !== "string" ||
-      provided.length === 0 ||
-      provided !== expectedAdminToken
-    ) {
+    if (typeof provided !== "string" || provided.length === 0) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+    // Timing-safe compare: reject short-circuit on mismatched length by
+    // first hardening the candidate to the expected length, then using
+    // constant-time equality. Length mismatch always takes the same path
+    // as a content mismatch.
+    const providedBuf = Buffer.from(provided, "utf8");
+    const sameLen = providedBuf.length === expectedBuf.length;
+    const candidate = sameLen
+      ? providedBuf
+      : Buffer.alloc(expectedBuf.length); // zero-filled; never matches
+    const equal = timingSafeEqual(candidate, expectedBuf);
+    if (!sameLen || !equal) {
       res.status(401).json({ error: "unauthorized" });
       return;
     }

--- a/services/blob-gateway/src/bearer-auth.ts
+++ b/services/blob-gateway/src/bearer-auth.ts
@@ -1,0 +1,130 @@
+/**
+ * Bearer auth middleware — preferred entry point for authenticated write
+ * routes. Accepts, in priority order:
+ *
+ *   1. Authorization: Bearer matra_<token>     (new, preferred)
+ *   2. x-api-key: <random-hex>                 (legacy per-operator key
+ *                                              minted at registration time)
+ *   3. x-api-key: <ss58-address>               (legacy "SS58-as-API-key"
+ *                                              — deprecated, warn-logged,
+ *                                              will be removed once all
+ *                                              clients migrate)
+ *
+ * On success, sets the following request properties for downstream handlers:
+ *   - req.account  — SS58 address (whichever auth path resolved)
+ *   - req.authTier — "bearer" | "api-key" | "api-key-legacy-ss58"
+ *   - req.keyInfo  — KeyInfo from quota.ts if path 2/3
+ */
+
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+import { verifyToken, getApiTokensDb, TOKEN_PREFIX } from "./api-tokens.js";
+import { resolveKey, type KeyInfo } from "./quota.js";
+
+export type AuthTier = "bearer" | "api-key" | "api-key-legacy-ss58";
+
+export interface AuthedRequest extends Request {
+  account?: string;
+  authTier?: AuthTier;
+  keyInfo?: KeyInfo;
+}
+
+export interface BearerAuthOptions {
+  /** If false, middleware passes through even when no auth is found. Default true. */
+  required?: boolean;
+}
+
+/** Quick-and-dirty SS58 shape check — matches the one in routes/operators.ts */
+const SS58_SHAPE = /^[15][a-zA-Z0-9]{45,47}$/;
+
+export function bearerAuth(opts: BearerAuthOptions = {}): RequestHandler {
+  const required = opts.required !== false;
+  return function (req: Request, res: Response, next: NextFunction): void {
+    const r = req as AuthedRequest;
+
+    // Path 1: Authorization: Bearer matra_<token>
+    const authHeader = (req.headers.authorization || req.headers.Authorization) as
+      | string
+      | undefined;
+    if (typeof authHeader === "string" && authHeader.startsWith("Bearer ")) {
+      const token = authHeader.slice("Bearer ".length).trim();
+      if (token.startsWith(TOKEN_PREFIX)) {
+        const verify = verifyToken(getApiTokensDb(), token);
+        if (verify.valid) {
+          r.account = verify.accountSs58;
+          r.authTier = "bearer";
+          next();
+          return;
+        }
+        // Explicit Bearer header that failed verification: deny, don't fall
+        // back. Falling back would mask revoked tokens.
+        res.status(401).json({ error: `invalid bearer token: ${verify.reason}` });
+        return;
+      }
+      // Bearer header with wrong prefix: still invalid.
+      res.status(401).json({ error: "invalid bearer token: malformed" });
+      return;
+    }
+
+    // Path 2 & 3: x-api-key
+    const apiKey = req.headers["x-api-key"] as string | undefined;
+    if (typeof apiKey === "string" && apiKey.length > 0) {
+      const keyInfo = resolveKey(apiKey);
+      if (keyInfo) {
+        // Determine if this was the legacy "SS58-as-API-key" path: the header
+        // value itself is an SS58 address AND the key row is bound to that
+        // same address via validator_id. That's the pattern we want to track
+        // so we know when all clients have moved off.
+        const isLegacySs58 = SS58_SHAPE.test(apiKey) && keyInfo.validatorId === apiKey;
+        if (isLegacySs58) {
+          // Structured warn-log for easy grep / log-scan:
+          //   deprecated-ss58-auth account=<ss58> route=<path>
+          // Fields are space-separated so `| grep deprecated-ss58-auth` gives
+          // a clean migration tracker.
+          console.warn(
+            `[blob-gateway] deprecated-ss58-auth account=${apiKey} route=${req.path} method=${req.method}`,
+          );
+          r.account = keyInfo.validatorId ?? apiKey;
+          r.authTier = "api-key-legacy-ss58";
+          r.keyInfo = keyInfo;
+          next();
+          return;
+        }
+        // Regular API key path (random hex, bound to operator SS58 via validator_id)
+        r.account = keyInfo.validatorId ?? keyInfo.name;
+        r.authTier = "api-key";
+        r.keyInfo = keyInfo;
+        next();
+        return;
+      }
+      // Explicit api-key header that failed lookup
+      res.status(401).json({ error: "invalid or disabled api key" });
+      return;
+    }
+
+    if (required) {
+      res.status(401).json({ error: "authentication required" });
+      return;
+    }
+    next();
+  };
+}
+
+/**
+ * Lightweight admin-only guard — used to protect token-mint / token-revoke
+ * endpoints. Compares a constant-time-ish string against the configured
+ * admin token (same env var as the rest of our admin endpoints).
+ */
+export function adminGuard(expectedAdminToken: string): RequestHandler {
+  return function (req: Request, res: Response, next: NextFunction): void {
+    const provided = req.headers["x-admin-token"];
+    if (
+      typeof provided !== "string" ||
+      provided.length === 0 ||
+      provided !== expectedAdminToken
+    ) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+    next();
+  };
+}

--- a/services/blob-gateway/src/index.ts
+++ b/services/blob-gateway/src/index.ts
@@ -12,12 +12,14 @@ import { chunksRouter } from "./routes/chunks.js";
 import { batchesRouter } from "./routes/batches.js";
 import { statusRouter } from "./routes/status.js";
 import { heartbeatsRouter } from "./routes/heartbeats.js";
-import { operatorsRouter, initOperatorsDb } from "./routes/operators.js";
+import { operatorsRouter, initOperatorsDb, getOperatorsDb } from "./routes/operators.js";
 import { ensureDir } from "./storage.js";
 import { initQuotaDb } from "./quota.js";
 import { initHeartbeatDb, startHeartbeatCleanup } from "./heartbeat-store.js";
 import { startCleanupTimer } from "./cleanup.js";
 import { startReceiptIndexer } from "./receipt-indexer.js";
+import { initApiTokensDb } from "./api-tokens.js";
+import { registerTokenRoutes } from "./routes/tokens.js";
 
 const app = express();
 
@@ -51,6 +53,7 @@ app.use(chunksRouter);      // Public (content-addressed, SHA-256 verified)
 app.use(batchesRouter);     // Write: resolveAuth(). Read: public.
 app.use(heartbeatsRouter);  // Handles own dual-mode auth (Phase 2)
 app.use(operatorsRouter);   // Invite-only operator registration
+registerTokenRoutes(app);   // Bearer-token lifecycle (admin-only)
 
 async function start(): Promise<void> {
   // Initialize sr25519/ed25519 WASM (required for signatureVerify)
@@ -64,6 +67,9 @@ async function start(): Promise<void> {
   initQuotaDb();
   initHeartbeatDb();
   initOperatorsDb();
+  // Bearer-token store (shares the SAME handle as operators.db so we never
+  // have two competing connections to the same file).
+  initApiTokensDb(getOperatorsDb());
 
   // Start cleanup timers
   startCleanupTimer();

--- a/services/blob-gateway/src/quota.ts
+++ b/services/blob-gateway/src/quota.ts
@@ -13,6 +13,14 @@ import { config } from "./config.js";
 
 let db: Database.Database;
 
+/**
+ * Test hook: allow a test to inject its own (in-memory) handle without
+ * needing a real /data/blobs/quota.db on disk. Never used in production.
+ */
+export function setQuotaDbForTests(injected: Database.Database): void {
+  db = injected;
+}
+
 export interface KeyInfo {
   keyHash: string;
   name: string;

--- a/services/blob-gateway/src/routes/operators.ts
+++ b/services/blob-gateway/src/routes/operators.ts
@@ -27,6 +27,18 @@ export const operatorsRouter = Router();
 
 let db: Database.Database;
 
+/**
+ * Expose the operators-db handle so other modules (api-tokens) can share
+ * the same SQLite connection instead of opening a second handle on the
+ * same file.
+ */
+export function getOperatorsDb(): Database.Database {
+  if (!db) {
+    throw new Error("operators db not initialised — call initOperatorsDb() first");
+  }
+  return db;
+}
+
 interface InviteRow {
   token_hash: string;
   label: string;

--- a/services/blob-gateway/src/routes/tokens.ts
+++ b/services/blob-gateway/src/routes/tokens.ts
@@ -1,0 +1,181 @@
+/**
+ * Admin routes for Bearer-token lifecycle:
+ *
+ *   POST   /auth/token            -- mint a new token for an SS58 (admin-only)
+ *   DELETE /auth/token/:hash      -- revoke a token by hash (admin-only)
+ *   GET    /auth/tokens           -- list tokens (hashes + metadata, admin-only)
+ *
+ * All three endpoints require x-admin-token (same env var used elsewhere —
+ * DAEMON_NOTIFY_TOKEN — to avoid sprouting a new secret channel).
+ *
+ * NOTE: these endpoints NEVER reveal or accept raw tokens anywhere except
+ * the single mint response. Never log, never store, never list the plaintext.
+ */
+
+import type { Express, Request, Response } from "express";
+import type Database from "better-sqlite3";
+import { randomBytes } from "crypto";
+import { config } from "../config.js";
+import {
+  issueToken,
+  revokeToken,
+  listTokens,
+  getApiTokensDb,
+  TOKEN_PREFIX,
+} from "../api-tokens.js";
+import { adminGuard } from "../bearer-auth.js";
+
+const SS58_SHAPE = /^[15][a-zA-Z0-9]{45,47}$/;
+
+/**
+ * Test hook — kept for symmetry with other modules' test hooks. Tests that
+ * already call setApiTokensDb() don't need this separately, but we expose
+ * it so future tests can stub it without touching module internals.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function setOperatorsDbForTests(_db: Database.Database): void {
+  // no-op: in production and in tests, api_tokens and the registrations
+  // table share the same operators.db file, which is set up by the
+  // api-tokens module via setApiTokensDb().
+}
+
+
+export interface RegisterTokenRoutesOpts {
+  /** Admin shared secret (falls back to config.daemonNotifyToken if empty). */
+  adminToken?: string;
+}
+
+export function registerTokenRoutes(app: Express, opts: RegisterTokenRoutesOpts = {}): void {
+  const adminToken = (opts.adminToken || config.daemonNotifyToken || "").trim();
+  if (!adminToken) {
+    // Still mount the routes so we return a clear 503 rather than a 404;
+    // surfaces misconfiguration loudly instead of silently.
+    app.post("/auth/token", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    app.delete("/auth/token/:hash", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    app.get("/auth/tokens", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    return;
+  }
+  const guard = adminGuard(adminToken);
+
+  app.post("/auth/token", guard, (req: Request, res: Response) => {
+    try {
+      const body = (req.body ?? {}) as {
+        account?: string;
+        label?: string;
+      };
+      if (typeof body.account !== "string" || !SS58_SHAPE.test(body.account)) {
+        res.status(400).json({ error: "missing or invalid account (expected SS58 address)" });
+        return;
+      }
+      const label =
+        typeof body.label === "string" && body.label.trim()
+          ? body.label.trim().slice(0, 128)
+          : null;
+
+      const issued = issueToken(getApiTokensDb(), {
+        accountSs58: body.account,
+        label: label ?? undefined,
+      });
+
+      // Structured audit log — account + label, never the raw token.
+      console.log(
+        `[blob-gateway] api-token minted account=${issued.accountSs58} label=${label ?? "-"} hash=${issued.tokenHash.slice(0, 16)}...`,
+      );
+
+      res.status(200).json({
+        status: "created",
+        token: issued.token, // SHOWN ONCE
+        tokenHash: issued.tokenHash,
+        account: issued.accountSs58,
+        label: issued.label,
+        createdAt: issued.createdAt,
+        message: "Store this token now. It will never be shown again.",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  app.delete("/auth/token/:hash", guard, (req: Request, res: Response) => {
+    try {
+      const hash = String(req.params.hash || "").toLowerCase();
+      if (!/^[0-9a-f]{64}$/.test(hash)) {
+        res.status(400).json({ error: "invalid token hash (expected 64 hex chars)" });
+        return;
+      }
+      const reason =
+        typeof req.body?.reason === "string" && req.body.reason.trim()
+          ? String(req.body.reason).trim().slice(0, 256)
+          : "admin-revoke";
+      const result = revokeToken(getApiTokensDb(), { tokenHash: hash, reason });
+      if (!result.revoked) {
+        res.status(404).json({ error: "token not found or already revoked" });
+        return;
+      }
+      console.log(
+        `[blob-gateway] api-token revoked hash=${hash.slice(0, 16)}... reason="${reason}"`,
+      );
+      res.status(200).json({ status: "revoked", tokenHash: hash, reason });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  app.get("/auth/tokens", guard, (req: Request, res: Response) => {
+    try {
+      const account =
+        typeof req.query.account === "string" && SS58_SHAPE.test(req.query.account)
+          ? req.query.account
+          : undefined;
+      const includeRevoked = req.query.includeRevoked === "1";
+      const tokens = listTokens(getApiTokensDb(), {
+        ...(account ? { account } : {}),
+        includeRevoked,
+      });
+      res.status(200).json({ tokens });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+}
+
+/**
+ * Test helper: mint a token directly against a provided DB handle.
+ * Mirrors what the CLI does.
+ */
+export function mintAdminTokenForTests(
+  db: Database.Database,
+  input: { account: string; label?: string | undefined },
+): { token: string; tokenHash: string } {
+  if (!SS58_SHAPE.test(input.account)) {
+    // Bypass SS58 shape in tests if they really want to — we accept any
+    // non-empty string here because unit tests may use fake addresses.
+    if (!input.account) throw new Error("account required");
+  }
+  const issued = issueToken(db, {
+    accountSs58: input.account,
+    label: input.label,
+  });
+  return { token: issued.token, tokenHash: issued.tokenHash };
+}
+
+/**
+ * Generate a stable default admin token for first-boot bootstrap. Only used
+ * by the CLI in unit tests — real deployments configure
+ * DAEMON_NOTIFY_TOKEN via the K8s secret or docker env.
+ */
+export function newRandomAdminToken(): string {
+  return `admin-${randomBytes(16).toString("hex")}`;
+}
+
+export { TOKEN_PREFIX };

--- a/services/blob-gateway/tsconfig.json
+++ b/services/blob-gateway/tsconfig.json
@@ -19,5 +19,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/__tests__/**", "src/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
     include: [
       'packages/**/src/**/*.test.ts',
       'packages/**/tests/**/*.test.ts',
+      'services/**/src/**/*.test.ts',
+      'services/**/tests/**/*.test.ts',
       'tests/**/*.test.ts',
     ],
     // Integration tests have longer timeouts


### PR DESCRIPTION
## Summary

Replaces the "SS58-as-API-key" pattern (where operators sent their public on-chain address as the secret) with cryptographically random opaque Bearer tokens. Tokens are shown ONCE at mint, stored only as sha256(token), revocable, and rotatable without touching on-chain state.

- New **api_tokens** table + **api-tokens.ts** / **bearer-auth.ts** / **routes/tokens.ts**
- **Coexistence window**: legacy `x-api-key: <ss58>` path still works, every call warn-logs `deprecated-ss58-auth account=<ss58> route=<path> method=<verb>`
- Admin endpoints (`POST/DELETE/GET /auth/token[s]`) + CLI (`bin/issue-token.mjs`, `bin/revoke-token.mjs`)
- 23/23 new tests (TDD red → green)
- README documents get/use/rotate flow + migration-tracking grep

## Auth priority in `resolveAuth()`

0. `Authorization: Bearer matra_<token>` ← preferred
1. `x-api-key: <random-hex>` ← legacy per-operator key
1b. `x-api-key: <ss58-address>` ← **deprecated**; warn-logged
2. Upload signature (`x-upload-sig`)
3. Registered-validator / sig-only tiers

## Test plan

- [x] `pnpm test -- --run services/blob-gateway` → 23 passed, 0 failed
- [x] `pnpm typecheck` in blob-gateway → clean
- [x] Docker build (`docker build -t ...:bearer-auth-dev .`) → OK
- [x] Live smoke test against dev container on :3099:
  - [x] Mint token via `POST /auth/token` → returns `matra_...`
  - [x] Use token as `Authorization: Bearer ...` on `PATCH /blobs/.../certified` → HTTP 404 (auth passed, receipt not found on made-up hash)
  - [x] Invalid Bearer → 401 "Invalid bearer token: unknown"
  - [x] Legacy `x-api-key: <ss58>` where ss58 is bound to that account → still works + warn-log emitted
  - [x] Revoke via `DELETE /auth/token/<hash>` → subsequent Bearer call → 401
- [x] End-to-end from MacBook (192.168.0.118) using thin Python client over Bearer → verified

## Follow-ups (not in this PR)

- Migrate cert-daemon (materios-operator-kit Python), anchor-worker-materios, and faucet clients to Bearer
- Once `deprecated-ss58-auth` log count hits zero: disable legacy path in a separate PR
- Add `apiToken` to `BlobGatewayConfig` in `@fluxpointstudios/orynq-sdk-anchors-materios` (or have it auto-detect `matra_` prefix and route to Bearer header)
- Self-serve mint via operator-signed request (admin-only today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)