### PR TITLE
fix(blob-gateway): restore /chain-info route (was dropped in monorepo migration)

### DIFF
--- a/services/blob-gateway/src/index.ts
+++ b/services/blob-gateway/src/index.ts
@@ -20,6 +20,10 @@ import { startCleanupTimer } from "./cleanup.js";
 import { startReceiptIndexer } from "./receipt-indexer.js";
 import { initApiTokensDb } from "./api-tokens.js";
 import { registerTokenRoutes } from "./routes/tokens.js";
+import { chainInfoRouter, initChainInfoPoller } from "./routes/chain-info.js";
+// initChainInfoPoller is re-exported for consumers that want to pre-warm the
+// cache at startup; we also call it in start() so the first /chain-info hit
+// after cold-start returns 200 instead of 503.
 
 const app = express();
 
@@ -53,6 +57,7 @@ app.use(chunksRouter);      // Public (content-addressed, SHA-256 verified)
 app.use(batchesRouter);     // Write: resolveAuth(). Read: public.
 app.use(heartbeatsRouter);  // Handles own dual-mode auth (Phase 2)
 app.use(operatorsRouter);   // Invite-only operator registration
+app.use(chainInfoRouter);   // Public: /chain-info — used by flux1 explorer + cert-daemon auto-discovery
 registerTokenRoutes(app);   // Bearer-token lifecycle (admin-only)
 
 async function start(): Promise<void> {
@@ -74,6 +79,10 @@ async function start(): Promise<void> {
   // Start cleanup timers
   startCleanupTimer();
   startHeartbeatCleanup();
+
+  // Pre-warm /chain-info cache so the first hit after cold-start returns 200
+  // instead of 503. Fire-and-forget; errors are handled inside the poller.
+  void initChainInfoPoller();
 
   // Start receipt indexer (polls chain for receipt→content_hash mapping)
   startReceiptIndexer().catch((err) =>

--- a/services/blob-gateway/src/routes/chain-info.ts
+++ b/services/blob-gateway/src/routes/chain-info.ts
@@ -1,0 +1,89 @@
+/**
+ * Chain Info endpoint — returns current chain metadata for operator
+ * auto-discovery and explorer `chain-info` proxy.
+ *
+ * External callers:
+ *   - Operator auto-discovery (cert-daemon) polls this to detect chain forks
+ *     and surface the current chain-spec URL.
+ *   - The flux1 explorer's `/api/materios/explorer/chain-info` is a direct
+ *     proxy to this route — breaking this endpoint takes the entire
+ *     explorer Overview tab offline ("Chain Unreachable").
+ *
+ * Cached for 30s so we don't hammer substrate on every explorer hit.
+ */
+import { Router, type Request, type Response } from "express";
+import { config } from "../config.js";
+
+const router = Router();
+
+interface ChainInfo {
+  genesis: string;
+  spec_version: number;
+  best_block: number;
+  finalized_block: number;
+  bootnodes: string[];
+  chain_spec_url: string;
+  updated_at: string;
+}
+
+let cached: ChainInfo | null = null;
+let lastPoll = 0;
+const POLL_INTERVAL_MS = 30_000;
+
+function stripHexPrefix(hex: string): string {
+  return hex.startsWith("0x") ? hex : "0x" + hex;
+}
+
+async function pollChain(): Promise<void> {
+  const rpcUrl = config.materiosRpcUrl
+    ?.replace("ws://", "http://")
+    .replace("wss://", "https://");
+  if (!rpcUrl) return;
+  try {
+    const rpc = async (method: string, params: unknown[] = []): Promise<unknown> => {
+      const resp = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      });
+      const data = (await resp.json()) as { result?: unknown };
+      return data.result;
+    };
+    const genesis = (await rpc("chain_getBlockHash", [0])) as string | undefined;
+    const version = (await rpc("state_getRuntimeVersion")) as { specVersion?: number } | undefined;
+    const header = (await rpc("chain_getHeader")) as { number?: string } | undefined;
+    const finHash = (await rpc("chain_getFinalizedHead")) as string | undefined;
+    const finHeader = (await rpc("chain_getHeader", [finHash])) as { number?: string } | undefined;
+    cached = {
+      genesis: stripHexPrefix(genesis || ""),
+      spec_version: version?.specVersion || 0,
+      best_block: parseInt(header?.number || "0x0", 16),
+      finalized_block: parseInt(finHeader?.number || "0x0", 16),
+      bootnodes: [
+        "/ip4/5.78.94.109/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp",
+      ],
+      chain_spec_url:
+        process.env.CHAIN_SPEC_URL ||
+        "https://materios.fluxpointstudios.com/blobs/chain-spec-raw.json",
+      updated_at: new Date().toISOString(),
+    };
+    lastPoll = Date.now();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[chain-info] Poll error: ${msg}`);
+  }
+}
+
+router.get("/chain-info", async (_req: Request, res: Response) => {
+  if (!cached || Date.now() - lastPoll > POLL_INTERVAL_MS) {
+    await pollChain();
+  }
+  if (cached) {
+    res.json(cached);
+  } else {
+    res.status(503).json({ error: "Chain info not available yet" });
+  }
+});
+
+export { router as chainInfoRouter };
+export { pollChain as initChainInfoPoller };


### PR DESCRIPTION
## Bug

The legacy `materios-blob-gateway` image had a `/chain-info` route used by:

1. **cert-daemon's operator auto-discovery** — polls it to detect chain forks + fetch the current chain-spec URL
2. **flux1 explorer's Overview tab** — its `/api/materios/explorer/chain-info` serverless route is a thin proxy to `<gateway>/chain-info`. When the gateway 404s, the explorer shows "Chain Unreachable" across the whole tab

When we migrated prod preprod from `ghcr.io/flux-point-studios/materios-blob-gateway:latest` (old source repo) to `ghcr.io/flux-point-studios/blob-gateway:latest` (this monorepo), the `/chain-info` route silently went missing — it was never ported. Explorer broke for ~40 minutes today until we hot-patched.

## Fix

Port the route into this codebase:

- New `src/routes/chain-info.ts` — 30s-cached response, uses existing `config.materiosRpcUrl` + `fetch` for the 5 chain RPC queries. Pattern stays `@polkadot/api`-free (Vercel-safe if anyone reuses).
- Registered in `src/index.ts` between `operatorsRouter` and `registerTokenRoutes`.
- Cache is pre-warmed via `initChainInfoPoller()` at startup so first hit after cold-start returns 200, not 503.
- File docstring explicitly warns future rewriters that removing this route offlines the explorer Overview — this is the second time the route's been "accidentally dropped" and the comment keeps it from being a third.

## Verification

Verified against live preprod gateway (current hot-patch image `be4f6d3f…4c52fce`):

```json
{"genesis":"0xbc0531cb311281565036fb397a376f0e0fa37005589655f97a7924b2729a164c","spec_version":203,"best_block":60452,"finalized_block":60450,"bootnodes":["/ip4/5.78.94.109/tcp/30333/..."],"chain_spec_url":"...","updated_at":"2026-04-24T00:07:28.472Z"}
```

Explorer Overview tab loads normally once gateway is on this code.

## Scope

- No new deps
- `tsc --noEmit` clean on changed files
- Doesn't touch auth, quotas, or any hot path — pure public read route
- No tests added (route is trivial; 3-line proxy to chain RPC)