### PR TITLE
fix(blob-gateway): Bearer auth on blob upload endpoints

### DIFF
--- a/services/blob-gateway/src/__tests__/upload-auth.test.ts
+++ b/services/blob-gateway/src/__tests__/upload-auth.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Integration tests for the unified auth path on blob UPLOAD endpoints:
+ *
+ *   POST /blobs/:contentHash/manifest
+ *   PUT  /blobs/:contentHash/chunks/:i
+ *
+ * PR #6 shipped Bearer tokens for /auth/* and /blobs/:hash/certified but the
+ * upload handlers in routes/blobs.ts were still reading x-api-key directly,
+ * so operators minting a Bearer token got 401 on the very endpoints they
+ * needed to hit. This test suite locks in the fix: Bearer, legacy x-api-key,
+ * and sr25519 upload-sig all reach the quota layer via a single resolveAuth()
+ * call, with the same 401/403/429 shapes the Penny client already parses.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+// rpc-client opens a WebSocket to a chain RPC in production. Tests must never
+// try to touch that; stub checkFunded so the sig-only path is deterministic
+// and doesn't hang. Use `{ amount: "*" }` matcher-equivalent via vi.mock with
+// a factory — fresh for every test.
+vi.mock("../rpc-client.js", () => ({
+  checkFunded: vi.fn(async () => true),
+  checkReceiptStatus: vi.fn(async () => "not_found" as const),
+  disconnectRpc: vi.fn(async () => {}),
+}));
+
+// storage.ts does fs writes under config.storagePath. notify.ts posts to a
+// daemon when uploads complete — no-op it in tests so we don't need a mock
+// HTTP server just to record chunks.
+vi.mock("../notify.js", () => ({
+  notifyDaemon: vi.fn(async () => {}),
+}));
+
+import express from "express";
+import Database from "better-sqlite3";
+import { createHash, randomBytes } from "crypto";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { cryptoWaitReady, signatureVerify } from "@polkadot/util-crypto";
+import { Keyring } from "@polkadot/api";
+import { u8aToHex, stringToU8a } from "@polkadot/util";
+
+import { config } from "../config.js";
+import { blobsRouter } from "../routes/blobs.js";
+import { setQuotaDbForTests } from "../quota.js";
+import {
+  initApiTokensDb,
+  issueToken,
+  setApiTokensDb,
+} from "../api-tokens.js";
+
+// --------------------------------------------------------------------------
+// Test harness
+// --------------------------------------------------------------------------
+
+async function setupApp(opts: { registerOperator?: boolean } = {}): Promise<{
+  app: express.Express;
+  ss58: string;
+  legacyApiKey: string;
+  randomApiKey: string;
+  bearerToken: string;
+  tokensDb: Database.Database;
+  quotaDb: Database.Database;
+  tmpStorage: string;
+  prevStoragePath: string;
+}> {
+  // --- fs: point storage at a throwaway temp dir ---
+  const tmpStorage = mkdtempSync(join(tmpdir(), "blob-gateway-upload-test-"));
+  const prevStoragePath = config.storagePath;
+  config.storagePath = tmpStorage;
+
+  // --- quota db (in-memory, matching initQuotaDb's schema) ---
+  const quotaDb = new Database(":memory:");
+  quotaDb.pragma("journal_mode = WAL");
+  quotaDb.exec(`
+    CREATE TABLE api_keys (
+      key_hash TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+      max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+      max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+      validator_id TEXT DEFAULT NULL
+    );
+    CREATE TABLE quota_daily (
+      key_hash TEXT NOT NULL,
+      day TEXT NOT NULL,
+      receipts INTEGER NOT NULL DEFAULT 0,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (key_hash, day)
+    );
+    CREATE TABLE uploads_inflight (
+      upload_id TEXT PRIMARY KEY,
+      key_hash TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+    CREATE TABLE account_quotas_daily (
+      address TEXT NOT NULL,
+      day TEXT NOT NULL,
+      receipts INTEGER NOT NULL DEFAULT 0,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (address, day)
+    );
+    CREATE TABLE account_uploads_inflight (
+      upload_id TEXT PRIMARY KEY,
+      address TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+  `);
+  setQuotaDbForTests(quotaDb);
+
+  // SS58-shape account used by both Bearer and legacy-SS58-as-API-key tests.
+  const ss58 = "5OperatorUploadAuthTestaaaaaaaaaaaaaaaaaaaaaaab";
+
+  // Random per-operator api key (the "real" production pattern — 64 hex).
+  const randomApiKey = randomBytes(32).toString("hex");
+  const randomKeyHash = createHash("sha256").update(randomApiKey).digest("hex");
+
+  if (opts.registerOperator !== false) {
+    quotaDb
+      .prepare(
+        `INSERT INTO api_keys
+         (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id)
+         VALUES (?, 'operator-test', 1, 100, 1073741824, 5, ?)`,
+      )
+      .run(randomKeyHash, ss58);
+
+    // Legacy SS58-as-API-key: hash(ss58) also stored, validator_id = ss58.
+    const legacyKeyHash = createHash("sha256").update(ss58).digest("hex");
+    quotaDb
+      .prepare(
+        `INSERT INTO api_keys
+         (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id)
+         VALUES (?, 'operator-test-legacy', 1, 100, 1073741824, 5, ?)`,
+      )
+      .run(legacyKeyHash, ss58);
+  }
+
+  // --- api_tokens db (in-memory) ---
+  const tokensDb = new Database(":memory:");
+  tokensDb.pragma("journal_mode = WAL");
+  initApiTokensDb(tokensDb);
+  setApiTokensDb(tokensDb);
+
+  const { token: bearerToken } = issueToken(tokensDb, {
+    accountSs58: ss58,
+    label: "upload-auth-test",
+  });
+
+  // --- Express app wired to the real blobsRouter ---
+  const app = express();
+  // Raw body parser for chunk uploads (mirrors production index.ts ordering).
+  app.put(
+    "/blobs/:contentHash/chunks/:i",
+    express.raw({ type: "*/*", limit: `${config.maxChunkBytes}` }),
+  );
+  app.use(express.json({ limit: "2mb" }));
+  app.use(blobsRouter);
+
+  return {
+    app,
+    ss58,
+    legacyApiKey: ss58,
+    randomApiKey,
+    bearerToken,
+    tokensDb,
+    quotaDb,
+    tmpStorage,
+    prevStoragePath,
+  };
+}
+
+/** Minimal fetch wrapper around an ephemeral-port listen. */
+async function fetchJson(
+  app: express.Express,
+  method: string,
+  path: string,
+  opts: {
+    headers?: Record<string, string>;
+    jsonBody?: unknown;
+    rawBody?: Buffer;
+  } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { ...(opts.headers || {}) },
+      };
+      if (opts.rawBody !== undefined) {
+        init.body = opts.rawBody;
+        (init.headers as Record<string, string>)["content-type"] =
+          (init.headers as Record<string, string>)["content-type"] ?? "application/octet-stream";
+        (init.headers as Record<string, string>)["content-length"] = String(opts.rawBody.length);
+      } else if (opts.jsonBody !== undefined) {
+        init.body = JSON.stringify(opts.jsonBody);
+        (init.headers as Record<string, string>)["content-type"] = "application/json";
+      }
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let body: unknown;
+          try {
+            body = text ? JSON.parse(text) : null;
+          } catch {
+            body = text;
+          }
+          server.close();
+          resolve({ status: res.status, body });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+/**
+ * Build a manifest body for a known payload. Returns the manifest, the
+ * single chunk buffer, and the contentHash (sha256 of the chunk as hex — we
+ * don't care about cryptographic fidelity here, just that the gateway's
+ * own SHA-256 verification passes).
+ */
+function buildSingleChunkManifest(payload = Buffer.from("hello-world")): {
+  manifest: { chunks: Array<{ index: number; sha256: string; size: number }> };
+  chunk: Buffer;
+  contentHash: string;
+} {
+  const sha = createHash("sha256").update(payload).digest("hex");
+  return {
+    manifest: { chunks: [{ index: 0, sha256: sha, size: payload.length }] },
+    chunk: payload,
+    contentHash: sha, // SHA-256 of the one chunk is a fine stand-in content hash
+  };
+}
+
+describe("upload endpoints: unified auth (Bearer / x-api-key / sig)", () => {
+  let ctx: Awaited<ReturnType<typeof setupApp>>;
+
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+
+  afterEach(() => {
+    config.storagePath = ctx.prevStoragePath;
+    rmSync(ctx.tmpStorage, { recursive: true, force: true });
+  });
+
+  // ------------------------------------------------------------------------
+  // 1. Bearer accepted on manifest POST
+  // ------------------------------------------------------------------------
+  test("bearer_accepted_on_manifest_post_returns_201_ok", async () => {
+    const { manifest, contentHash } = buildSingleChunkManifest();
+    const res = await fetchJson(ctx.app, "POST", `/blobs/${contentHash}/manifest`, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      jsonBody: manifest,
+    });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ status: "ok", contentHash });
+    // Print the happy-path response so the PR report can quote literal JSON.
+    // eslint-disable-next-line no-console
+    console.log(
+      `[upload-auth-test] bearer_manifest_success status=${res.status} body=${JSON.stringify(res.body)}`,
+    );
+  });
+
+  // ------------------------------------------------------------------------
+  // 2. Bearer accepted on chunk PUT
+  // ------------------------------------------------------------------------
+  test("bearer_accepted_on_chunk_put_returns_200_ok", async () => {
+    const { manifest, chunk, contentHash } = buildSingleChunkManifest();
+    const manifestRes = await fetchJson(ctx.app, "POST", `/blobs/${contentHash}/manifest`, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      jsonBody: manifest,
+    });
+    expect(manifestRes.status).toBe(201);
+
+    const chunkRes = await fetchJson(ctx.app, "PUT", `/blobs/${contentHash}/chunks/0`, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      rawBody: chunk,
+    });
+    expect(chunkRes.status).toBe(200);
+    expect(chunkRes.body).toEqual({ status: "ok", chunkIndex: 0 });
+  });
+
+  // ------------------------------------------------------------------------
+  // 3. Legacy x-api-key (random hex) still works — regression guard
+  // ------------------------------------------------------------------------
+  test("legacy_x_api_key_still_works_on_upload", async () => {
+    const { manifest, chunk, contentHash } = buildSingleChunkManifest();
+    const manifestRes = await fetchJson(ctx.app, "POST", `/blobs/${contentHash}/manifest`, {
+      headers: { "x-api-key": ctx.randomApiKey },
+      jsonBody: manifest,
+    });
+    expect(manifestRes.status).toBe(201);
+
+    const chunkRes = await fetchJson(ctx.app, "PUT", `/blobs/${contentHash}/chunks/0`, {
+      headers: { "x-api-key": ctx.randomApiKey },
+      rawBody: chunk,
+    });
+    expect(chunkRes.status).toBe(200);
+  });
+
+  // ------------------------------------------------------------------------
+  // 3b. Legacy SS58-as-API-key still works (deprecation coexistence window)
+  // ------------------------------------------------------------------------
+  test("legacy_ss58_as_api_key_still_works_on_upload", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation((() => {}) as (...args: unknown[]) => void);
+    try {
+      const { manifest, contentHash } = buildSingleChunkManifest();
+      const res = await fetchJson(ctx.app, "POST", `/blobs/${contentHash}/manifest`, {
+        headers: { "x-api-key": ctx.legacyApiKey },
+        jsonBody: manifest,
+      });
+      expect(res.status).toBe(201);
+      // deprecated-ss58-auth warn-log fires in resolveAuth
+      const calls = (warn.mock.calls as unknown[][]).map((c) => c.join(" "));
+      expect(calls.some((m) => m.includes("deprecated-ss58-auth"))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // ------------------------------------------------------------------------
+  // 4. Sig-only path still works — regression guard
+  // ------------------------------------------------------------------------
+  test("sig_only_path_still_works_on_upload", async () => {
+    await cryptoWaitReady();
+    const keyring = new Keyring({ type: "sr25519" });
+    // Deterministic seed for reproducibility; any 32-byte seed works.
+    const pair = keyring.addFromUri("//SigOnlyUploader");
+    const addr = pair.address;
+
+    const { manifest, chunk, contentHash } = buildSingleChunkManifest(Buffer.from("sig-only-hello"));
+    const ts = Math.floor(Date.now() / 1000);
+    const signingString = `materios-upload-v1|${contentHash}|${addr}|${ts}`;
+    const sig = u8aToHex(pair.sign(stringToU8a(signingString)));
+
+    // Sanity: the gateway's signatureVerify should accept this pair too.
+    expect(signatureVerify(stringToU8a(signingString), sig, addr).isValid).toBe(true);
+
+    const sigHeaders: Record<string, string> = {
+      "x-upload-sig": sig,
+      "x-uploader-address": addr,
+      "x-upload-ts": String(ts),
+    };
+
+    const mres = await fetchJson(ctx.app, "POST", `/blobs/${contentHash}/manifest`, {
+      headers: sigHeaders,
+      jsonBody: manifest,
+    });
+    expect(mres.status).toBe(201);
+
+    const cres = await fetchJson(ctx.app, "PUT", `/blobs/${contentHash}/chunks/0`, {
+      headers: sigHeaders,
+      rawBody: chunk,
+    });
+    expect(cres.status).toBe(200);
+  });
+
+  // ------------------------------------------------------------------------
+  // 5. Unauthenticated upload → 401
+  // ------------------------------------------------------------------------
+  test("unauthenticated_upload_returns_401", async () => {
+    const { manifest, contentHash } = buildSingleChunkManifest();
+    const res = await fetchJson(ctx.app, "POST", `/blobs/${contentHash}/manifest`, {
+      jsonBody: manifest,
+    });
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  // ------------------------------------------------------------------------
+  // 6. Bearer + revoked token → 401 (full lifecycle integration)
+  // ------------------------------------------------------------------------
+  test("revoked_bearer_rejected_with_401_on_upload", async () => {
+    // Revoke by hashing the plaintext and updating the tokens DB directly —
+    // mirrors what /auth/token/:hash DELETE does in production.
+    const tokenHash = createHash("sha256").update(ctx.bearerToken).digest("hex");
+    ctx.tokensDb
+      .prepare(
+        `UPDATE api_tokens SET revoked_at = ?, revoked_reason = 'test' WHERE token_hash = ?`,
+      )
+      .run(Math.floor(Date.now() / 1000), tokenHash);
+
+    const { manifest, contentHash } = buildSingleChunkManifest();
+    const res = await fetchJson(ctx.app, "POST", `/blobs/${contentHash}/manifest`, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      jsonBody: manifest,
+    });
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty("error");
+    const err = (res.body as { error: string }).error;
+    expect(err.toLowerCase()).toContain("revoked");
+  });
+});

--- a/services/blob-gateway/src/auth.ts
+++ b/services/blob-gateway/src/auth.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Request } from "express";
-import { resolveKey, lookupValidatorInfo, type KeyInfo } from "./quota.js";
+import { resolveKey, resolveKeyByAccount, lookupValidatorInfo, type KeyInfo } from "./quota.js";
 import { verifyUploadSig } from "./upload-auth.js";
 import { checkFunded } from "./rpc-client.js";
 import {
@@ -51,10 +51,17 @@ export async function resolveAuth(req: Request, contentHash?: string): Promise<A
       try {
         const verify = verifyToken(getApiTokensDb(), token);
         if (verify.valid) {
+          // Best-effort lookup: if this account has a registered api_keys row,
+          // surface the KeyInfo so upload quotas key off the same pool
+          // regardless of which header the caller used. If the account isn't
+          // registered, keyInfo stays undefined and callers fall back to
+          // account-based quotas.
+          const keyInfo = resolveKeyByAccount(verify.accountSs58) ?? undefined;
           return {
             authenticated: true,
             tier: "bearer",
             identity: verify.accountSs58,
+            ...(keyInfo ? { keyInfo } : {}),
           };
         }
         return {

--- a/services/blob-gateway/src/quota.ts
+++ b/services/blob-gateway/src/quota.ts
@@ -289,6 +289,33 @@ export function lookupValidatorInfo(validatorId: string): { name: string } | nul
   return row ?? null;
 }
 
+/**
+ * Resolve full KeyInfo by SS58 validator_id. Used by the Bearer-token path in
+ * resolveAuth() — a bearer token identifies the account, and we need to find
+ * the operator's registered api_keys row so upload quotas apply to the same
+ * pool whether the caller used Bearer or x-api-key.
+ *
+ * Returns the first enabled key row bound to this validator_id, or null if
+ * the account hasn't registered as an operator (in which case callers should
+ * fall back to account-based quotas).
+ */
+export function resolveKeyByAccount(ss58: string): KeyInfo | null {
+  const row = db.prepare(
+    `SELECT key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id
+     FROM api_keys WHERE validator_id = ? AND enabled = 1 LIMIT 1`,
+  ).get(ss58) as Record<string, unknown> | undefined;
+  if (!row || !row.enabled) return null;
+  return {
+    keyHash: row.key_hash as string,
+    name: row.name as string,
+    enabled: !!row.enabled,
+    maxReceiptsPerDay: row.max_receipts_per_day as number,
+    maxBytesPerDay: row.max_bytes_per_day as number,
+    maxConcurrentUploads: row.max_concurrent_uploads as number,
+    validatorId: (row.validator_id as string) ?? null,
+  };
+}
+
 export function finalizeUpload(keyInfo: KeyInfo, contentHash: string): QuotaCheckResult {
   const d = today();
   const txn = db.transaction(() => {

--- a/services/blob-gateway/src/routes/blobs.ts
+++ b/services/blob-gateway/src/routes/blobs.ts
@@ -7,11 +7,9 @@ import { createHash } from "crypto";
 import { saveManifest, getManifest, saveChunk, getChunk, getStatus, markCertified, updateReceiptMeta } from "../storage.js";
 import { config } from "../config.js";
 import {
-  resolveKey, startUpload, recordChunkBytes, finalizeUpload,
+  startUpload, recordChunkBytes, finalizeUpload,
   startAccountUpload, recordAccountChunkBytes, finalizeAccountUpload,
 } from "../quota.js";
-import { verifyUploadSig } from "../upload-auth.js";
-import { checkFunded } from "../rpc-client.js";
 import { resolveAuth } from "../auth.js";
 
 export const blobsRouter = Router();
@@ -32,6 +30,11 @@ interface Manifest {
 /**
  * POST /blobs/:contentHash/manifest
  * Saves the manifest JSON for a blob.
+ *
+ * Auth (unified via resolveAuth): Bearer → x-api-key (legacy incl. SS58-as-key)
+ * → sr25519 upload signature. The Bearer and api-key tiers are pre-funded
+ * (operators authorised by admin); sig-only tier is balance-gated inside
+ * resolveAuth() via checkFunded().
  */
 blobsRouter.post("/blobs/:contentHash/manifest", async (req: Request, res: Response) => {
   try {
@@ -43,40 +46,51 @@ blobsRouter.post("/blobs/:contentHash/manifest", async (req: Request, res: Respo
       return;
     }
 
-    // Dual-path auth: API key OR upload signature
-    const apiKey = req.headers["x-api-key"] as string | undefined;
-    let uploaderAddress: string | undefined;
-
-    if (apiKey) {
-      const keyInfo = resolveKey(apiKey);
-      if (!keyInfo) {
-        res.status(401).json({ error: "Invalid or disabled API key" });
+    const auth = await resolveAuth(req, contentHash);
+    if (!auth.authenticated) {
+      // Preserve existing 403 for the specific "below min balance" case so
+      // Penny's client can keep distinguishing 401 (no/invalid creds) from
+      // 403 (valid sig, underfunded account).
+      if (auth.error && auth.error.toLowerCase().includes("below minimum balance")) {
+        res.status(403).json({ error: "Account does not meet minimum MATRA balance" });
         return;
       }
-      const quotaCheck = startUpload(keyInfo, contentHash);
+      res.status(401).json({ error: auth.error ?? "authentication required" });
+      return;
+    }
+
+    // Dispatch quota tracking by tier. Bearer/api-key tiers use per-operator
+    // keyed quotas if the account is a registered operator; otherwise (bearer
+    // tied to an unregistered account) we fall back to per-account quotas.
+    // Sig-only + registered-validator always use per-account quotas.
+    let uploaderAddress: string | undefined;
+    const useKeyedQuotas =
+      (auth.tier === "bearer" || auth.tier === "api-key" || auth.tier === "api-key-legacy-ss58") &&
+      auth.keyInfo !== undefined;
+
+    if (useKeyedQuotas && auth.keyInfo) {
+      const quotaCheck = startUpload(auth.keyInfo, contentHash);
       if (!quotaCheck.allowed) {
         res.status(429).json({ error: quotaCheck.error, limit: quotaCheck.limit, current: quotaCheck.current });
         return;
       }
     } else {
-      // Sig-based auth
-      const authResult = verifyUploadSig(req, contentHash);
-      if (!authResult.valid) {
-        res.status(401).json({ error: authResult.error });
+      // Account-based quota — covers sig-only, registered-validator, and
+      // Bearer tokens for operators not yet present in quota.db api_keys.
+      const accountId = auth.identity;
+      if (!accountId) {
+        res.status(401).json({ error: "resolved auth has no identity" });
         return;
       }
-      uploaderAddress = authResult.address;
-
-      const funded = await checkFunded(uploaderAddress!);
-      if (!funded) {
-        res.status(403).json({ error: "Account does not meet minimum MATRA balance" });
-        return;
-      }
-
-      const quotaCheck = startAccountUpload(uploaderAddress!, contentHash);
+      const quotaCheck = startAccountUpload(accountId, contentHash);
       if (!quotaCheck.allowed) {
         res.status(429).json({ error: quotaCheck.error, limit: quotaCheck.limit, current: quotaCheck.current });
         return;
+      }
+      // Record uploader address only for actual sig-based uploads, mirroring
+      // previous behaviour (Bearer/api-key don't set uploaderAddress in meta).
+      if (auth.tier === "sig-only" || auth.tier === "registered-validator") {
+        uploaderAddress = accountId;
       }
     }
 
@@ -120,6 +134,11 @@ blobsRouter.post("/blobs/:contentHash/manifest", async (req: Request, res: Respo
  * Uploads a chunk binary. Validates SHA-256 against manifest entry.
  * Returns 409 if chunk already exists (idempotent).
  * Returns 400 if manifest not found or chunk index out of range.
+ *
+ * Auth (unified via resolveAuth): Bearer → x-api-key (legacy incl. SS58) →
+ * sr25519 upload signature. Same dispatch as POST manifest; no header is
+ * strictly required on the chunk leg if the manifest was authed, but if any
+ * auth is present we validate + record quotas.
  */
 blobsRouter.put("/blobs/:contentHash/chunks/:i", async (req: Request, res: Response) => {
   try {
@@ -162,27 +181,48 @@ blobsRouter.put("/blobs/:contentHash/chunks/:i", async (req: Request, res: Respo
       return;
     }
 
-    // Quota: record bytes (API key or sig-based)
-    const apiKey = req.headers["x-api-key"] as string | undefined;
-    const keyInfo = apiKey ? resolveKey(apiKey) : null;
-    if (keyInfo && data) {
-      const quotaCheck = recordChunkBytes(keyInfo, contentHash, data.length);
+    // Resolve auth once for quota routing.
+    //
+    // Historical behaviour: if no auth header was present the chunk leg
+    // silently allowed the write (SHA-256 was the guard). We keep that
+    // fallback so existing sig-without-sig-headers-on-chunk flows don't
+    // regress, but when any auth is present we validate it and record
+    // quotas. A Bearer token that *fails* verification, however, is rejected
+    // outright — we never mask a revoked token as "unauthenticated".
+    const hasAuthHeader =
+      typeof req.headers.authorization === "string" ||
+      typeof req.headers["x-api-key"] === "string" ||
+      typeof req.headers["x-upload-sig"] === "string";
+    const auth = hasAuthHeader ? await resolveAuth(req, contentHash) : null;
+
+    if (auth && !auth.authenticated) {
+      if (auth.error && auth.error.toLowerCase().includes("below minimum balance")) {
+        res.status(403).json({ error: "Account does not meet minimum MATRA balance" });
+        return;
+      }
+      res.status(401).json({ error: auth.error ?? "authentication required" });
+      return;
+    }
+
+    const useKeyedQuotas =
+      auth !== null &&
+      (auth.tier === "bearer" || auth.tier === "api-key" || auth.tier === "api-key-legacy-ss58") &&
+      auth.keyInfo !== undefined;
+
+    if (useKeyedQuotas && auth && auth.keyInfo) {
+      const quotaCheck = recordChunkBytes(auth.keyInfo, contentHash, data.length);
       if (!quotaCheck.allowed) {
         res.status(429).json({ error: quotaCheck.error, limit: quotaCheck.limit, current: quotaCheck.current });
         return;
       }
-    } else if (!apiKey && data) {
-      // For sig-based: check upload auth headers if present for quota tracking
-      const authResult = verifyUploadSig(req, contentHash);
-      if (authResult.valid && authResult.address) {
-        const quotaCheck = recordAccountChunkBytes(authResult.address, contentHash, data.length);
-        if (!quotaCheck.allowed) {
-          res.status(429).json({ error: quotaCheck.error, limit: quotaCheck.limit, current: quotaCheck.current });
-          return;
-        }
+    } else if (auth && auth.identity) {
+      const quotaCheck = recordAccountChunkBytes(auth.identity, contentHash, data.length);
+      if (!quotaCheck.allowed) {
+        res.status(429).json({ error: quotaCheck.error, limit: quotaCheck.limit, current: quotaCheck.current });
+        return;
       }
-      // No sig headers on chunk → allow anyway (SHA-256 is the guard)
     }
+    // else: no auth header present → legacy fallthrough (SHA-256 is the guard)
 
     // Validate SHA-256 against manifest entry
     const manifestChunk = manifest.chunks[chunkIndex];
@@ -206,19 +246,15 @@ blobsRouter.put("/blobs/:contentHash/chunks/:i", async (req: Request, res: Respo
     // Check if upload is now complete and finalize quota
     const statusAfter = await getStatus(contentHash);
     if (statusAfter.complete) {
-      if (keyInfo) {
-        const finalCheck = finalizeUpload(keyInfo, contentHash);
+      if (useKeyedQuotas && auth && auth.keyInfo) {
+        const finalCheck = finalizeUpload(auth.keyInfo, contentHash);
         if (!finalCheck.allowed) {
-          console.warn(`[blob-gateway] Receipt quota exceeded for key ${keyInfo.name} but upload already complete`);
+          console.warn(`[blob-gateway] Receipt quota exceeded for key ${auth.keyInfo.name} but upload already complete`);
         }
-      } else {
-        // Finalize account quota for sig-based uploads
-        const authResult = verifyUploadSig(req, contentHash);
-        if (authResult.valid && authResult.address) {
-          const finalCheck = finalizeAccountUpload(authResult.address, contentHash);
-          if (!finalCheck.allowed) {
-            console.warn(`[blob-gateway] Receipt quota exceeded for ${authResult.address} but upload already complete`);
-          }
+      } else if (auth && auth.identity) {
+        const finalCheck = finalizeAccountUpload(auth.identity, contentHash);
+        if (!finalCheck.allowed) {
+          console.warn(`[blob-gateway] Receipt quota exceeded for ${auth.identity} but upload already complete`);
         }
       }
     }


### PR DESCRIPTION
## Summary

- PR #6 shipped Bearer-token auth for \`/auth/*\` lifecycle + \`PATCH /blobs/:hash/certified\`, but the two upload endpoints in \`routes/blobs.ts\` were still reading \`req.headers[\"x-api-key\"]\` directly. OpenHome's e2e caught the gap: mint a bearer, hit \`POST /blobs/:hash/manifest\` with \`Authorization: Bearer matra_...\`, get 401.
- Both upload handlers now call \`resolveAuth(req, contentHash)\` and dispatch quota tracking by tier. \`checkFunded()\` still gates sig-only uploads inside \`resolveAuth()\`; the handler re-maps \"below minimum balance\" to 403 so Penny's client keeps its existing 401-vs-403 branch.
- New \`resolveKeyByAccount(ss58)\` in \`quota.ts\` lets bearer-authed requests share the same \`api_keys\` quota pool as the matching \`x-api-key\` for the same operator — consistent rate limits regardless of which header the operator uses.

## Files changed

| File | + / - |
| --- | --- |
| \`services/blob-gateway/src/auth.ts\` | +8 / -1 |
| \`services/blob-gateway/src/quota.ts\` | +27 / -0 |
| \`services/blob-gateway/src/routes/blobs.ts\` | +92 / -46 |
| \`services/blob-gateway/src/__tests__/upload-auth.test.ts\` | +404 (new) |

## Auth dispatch (new)

| Tier (from \`resolveAuth\`) | Quota path |
| --- | --- |
| \`bearer\` + keyInfo found | \`startUpload(keyInfo)\` / \`recordChunkBytes\` |
| \`bearer\` without keyInfo (unregistered operator) | \`startAccountUpload(ss58)\` / \`recordAccountChunkBytes\` |
| \`api-key\` | \`startUpload(keyInfo)\` |
| \`api-key-legacy-ss58\` | \`startUpload(keyInfo)\` + \`deprecated-ss58-auth\` warn (from resolveAuth) |
| \`sig-only\` / \`registered-validator\` | \`startAccountUpload(ss58)\` (checkFunded already ran in resolveAuth) |

## Status code preservation

- Missing/invalid creds: 401 (unchanged)
- Sig valid, below min MATRA: 403 (unchanged, now surfaced via \`resolveAuth\` error string)
- Quota exceeded: 429 with \`{ error, limit, current }\` shape (unchanged)
- Revoked bearer: 401 with \`revoked\` reason in error (new — previously got generic 401 since the bearer path never fired)

## Test plan

- [x] \`pnpm vitest run services/blob-gateway\` — 31/31 pass (was 24)
- [x] \`tsc --noEmit\` clean on all changed files
- [x] \`blobsRouter.post(\"/blobs/:contentHash/manifest\")\` + \`blobsRouter.put(\"/blobs/:contentHash/chunks/:i\")\` still exported (AST sanity)
- [x] Full repo \`pnpm test\`: 1712 passed / 1 pre-existing client-auto-pay integration flake (same flake in baseline, unrelated)
- [ ] Post-merge: rebuild \`ghcr.io/flux-point-studios/blob-gateway:latest\`, restart preprod container, OpenHome re-tests

### New tests (\`upload-auth.test.ts\`)

1. \`bearer_accepted_on_manifest_post_returns_201_ok\`
2. \`bearer_accepted_on_chunk_put_returns_200_ok\`
3. \`legacy_x_api_key_still_works_on_upload\`
4. \`legacy_ss58_as_api_key_still_works_on_upload\` (asserts \`deprecated-ss58-auth\` warn fires)
5. \`sig_only_path_still_works_on_upload\` (sr25519 from //SigOnlyUploader, checkFunded mocked via \`vi.mock(\"../rpc-client.js\")\`)
6. \`unauthenticated_upload_returns_401\`
7. \`revoked_bearer_rejected_with_401_on_upload\`

Literal happy-path response from test run:
\`\`\`
[upload-auth-test] bearer_manifest_success status=201 body={\"status\":\"ok\",\"contentHash\":\"afa27b44d43b02a9fea41d13cedc2e4016cfcf87c5dbf990e593669aa8ce286d\"}
\`\`\`

## Out of scope

- \`heartbeats.ts\` and \`operators.ts\` still read \`x-api-key\` directly — tracked in follow-up issue #129.
- Post-merge build + preprod container restart is a separate step (user will trigger).

Please review and merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>