### PR TITLE
feat(blob-gateway): resolveAuth on heartbeat route (closes #129)

### DIFF
--- a/services/blob-gateway/src/__tests__/heartbeats-auth.test.ts
+++ b/services/blob-gateway/src/__tests__/heartbeats-auth.test.ts
@@ -1,0 +1,513 @@
+/**
+ * Integration tests for the unified auth path on POST /heartbeats.
+ *
+ * Before this PR the handler read `req.headers["x-api-key"]` directly, so
+ * operators who had issued themselves a Bearer token (`matra_...`) got a
+ * silent 401/403 when trying to flip their cert-daemon over. This suite
+ * locks in the fix: Bearer (priority 0), legacy x-api-key (priority 1),
+ * and the existing sr25519 `x-heartbeat-sig` fallback (priority 2) all
+ * land 200 OK, while revoked/missing auth still fail closed with the
+ * wire formats the cert-daemon + explorer parse today.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+// rpc-client opens a WebSocket to a chain RPC in production. resolveAuth()
+// only reaches that code path on the upload-sig branch, which heartbeats
+// never trip (we call resolveAuth without a contentHash), but the module is
+// still transitively imported — stub it anyway for deterministic teardown.
+vi.mock("../rpc-client.js", () => ({
+  checkFunded: vi.fn(async () => true),
+  checkReceiptStatus: vi.fn(async () => "not_found" as const),
+  disconnectRpc: vi.fn(async () => {}),
+}));
+
+import express from "express";
+import Database from "better-sqlite3";
+import { createHash } from "crypto";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { Keyring } from "@polkadot/api";
+import { u8aToHex, stringToU8a } from "@polkadot/util";
+import type { KeyringPair } from "@polkadot/keyring/types";
+
+import { config } from "../config.js";
+import { heartbeatsRouter } from "../routes/heartbeats.js";
+import { setQuotaDbForTests } from "../quota.js";
+import {
+  initApiTokensDb,
+  issueToken,
+  setApiTokensDb,
+} from "../api-tokens.js";
+import { initHeartbeatDb } from "../heartbeat-store.js";
+
+// --------------------------------------------------------------------------
+// Test harness
+// --------------------------------------------------------------------------
+
+interface HarnessCtx {
+  app: express.Express;
+  pair: KeyringPair;
+  ss58: string;
+  legacyApiKey: string;
+  randomApiKey: string;
+  bearerToken: string;
+  tokensDb: Database.Database;
+  quotaDb: Database.Database;
+  tmpStorage: string;
+  prevStoragePath: string;
+}
+
+/** Counter for generating unique validator keys per test. The heartbeat
+ * route carries a module-level in-memory rate limiter keyed by
+ * validator_id; reusing the same ID across sub-tests would 429. Each test
+ * gets its own pair via `//HeartbeatValidator${n}`. */
+let _pairCounter = 0;
+
+async function setupApp(opts: { registerValidator?: boolean } = {}): Promise<HarnessCtx> {
+  await cryptoWaitReady();
+
+  // --- fs: point storage at a throwaway temp dir (heartbeat.db lives here) ---
+  const tmpStorage = mkdtempSync(join(tmpdir(), "blob-gateway-heartbeats-test-"));
+  const prevStoragePath = config.storagePath;
+  config.storagePath = tmpStorage;
+
+  // Init the real heartbeat-store against a file in tmpStorage. This is a
+  // module-level singleton, so once initialised it points at our temp DB
+  // until the test process exits.
+  initHeartbeatDb();
+
+  // --- quota db (in-memory, matching initQuotaDb's schema) ---
+  const quotaDb = new Database(":memory:");
+  quotaDb.pragma("journal_mode = WAL");
+  quotaDb.exec(`
+    CREATE TABLE api_keys (
+      key_hash TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+      max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+      max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+      validator_id TEXT DEFAULT NULL
+    );
+    CREATE TABLE quota_daily (
+      key_hash TEXT NOT NULL,
+      day TEXT NOT NULL,
+      receipts INTEGER NOT NULL DEFAULT 0,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (key_hash, day)
+    );
+    CREATE TABLE uploads_inflight (
+      upload_id TEXT PRIMARY KEY,
+      key_hash TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+    CREATE TABLE account_quotas_daily (
+      address TEXT NOT NULL,
+      day TEXT NOT NULL,
+      receipts INTEGER NOT NULL DEFAULT 0,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (address, day)
+    );
+    CREATE TABLE account_uploads_inflight (
+      upload_id TEXT PRIMARY KEY,
+      address TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+  `);
+  setQuotaDbForTests(quotaDb);
+
+  // Real sr25519 validator key — the heartbeat-sig path requires a real
+  // signature that signatureVerify() can check against validator_id. We
+  // mint a unique key per setupApp() call so the in-memory rate limiter
+  // (module-level `lastPostTime` in heartbeats.ts) doesn't 429 subsequent
+  // tests for the same validator_id.
+  const keyring = new Keyring({ type: "sr25519" });
+  _pairCounter += 1;
+  const pair = keyring.addFromUri(`//HeartbeatValidator${_pairCounter}`);
+  const ss58 = pair.address;
+
+  // Random per-operator api key (production pattern — 64 hex).
+  const randomApiKey = "0".repeat(64);
+  const randomKeyHash = createHash("sha256").update(randomApiKey).digest("hex");
+
+  if (opts.registerValidator !== false) {
+    quotaDb
+      .prepare(
+        `INSERT INTO api_keys
+         (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id)
+         VALUES (?, 'operator-heartbeat-test', 1, 100, 1073741824, 5, ?)`,
+      )
+      .run(randomKeyHash, ss58);
+
+    // Legacy SS58-as-API-key row: hash(ss58) → validator_id = ss58. This
+    // is the path the cert-daemon has been using in prod since v5.
+    const legacyKeyHash = createHash("sha256").update(ss58).digest("hex");
+    quotaDb
+      .prepare(
+        `INSERT INTO api_keys
+         (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id)
+         VALUES (?, 'operator-heartbeat-test-legacy', 1, 100, 1073741824, 5, ?)`,
+      )
+      .run(legacyKeyHash, ss58);
+  }
+
+  // --- api_tokens db (in-memory) ---
+  const tokensDb = new Database(":memory:");
+  tokensDb.pragma("journal_mode = WAL");
+  initApiTokensDb(tokensDb);
+  setApiTokensDb(tokensDb);
+
+  const { token: bearerToken } = issueToken(tokensDb, {
+    accountSs58: ss58,
+    label: "heartbeats-auth-test",
+  });
+
+  // --- Express app wired to the real heartbeatsRouter ---
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.use(heartbeatsRouter);
+
+  return {
+    app,
+    pair,
+    ss58,
+    legacyApiKey: ss58, // legacy pattern = send the SS58 itself as the key
+    randomApiKey,
+    bearerToken,
+    tokensDb,
+    quotaDb,
+    tmpStorage,
+    prevStoragePath,
+  };
+}
+
+/** Minimal fetch wrapper around an ephemeral-port listen. */
+async function fetchJson(
+  app: express.Express,
+  method: string,
+  path: string,
+  opts: {
+    headers?: Record<string, string>;
+    jsonBody?: unknown;
+  } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { ...(opts.headers || {}) },
+      };
+      if (opts.jsonBody !== undefined) {
+        init.body = JSON.stringify(opts.jsonBody);
+        (init.headers as Record<string, string>)["content-type"] = "application/json";
+      }
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let body: unknown;
+          try {
+            body = text ? JSON.parse(text) : null;
+          } catch {
+            body = text;
+          }
+          server.close();
+          resolve({ status: res.status, body });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+interface HeartbeatBody {
+  validator_id: string;
+  seq: number;
+  timestamp: number;
+  best_block: number;
+  finalized_block: number;
+  finality_gap: number;
+  pending_receipts: number;
+  certs_submitted: number;
+  substrate_connected: boolean;
+  version: string;
+  uptime_seconds: number;
+}
+
+/** Build a well-formed heartbeat body + matching x-heartbeat-sig header. */
+function buildHeartbeat(
+  pair: KeyringPair,
+  validator_id: string,
+  seq: number,
+  overrides: Partial<HeartbeatBody> = {},
+): { body: HeartbeatBody; sig: string } {
+  const body: HeartbeatBody = {
+    validator_id,
+    seq,
+    timestamp: Math.floor(Date.now() / 1000),
+    best_block: 12345,
+    finalized_block: 12340,
+    finality_gap: 5,
+    pending_receipts: 0,
+    certs_submitted: 0,
+    substrate_connected: true,
+    version: "test-1.0.0",
+    uptime_seconds: 3600,
+    ...overrides,
+  };
+  const scInt = body.substrate_connected ? 1 : 0;
+  const signingString = [
+    "materios-heartbeat-v1",
+    body.validator_id,
+    String(body.seq),
+    String(body.timestamp),
+    String(body.best_block),
+    String(body.finalized_block),
+    String(body.finality_gap),
+    String(body.pending_receipts),
+    String(body.certs_submitted),
+    String(scInt),
+    String(body.version),
+    String(body.uptime_seconds),
+  ].join("|");
+  const sig = u8aToHex(pair.sign(stringToU8a(signingString)));
+  return { body, sig };
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe("POST /heartbeats: unified auth (Bearer / x-api-key / x-heartbeat-sig)", () => {
+  let ctx: HarnessCtx;
+  /** Monotonically-increasing seq per test to dodge the replay guard. */
+  let nextSeq = 1_000_000;
+
+  beforeEach(async () => {
+    ctx = await setupApp();
+    // Bump seq baseline by a large step so the in-memory heartbeat-store
+    // (reused across beforeEach's, since initHeartbeatDb opens a file on
+    // disk keyed by tmpStorage) never flags sub-tests as replays.
+    nextSeq += 1_000;
+  });
+
+  afterEach(() => {
+    config.storagePath = ctx.prevStoragePath;
+    rmSync(ctx.tmpStorage, { recursive: true, force: true });
+  });
+
+  // ------------------------------------------------------------------------
+  // 1. Bearer token accepted — the actual regression this PR fixes
+  // ------------------------------------------------------------------------
+  test("test_heartbeat_accepts_bearer_token", async () => {
+    const seq = nextSeq++;
+    const { body, sig } = buildHeartbeat(ctx.pair, ctx.ss58, seq);
+    const res = await fetchJson(ctx.app, "POST", "/heartbeats", {
+      headers: {
+        authorization: `Bearer ${ctx.bearerToken}`,
+        "x-heartbeat-sig": sig,
+      },
+      jsonBody: body,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ status: "ok", seq });
+    // Surfacing the tier helps operators debug which header was accepted
+    // during the rollout; we lock it in so the contract survives.
+    expect((res.body as { auth_tier?: string }).auth_tier).toBe("bearer");
+
+    // Regression: last_seq stored under the validator_id
+    const lastSeq = await fetchJson(ctx.app, "GET", `/heartbeats/seq/${ctx.ss58}`);
+    expect(lastSeq.status).toBe(200);
+    expect((lastSeq.body as { last_seq: number }).last_seq).toBe(seq);
+  });
+
+  // ------------------------------------------------------------------------
+  // 2. Legacy x-api-key (random hex) — regression guard
+  // ------------------------------------------------------------------------
+  test("test_heartbeat_accepts_legacy_x_api_key_random_hex", async () => {
+    const seq = nextSeq++;
+    const { body, sig } = buildHeartbeat(ctx.pair, ctx.ss58, seq);
+    const res = await fetchJson(ctx.app, "POST", "/heartbeats", {
+      headers: {
+        "x-api-key": ctx.randomApiKey,
+        "x-heartbeat-sig": sig,
+      },
+      jsonBody: body,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ status: "ok", seq });
+    expect((res.body as { auth_tier?: string }).auth_tier).toBe("api-key");
+  });
+
+  // ------------------------------------------------------------------------
+  // 2b. Legacy SS58-as-x-api-key — PROD cert-daemon's current flow.
+  //     Regression guard: breaking this would take every attestor's
+  //     heartbeat offline until they rotate to a Bearer token.
+  // ------------------------------------------------------------------------
+  test("test_heartbeat_accepts_legacy_x_api_key_ss58", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation((() => {}) as (...args: unknown[]) => void);
+    try {
+      const seq = nextSeq++;
+      const { body, sig } = buildHeartbeat(ctx.pair, ctx.ss58, seq);
+      const res = await fetchJson(ctx.app, "POST", "/heartbeats", {
+        headers: {
+          "x-api-key": ctx.legacyApiKey,
+          "x-heartbeat-sig": sig,
+        },
+        jsonBody: body,
+      });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ status: "ok", seq });
+      expect((res.body as { auth_tier?: string }).auth_tier).toBe("api-key-legacy-ss58");
+
+      // The deprecated-ss58-auth warn-log must fire so we can track
+      // migration progress via `kubectl logs | grep deprecated-ss58-auth`.
+      const calls = (warn.mock.calls as unknown[][]).map((c) => c.join(" "));
+      expect(calls.some((m) => m.includes("deprecated-ss58-auth"))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // ------------------------------------------------------------------------
+  // 3. Keyless x-heartbeat-sig flow still works (registered validator,
+  //    no account-auth headers at all)
+  // ------------------------------------------------------------------------
+  test("test_heartbeat_accepts_x_heartbeat_sig_only", async () => {
+    const seq = nextSeq++;
+    const { body, sig } = buildHeartbeat(ctx.pair, ctx.ss58, seq);
+    const res = await fetchJson(ctx.app, "POST", "/heartbeats", {
+      headers: { "x-heartbeat-sig": sig },
+      jsonBody: body,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ status: "ok", seq });
+    expect((res.body as { auth_tier?: string }).auth_tier).toBe("sig-only");
+  });
+
+  // ------------------------------------------------------------------------
+  // 4. No auth at all → 403 (unregistered validator branch). An
+  //    unregistered account with no Bearer/api-key can't backdoor the
+  //    heartbeat ingest even if they can sign a payload.
+  // ------------------------------------------------------------------------
+  test("test_heartbeat_rejects_no_auth_unregistered_validator", async () => {
+    // Re-setup without registering — forces the sig-path lookupValidatorInfo
+    // to return null.
+    config.storagePath = ctx.prevStoragePath;
+    rmSync(ctx.tmpStorage, { recursive: true, force: true });
+    ctx = await setupApp({ registerValidator: false });
+
+    const seq = nextSeq++;
+    const { body, sig } = buildHeartbeat(ctx.pair, ctx.ss58, seq);
+    const res = await fetchJson(ctx.app, "POST", "/heartbeats", {
+      headers: { "x-heartbeat-sig": sig },
+      jsonBody: body,
+    });
+    expect(res.status).toBe(403);
+    expect((res.body as { error: string }).error).toMatch(/not registered/i);
+  });
+
+  // ------------------------------------------------------------------------
+  // 5. Missing x-heartbeat-sig with a Bearer present → 400. The Bearer
+  //    authenticates the ACCOUNT; the sig is what binds this specific
+  //    heartbeat payload to the key. Dropping the sig would let anyone
+  //    with the Bearer replay arbitrary payloads.
+  // ------------------------------------------------------------------------
+  test("test_heartbeat_rejects_bearer_without_heartbeat_sig", async () => {
+    const seq = nextSeq++;
+    const { body } = buildHeartbeat(ctx.pair, ctx.ss58, seq);
+    const res = await fetchJson(ctx.app, "POST", "/heartbeats", {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      jsonBody: body,
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/x-heartbeat-sig/);
+  });
+
+  // ------------------------------------------------------------------------
+  // 6. Revoked Bearer → 401. Mirrors upload-auth.test.ts' revocation test.
+  // ------------------------------------------------------------------------
+  test("test_heartbeat_rejects_revoked_bearer", async () => {
+    const tokenHash = createHash("sha256").update(ctx.bearerToken).digest("hex");
+    ctx.tokensDb
+      .prepare(
+        `UPDATE api_tokens SET revoked_at = ?, revoked_reason = 'test' WHERE token_hash = ?`,
+      )
+      .run(Math.floor(Date.now() / 1000), tokenHash);
+
+    const seq = nextSeq++;
+    const { body, sig } = buildHeartbeat(ctx.pair, ctx.ss58, seq);
+    const res = await fetchJson(ctx.app, "POST", "/heartbeats", {
+      headers: {
+        authorization: `Bearer ${ctx.bearerToken}`,
+        "x-heartbeat-sig": sig,
+      },
+      jsonBody: body,
+    });
+    expect(res.status).toBe(401);
+    const err = (res.body as { error: string }).error;
+    expect(err.toLowerCase()).toContain("revoked");
+  });
+
+  // ------------------------------------------------------------------------
+  // 7. Bad x-api-key → 401 with the legacy wire-format error message.
+  //    cert-daemon clients parse this exact string to distinguish auth
+  //    failures from other 4xx modes.
+  // ------------------------------------------------------------------------
+  test("test_heartbeat_bad_x_api_key_returns_legacy_401_message", async () => {
+    const seq = nextSeq++;
+    const { body, sig } = buildHeartbeat(ctx.pair, ctx.ss58, seq);
+    const res = await fetchJson(ctx.app, "POST", "/heartbeats", {
+      headers: {
+        "x-api-key": "not-a-valid-key-at-all",
+        "x-heartbeat-sig": sig,
+      },
+      jsonBody: body,
+    });
+    expect(res.status).toBe(401);
+    const err = (res.body as { error: string }).error;
+    expect(err).toBe("Invalid or disabled API key");
+  });
+
+  // ------------------------------------------------------------------------
+  // 8. Bearer with MISMATCHED validator_id in body → 403. The Bearer
+  //    token binds to a specific SS58; the body can't claim to be
+  //    someone else.
+  // ------------------------------------------------------------------------
+  test("test_heartbeat_rejects_bearer_with_mismatched_validator_id", async () => {
+    // Build a body for a different SS58 entirely, signed by a different
+    // key so the sig is still valid for THAT payload — the test is that
+    // the binding check trips BEFORE the sig check.
+    const otherKeyring = new Keyring({ type: "sr25519" });
+    const otherPair = otherKeyring.addFromUri("//OtherValidator");
+    const otherSs58 = otherPair.address;
+
+    const seq = nextSeq++;
+    const { body, sig } = buildHeartbeat(otherPair, otherSs58, seq);
+
+    const res = await fetchJson(ctx.app, "POST", "/heartbeats", {
+      headers: {
+        authorization: `Bearer ${ctx.bearerToken}`, // Bearer is for ctx.ss58
+        "x-heartbeat-sig": sig,
+      },
+      jsonBody: body,
+    });
+    expect(res.status).toBe(403);
+    expect((res.body as { error: string }).error).toMatch(/does not match/i);
+  });
+});

--- a/services/blob-gateway/src/routes/heartbeats.ts
+++ b/services/blob-gateway/src/routes/heartbeats.ts
@@ -1,14 +1,23 @@
 /**
  * Heartbeat routes — validators report liveness with sr25519-signed heartbeats.
  *
- * POST /heartbeats        — API-key-protected, validates signature + seq
+ * POST /heartbeats        — Accepts Bearer / x-api-key / sr25519 sig; validates signature + seq
  * GET  /heartbeats/status — Public, returns validator liveness summary
+ *
+ * Auth (PR #129): unified via `resolveAuth` for the account-bound tiers
+ * (Bearer token → legacy x-api-key), then falls through to the heartbeat-
+ * specific sr25519 `x-heartbeat-sig` path for keyless validators. The
+ * heartbeat-sig scheme signs a different payload than upload-sig
+ * (`materios-heartbeat-v1|...` vs `materios-upload-v1|...`) and uses a
+ * different header, so we cannot collapse it into resolveAuth without
+ * breaking the cert-daemon wire format.
  */
 
 import { Router, type Request, type Response } from "express";
 import { signatureVerify } from "@polkadot/util-crypto";
 import { stringToU8a } from "@polkadot/util";
-import { resolveKey, lookupValidatorInfo } from "../quota.js";
+import { lookupValidatorInfo } from "../quota.js";
+import { resolveAuth } from "../auth.js";
 import {
   upsertHeartbeat,
   getLastSeq,
@@ -57,7 +66,7 @@ const STATUS_CACHE_TTL_MS = 10_000; // 10 seconds
 
 /* ---------- POST /heartbeats ---------- */
 
-heartbeatsRouter.post("/heartbeats", (req: Request, res: Response) => {
+heartbeatsRouter.post("/heartbeats", async (req: Request, res: Response) => {
   try {
     const body = req.body;
     if (!body || typeof body !== "object") {
@@ -99,25 +108,59 @@ heartbeatsRouter.post("/heartbeats", (req: Request, res: Response) => {
 
     const ip = (req.headers["x-forwarded-for"] as string) || req.socket.remoteAddress || "";
 
-    // --- AUTH: API key OR signature-only with registered validator ---
-    const apiKey = req.headers["x-api-key"] as string | undefined;
-    let label: string;
+    // --- AUTH: Bearer token → legacy x-api-key → sr25519 x-heartbeat-sig ---
+    //
+    // resolveAuth() handles Bearer (priority 0) and x-api-key (priority 1).
+    // We call it without a contentHash so its upload-sig branch is skipped —
+    // heartbeats use `x-heartbeat-sig` with a completely different signing
+    // payload, which we handle as a parallel fallback below.
+    //
+    // If neither a Bearer nor an x-api-key header is present, resolveAuth
+    // returns `authenticated: false` with error "No authentication
+    // provided" — that's our signal to fall through to the sig path.
+    // An INVALID api-key or Bearer short-circuits with 401 here so the
+    // cert-daemon's `401 Invalid or disabled API key` contract survives.
+    const hasAccountAuthHeader =
+      typeof req.headers.authorization === "string" ||
+      typeof req.headers["x-api-key"] === "string";
 
-    if (apiKey) {
-      // Traditional path: validate API key + binding
-      const keyInfo = resolveKey(apiKey);
-      if (!keyInfo) {
-        res.status(401).json({ error: "Invalid or disabled API key" });
+    let label: string | undefined;
+    let authTier: "bearer" | "api-key" | "api-key-legacy-ss58" | "sig-only" | undefined;
+
+    if (hasAccountAuthHeader) {
+      const auth = await resolveAuth(req);
+      if (!auth.authenticated) {
+        // Wire-format preserved: "Invalid or disabled API key" for legacy
+        // x-api-key clients; bearer errors surface their own verbose reason.
+        res.status(401).json({ error: auth.error ?? "Invalid or disabled API key" });
         return;
       }
-      if (keyInfo.validatorId && validator_id !== keyInfo.validatorId) {
-        logReject(validator_id, "validator_id mismatch with API key binding", ip);
+
+      // Bearer / api-key / api-key-legacy-ss58 tiers carry an identity.
+      // Enforce the validator_id binding: if the auth maps to a specific
+      // SS58 (either via keyInfo.validatorId or the bearer's accountSs58),
+      // the body's validator_id must match. Same 403 as the old code.
+      const boundSs58 =
+        auth.keyInfo?.validatorId ?? (auth.tier === "bearer" ? auth.identity : undefined);
+      if (boundSs58 && validator_id !== boundSs58) {
+        logReject(validator_id, "validator_id mismatch with auth binding", ip);
         res.status(403).json({ error: "validator_id does not match API key binding" });
         return;
       }
-      label = keyInfo.name;
+
+      // Label preference: KeyInfo.name (named operator row) > registered
+      // validator name > the raw identity SS58. Matches the prior behaviour
+      // where `keyInfo.name` was used for api-key flows; for Bearer tokens
+      // with no api_keys row, we fall back to the validator registry.
+      if (auth.keyInfo) {
+        label = auth.keyInfo.name;
+      } else {
+        const info = lookupValidatorInfo(validator_id);
+        label = info ? info.name : (auth.identity ?? validator_id);
+      }
+      authTier = auth.tier as typeof authTier;
     } else {
-      // Keyless path: validator must be in registry, sig is the real auth
+      // Keyless path: validator must be in registry, sig is the real auth.
       const info = lookupValidatorInfo(validator_id);
       if (!info) {
         logReject(validator_id, "unregistered validator (no API key, not in registry)", ip);
@@ -125,6 +168,7 @@ heartbeatsRouter.post("/heartbeats", (req: Request, res: Response) => {
         return;
       }
       label = info.name;
+      authTier = "sig-only";
     }
 
     // Rate limit: reject if < 10s since last POST for this validator
@@ -142,7 +186,6 @@ heartbeatsRouter.post("/heartbeats", (req: Request, res: Response) => {
     const nowSecs = Math.floor(now / 1000);
     const clockSkew = timestamp - nowSecs;
     if (Math.abs(clockSkew) > 120) {
-      const ip = (req.headers["x-forwarded-for"] as string) || req.socket.remoteAddress || "";
       logReject(validator_id, `clock skew too large: ${clockSkew}s`, ip);
       res.status(400).json({ error: "Clock skew exceeds 120 seconds", clock_skew_secs: clockSkew });
       return;
@@ -159,10 +202,13 @@ heartbeatsRouter.post("/heartbeats", (req: Request, res: Response) => {
       return;
     }
 
-    // Verify sr25519 signature
+    // Verify sr25519 signature. This is REQUIRED for every heartbeat — even
+    // Bearer/api-key flows must supply `x-heartbeat-sig`, because the sig is
+    // what binds the heartbeat payload to the validator's key. The bearer
+    // token only authenticates the account; the sig proves the
+    // payload-integrity + non-replay of this specific beat.
     const signature = req.headers["x-heartbeat-sig"] as string | undefined;
     if (!signature) {
-      const ip = (req.headers["x-forwarded-for"] as string) || req.socket.remoteAddress || "";
       logReject(validator_id, "missing x-heartbeat-sig header", ip);
       res.status(400).json({ error: "Missing x-heartbeat-sig header" });
       return;
@@ -190,7 +236,6 @@ heartbeatsRouter.post("/heartbeats", (req: Request, res: Response) => {
     const result = signatureVerify(sigBytes, signature, validator_id);
 
     if (!result.isValid) {
-      const ip = (req.headers["x-forwarded-for"] as string) || req.socket.remoteAddress || "";
       logReject(validator_id, "invalid sr25519 signature", ip);
       res.status(400).json({ error: "Invalid signature" });
       return;
@@ -199,7 +244,7 @@ heartbeatsRouter.post("/heartbeats", (req: Request, res: Response) => {
     // All checks passed — upsert heartbeat
     upsertHeartbeat(
       validator_id,
-      label,               // label from registry, NOT from body
+      label ?? validator_id, // label from registry/key, NOT from body
       seq,
       JSON.stringify(body), // store full payload
       signature,
@@ -220,7 +265,10 @@ heartbeatsRouter.post("/heartbeats", (req: Request, res: Response) => {
     // Invalidate status cache on new heartbeat
     cachedStatusResponse = null;
 
-    res.status(200).json({ status: "ok", seq, clock_skew_secs: clockSkew });
+    // auth_tier is informational only — clients have historically ignored
+    // unknown response fields, and surfacing it helps operators debug which
+    // header was accepted during migration.
+    res.status(200).json({ status: "ok", seq, clock_skew_secs: clockSkew, auth_tier: authTier });
   } catch (error) {
     console.error("[blob-gateway] Heartbeat POST error:", error);
     const message = error instanceof Error ? error.message : "Unknown error";


### PR DESCRIPTION
## Summary

- Migrates `POST /heartbeats` in `services/blob-gateway/src/routes/heartbeats.ts` from a hand-rolled `req.headers[\"x-api-key\"]` check to the unified `resolveAuth()` helper introduced in PR #7. Bearer tokens (`matra_...`) now work on heartbeat submission, not just on the blob upload endpoints.
- Closes #129 (\"Migrate remaining blob-gateway clients to Bearer tokens\"). `operators.ts` is the last significant hand-rolled `x-api-key` site left in the route tree; it's out of scope here and can be covered in a follow-up.

Auth priority on the heartbeat POST is now:

1. `Authorization: Bearer matra_...`  (via `resolveAuth` → `verifyToken`)
2. `x-api-key: <hex-or-SS58>`         (via `resolveAuth` → `resolveKey`, legacy SS58 still emits the `deprecated-ss58-auth` warn-log)
3. `x-heartbeat-sig: 0x...`           (keyless validators in the registry — parallel fallback, see below)

**Why `x-heartbeat-sig` stays a parallel fallback:** it signs a different payload than `x-upload-sig` (`materios-heartbeat-v1|validator_id|seq|...` vs `materios-upload-v1|contentHash|uploaderAddress|ts`) and uses a different header. Folding it into `resolveAuth` would either break the cert-daemon wire format or require teaching `resolveAuth` a second sig scheme keyed on path. Keeping it as a parallel fallback preserves the existing cert-daemon flow byte-for-byte.

## What's preserved (regression-tested)

- **cert-daemon coexistence.** Live mainnet + preprod cert-daemons send `x-api-key: <SS58>`; legacy SS58-as-key still passes and emits the `deprecated-ss58-auth` warn-log.
- **Error codes & wire format.**
  - `401 \"Invalid or disabled API key\"` for bad `x-api-key` (cert-daemon parses this exact string).
  - `403 \"validator_id does not match API key binding\"` for bound Bearer/api-key with mismatched `body.validator_id`.
  - `400 \"Missing x-heartbeat-sig header\"` — every heartbeat still requires a sig, even Bearer/api-key flows (the sig binds the payload to the key; the Bearer only authenticates the account).
  - `429` rate limiter (10s min interval), 120s clock-skew check, seq-replay guard, IP logging all unchanged.
- **New field**: the 200-OK response now includes an informational `auth_tier` (`bearer` / `api-key` / `api-key-legacy-ss58` / `sig-only`). Clients ignore unknown fields — this is additive and exists purely to make rollout-debugging easier (`kubectl logs ... | jq '.auth_tier'`).

## Diff summary

| File | + / − |
|------|-------|
| `services/blob-gateway/src/routes/heartbeats.ts` | +70 / −22 |
| `services/blob-gateway/src/__tests__/heartbeats-auth.test.ts` (new) | +513 / 0 |

**Net: 9 new test cases.**

## Test plan

- [x] `pnpm --filter @orynq/blob-gateway build` — clean.
- [x] `npx tsc --noEmit -p services/blob-gateway/tsconfig.json` — clean on the changed file.
- [x] `npx vitest run services/blob-gateway/src/__tests__/` — **48 passed** (39 prior + 9 new).
  - `heartbeats-auth.test.ts` — 9/9 green covering: bearer-accepted, legacy-random-hex api-key, legacy-SS58-as-api-key (with `deprecated-ss58-auth` log assertion), keyless `x-heartbeat-sig`, unregistered→403, missing-sig-with-bearer→400, revoked-bearer→401, bad-x-api-key wire-format, bearer-with-mismatched-validator-id→403.
- [x] Full repo: `npx vitest run` — **1729 passed / 44 skipped**. A single pre-existing flake in `tests/integration/client-auto-pay.integration.test.ts` (port 9876 EADDRINUSE when run fully parallel) is unrelated; re-running that file in isolation is clean on both `main` and this branch.
- [x] `heartbeatsRouter` export still at module level; `import { heartbeatsRouter }` in `src/index.ts` resolves unchanged.
- [x] No new `@polkadot/api` / `WsProvider` usage; only the existing `util-crypto` import is touched (Vercel-safe per `feedback_vercel_no_ws.md`).
- [x] Path-check clean (no `D:/fluxPoint` / `C:/Users`).
- [x] Commit author: `Claude Code <noreply@anthropic.com>` (Vercel-safe).

## Notes for reviewer

- `pnpm typecheck` at the repo root still fails on `packages/payer-cardano-cip30` (9 pre-existing errors about `@fluxpointstudios/orynq-sdk-core`); those exist on `main` and are not introduced here. Confirmed with a `git stash && pnpm typecheck` on `main`. Happy to roll those into a cleanup PR if you want, but figured they should stay separate.
- `auth_tier` in the 200 response is the one additive wire change. Flag if you'd rather strip it — everything else is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)