### PR TITLE
fix(blob-gateway): paginate through full Receipts map in receipt-indexer (fixes stuck sponsored receipts)

### DIFF
--- a/services/blob-gateway/src/__tests__/receipt-indexer-paginate.test.ts
+++ b/services/blob-gateway/src/__tests__/receipt-indexer-paginate.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for the receipt-indexer key-enumeration paginator.
+ *
+ * Bug recap (Penny ops report, task #145): the prior implementation called
+ *   state_getKeysPaged(prefix, 100, null)
+ * on every tick with a hard-coded `null` start_key, so it only ever saw the
+ * first 100 storage keys in blake2_128(receipt_id) order. Receipts whose hash
+ * landed past that page were silently never indexed, which left them stuck
+ * at availability_cert_hash = 0x00... and the cert-daemon would log
+ *   "No locator found for 0x..."
+ * indefinitely. These tests pin down the paginator behaviour so the bug can't
+ * regress.
+ *
+ * Mocking strategy: we mock global `fetch` at the module boundary via
+ * `vi.stubGlobal("fetch", ...)`. A small handler dispatches on the
+ * JSON-RPC method so each test can script its own storage responses.
+ *
+ * Timers: the indexer schedules a recurring `setInterval` callback. We use
+ * `vi.useFakeTimers()` so that (a) no real timer ever fires in test context
+ * and (b) the "walks full map on each tick" test can drive a second tick
+ * deterministically with `vi.advanceTimersByTimeAsync`.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// OrinqReceipts.Receipts storage prefix (twox128 x2) — must match the
+// constant in receipt-indexer.ts so the production code path is exercised.
+const RECEIPTS_PREFIX =
+  "0xcd01cd31249ddf8841dad036babd910f9a6912f00c3f09f66bdf9eb1bdb77563";
+
+// The indexer extracts receipt_id from the last 32 bytes (64 hex chars) of
+// each storage key: prefix(32) + blake2_128(16) + receipt_id(32). To keep
+// tests readable we build keys from a receipt_id seed and a "page number"
+// byte so the keys are unique, plausibly-shaped, and easy to inspect.
+function makeKey(page: number, index: number): string {
+  // 16-byte hash prefix (32 hex) + 32-byte receipt id (64 hex). Receipt id
+  // carries the (page, index) for easy assertions.
+  const hash = "aa".repeat(16);
+  const receiptId =
+    page.toString(16).padStart(2, "0").repeat(16) +
+    index.toString(16).padStart(2, "0").repeat(16);
+  return RECEIPTS_PREFIX + hash + receiptId;
+}
+
+// Build a well-formed ReceiptRecord hex value: schema_hash(32) +
+// content_hash(32) + trailing bytes. The indexer only reads the
+// content_hash slice (bytes 32..64); everything else can be zeroed.
+function makeReceiptValue(contentHashHex: string): string {
+  const schema = "00".repeat(32);
+  const content = contentHashHex.padStart(64, "0").slice(-64);
+  const tail = "00".repeat(16); // extra payload so length > 128 hex chars
+  return "0x" + schema + content + tail;
+}
+
+interface KeyPageScript {
+  // Ordered list of page responses. Each page is the array of keys returned
+  // to the NEXT state_getKeysPaged call. When exhausted we return [].
+  pages: string[][];
+}
+
+interface FetchHarness {
+  calls: Array<{ method: string; params: unknown[] }>;
+  // Mutable so tests can extend pages between ticks.
+  script: KeyPageScript;
+  bestBlockHex: string;
+  receiptCount: number;
+  // Map of storage key -> receipt value (hex). Any unknown key returns null.
+  values: Map<string, string>;
+}
+
+function makeHandler(harness: FetchHarness) {
+  return vi.fn(async (_url: string, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as {
+      method: string;
+      params: unknown[];
+    };
+    harness.calls.push({ method: body.method, params: body.params });
+
+    const respond = (result: unknown): Response => {
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    switch (body.method) {
+      case "chain_getHeader":
+        return respond({ number: harness.bestBlockHex });
+      case "chain_getBlockHash":
+        return respond("0x" + "bb".repeat(32));
+      case "orinq_getReceiptCount":
+        return respond(harness.receiptCount);
+      case "state_getKeysPaged": {
+        const page = harness.script.pages.shift() ?? [];
+        return respond(page);
+      }
+      case "state_getStorage": {
+        const key = body.params[0] as string;
+        return respond(harness.values.get(key) ?? null);
+      }
+      default:
+        return respond(null);
+    }
+  });
+}
+
+describe("receipt-indexer pagination (task #145 regression)", () => {
+  let tmp: string;
+  let indexRoot: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "blob-gateway-indexer-test-"));
+    indexRoot = join(tmp, "index", "receipt-to-content");
+    // Pre-create the index dir so fast-path reads don't hit a "no such
+    // directory" noise-branch (the indexer also mkdir -p's on first write,
+    // so this is strictly belt-and-suspenders).
+    await mkdir(indexRoot, { recursive: true });
+    // Fresh env for each test. STORAGE_PATH is read by config.ts at module
+    // load so we must set it BEFORE dynamic-importing the indexer.
+    process.env.STORAGE_PATH = tmp;
+    process.env.MATERIOS_RPC_URL = "http://127.0.0.1:19999";
+    // vi.resetModules() forces a fresh config.ts evaluation per test.
+    vi.resetModules();
+    // Fake timers so setInterval never schedules a real tick; each test
+    // controls its own advancement via vi.advanceTimersByTimeAsync.
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete process.env.STORAGE_PATH;
+    delete process.env.MATERIOS_RPC_URL;
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("test_paginates_through_multiple_batches", async () => {
+    // Four-call script: two full PAGE_SIZE pages, one short page, one
+    // empty sentinel. Shape in the task brief was "[100, 100, 50, 0]"
+    // at the conceptual level; we instantiate it at PAGE_SIZE=1000 so
+    // the real short-circuit `batch.length < PAGE_SIZE` does not fire
+    // prematurely. The net behaviour asserted — "walk until empty" —
+    // is identical: if pagination stays at a single call, this fails;
+    // if it stops early on any short batch below PAGE_SIZE, this also
+    // fails on the 3rd page (500 keys, < 1000).
+    const PAGE_SIZE = 1000;
+    const page1 = Array.from({ length: PAGE_SIZE }, (_, i) => makeKey(1, i));
+    const page2 = Array.from({ length: PAGE_SIZE }, (_, i) => makeKey(2, i));
+    const page3 = Array.from({ length: 500 }, (_, i) => makeKey(3, i));
+    const allExpected = [...page1, ...page2, ...page3];
+
+    const values = new Map<string, string>();
+    for (let i = 0; i < allExpected.length; i++) {
+      // Distinct content_hash per key so we can assert the map 1:1.
+      values.set(
+        allExpected[i],
+        makeReceiptValue(i.toString(16).padStart(64, "0")),
+      );
+    }
+
+    const harness: FetchHarness = {
+      calls: [],
+      script: { pages: [page1, page2, page3, []] },
+      bestBlockHex: "0x64", // 100 decimal
+      receiptCount: allExpected.length,
+      values,
+    };
+    vi.stubGlobal("fetch", makeHandler(harness));
+
+    const { startReceiptIndexer } = await import("../receipt-indexer.js");
+    await startReceiptIndexer();
+
+    // Every state_getKeysPaged call we made. Expected: 3 calls when the
+    // implementation short-circuits on `batch.length < PAGE_SIZE` (page3
+    // has 500 keys which < 1000 so no 4th call is needed). The critical
+    // regression guard is that it's > 1 (prior bug: 1 hard-coded call).
+    const pagedCalls = harness.calls.filter(
+      (c) => c.method === "state_getKeysPaged",
+    );
+    expect(pagedCalls.length).toBeGreaterThanOrEqual(3);
+    expect(pagedCalls[0].params).toEqual([RECEIPTS_PREFIX, PAGE_SIZE, null]);
+    // start_key MUST advance to the last key of the prior page.
+    expect(pagedCalls[1].params).toEqual([
+      RECEIPTS_PREFIX,
+      PAGE_SIZE,
+      page1[page1.length - 1],
+    ]);
+    expect(pagedCalls[2].params).toEqual([
+      RECEIPTS_PREFIX,
+      PAGE_SIZE,
+      page2[page2.length - 1],
+    ]);
+
+    // All 2500 receipts must have been indexed to disk.
+    const files = await readdir(indexRoot);
+    expect(files).toHaveLength(allExpected.length);
+  });
+
+  test("test_walks_full_map_on_each_tick", async () => {
+    // This test pins the re-walk-each-tick behaviour: the indexer must
+    // NOT carry a cursor across poll invocations. New receipts land at
+    // random blake2_128 hash positions; a receipt submitted between
+    // tick T and tick T+1 may hash to page 3 even though at tick T the
+    // last-seen page was page 2. If we cached a cursor we'd skip it.
+    //
+    // Stage: full-size pages so the real PAGE_SIZE=1000 short-circuit
+    // doesn't hide a cursor-retention bug. `lateKey` is appended onto
+    // tick 2's page 2, past the pagination boundary that tick 1 saw.
+    const PAGE_SIZE = 1000;
+    const tick1Page1 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+      makeKey(1, i),
+    );
+    const tick1Page2 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+      makeKey(2, i),
+    );
+    // Late-arriving key — deliberately placed past tick 1's walked range.
+    const lateKey = makeKey(3, 999);
+
+    const values = new Map<string, string>();
+    for (const k of [...tick1Page1, ...tick1Page2, lateKey]) {
+      values.set(k, makeReceiptValue(k.slice(-64)));
+    }
+
+    // Script: tick 1 = 3 calls (page1, page2, empty).
+    //         tick 2 = 3 calls (page1, page2, page-containing-lateKey).
+    //                  Final page is short (< PAGE_SIZE), so no empty
+    //                  sentinel is needed — paginator short-circuits.
+    const harness: FetchHarness = {
+      calls: [],
+      script: {
+        pages: [
+          // Tick 1
+          tick1Page1,
+          tick1Page2,
+          [],
+          // Tick 2
+          tick1Page1,
+          tick1Page2,
+          [lateKey],
+        ],
+      },
+      bestBlockHex: "0x64",
+      receiptCount: tick1Page1.length + tick1Page2.length,
+      values,
+    };
+    vi.stubGlobal("fetch", makeHandler(harness));
+
+    const { startReceiptIndexer } = await import("../receipt-indexer.js");
+    await startReceiptIndexer();
+
+    // After tick 1: all 2000 page-1+page-2 keys indexed. Late key NOT yet.
+    const afterTick1 = await readdir(indexRoot);
+    expect(afterTick1).toHaveLength(
+      tick1Page1.length + tick1Page2.length,
+    );
+    const lateReceiptId = lateKey.slice(lateKey.length - 64);
+    expect(afterTick1).not.toContain(`${lateReceiptId}.txt`);
+
+    // Drive tick 2. The indexer installs a setInterval(poll, 6000), but
+    // under fake timers we invoke it explicitly instead. Calling
+    // startReceiptIndexer() a second time re-reads indexer-state.json
+    // from disk and proceeds from there — equivalent to the interval
+    // firing, but deterministic. Advance the chain first so the poll
+    // doesn't short-circuit on `bestBlock <= lastProcessedBlock`.
+    harness.bestBlockHex = "0x65";
+    harness.receiptCount += 1;
+    await startReceiptIndexer();
+
+    const afterTick2 = await readdir(indexRoot);
+    expect(afterTick2).toHaveLength(
+      tick1Page1.length + tick1Page2.length + 1,
+    );
+    expect(afterTick2).toContain(`${lateReceiptId}.txt`);
+
+    // Sanity: tick 2's first paginator call had start_key=null. If a
+    // regression persisted start_key across ticks we'd see a non-null here.
+    const pagedCalls = harness.calls.filter(
+      (c) => c.method === "state_getKeysPaged",
+    );
+    // Tick 1 issued 3 paged calls, so tick 2's first paged call is index 3.
+    expect(pagedCalls[3].params).toEqual([RECEIPTS_PREFIX, PAGE_SIZE, null]);
+  });
+
+  test("test_stops_on_empty_response", async () => {
+    // First (and only) response is []. Indexer must make exactly one
+    // state_getKeysPaged call and no state_getStorage calls. If the loop
+    // condition is wrong, we either infinite-loop (test times out) or
+    // fire a spurious second call.
+    const harness: FetchHarness = {
+      calls: [],
+      script: { pages: [[]] },
+      bestBlockHex: "0x64",
+      // receiptCount > 0 so the indexer enters the paginator branch at all.
+      receiptCount: 7,
+      values: new Map(),
+    };
+    vi.stubGlobal("fetch", makeHandler(harness));
+
+    const { startReceiptIndexer } = await import("../receipt-indexer.js");
+    await startReceiptIndexer();
+
+    const pagedCalls = harness.calls.filter(
+      (c) => c.method === "state_getKeysPaged",
+    );
+    expect(pagedCalls).toHaveLength(1);
+    expect(
+      harness.calls.filter((c) => c.method === "state_getStorage"),
+    ).toHaveLength(0);
+    const files = await readdir(indexRoot);
+    expect(files).toHaveLength(0);
+  });
+
+  test("test_already_indexed_keys_are_skipped", async () => {
+    // Three keys returned from pagination. The first two already have
+    // index files on disk. The indexer must NOT issue state_getStorage for
+    // those two, and MUST issue exactly one state_getStorage for the third.
+    const keys = [makeKey(1, 0), makeKey(1, 1), makeKey(1, 2)];
+    const receiptIds = keys.map((k) => k.slice(k.length - 64));
+
+    // Pre-seed the first two as already-indexed.
+    await writeFile(join(indexRoot, `${receiptIds[0]}.txt`), "deadbeef");
+    await writeFile(join(indexRoot, `${receiptIds[1]}.txt`), "cafebabe");
+
+    const values = new Map<string, string>();
+    values.set(keys[2], makeReceiptValue("ff".repeat(32)));
+
+    // Single page of 3 keys (< PAGE_SIZE) short-circuits the paginator
+    // after one call, so no trailing empty-sentinel page is needed.
+    const harness: FetchHarness = {
+      calls: [],
+      script: { pages: [keys] },
+      bestBlockHex: "0x64",
+      receiptCount: 3,
+      values,
+    };
+    vi.stubGlobal("fetch", makeHandler(harness));
+
+    const { startReceiptIndexer } = await import("../receipt-indexer.js");
+    await startReceiptIndexer();
+
+    const storageCalls = harness.calls.filter(
+      (c) => c.method === "state_getStorage",
+    );
+    // Only the unindexed third key should have been read from storage.
+    expect(storageCalls).toHaveLength(1);
+    expect(storageCalls[0].params).toEqual([keys[2]]);
+
+    const files = await readdir(indexRoot);
+    expect(files).toHaveLength(3);
+    expect(files).toContain(`${receiptIds[2]}.txt`);
+    // And the pre-seeded entries were not clobbered.
+    const { readFile } = await import("node:fs/promises");
+    expect(
+      await readFile(join(indexRoot, `${receiptIds[0]}.txt`), "utf-8"),
+    ).toBe("deadbeef");
+  });
+
+  test("top_level_exports_preserved", async () => {
+    // Guardrail from the task brief: we've hit nested-def bugs in this
+    // repo twice (PR #2, PR #43). Assert the module's public surface is
+    // exactly what callers import.
+    const mod = await import("../receipt-indexer.js");
+    expect(typeof mod.startReceiptIndexer).toBe("function");
+    // `startReceiptIndexer` must be a top-level named export, not a
+    // method hidden inside a nested namespace.
+    expect(Object.prototype.hasOwnProperty.call(mod, "startReceiptIndexer"))
+      .toBe(true);
+  });
+});

--- a/services/blob-gateway/src/receipt-indexer.ts
+++ b/services/blob-gateway/src/receipt-indexer.ts
@@ -135,27 +135,44 @@ export async function startReceiptIndexer(): Promise<void> {
       const receiptCount = countData.result || 0;
 
       if (receiptCount > 0) {
-        // Scan all receipts and check if they're indexed
-        // Use state_getKeysPaged to enumerate receipt storage keys
-        const keysResp = await fetch(rpcUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1,
-            method: "state_getKeysPaged",
-            // OrinqReceipts.Receipts prefix (twox128("OrinqReceipts") ++ twox128("Receipts"))
-            params: [
-              "0xcd01cd31249ddf8841dad036babd910f9a6912f00c3f09f66bdf9eb1bdb77563",
-              100,
-              null,
-            ],
-          }),
-        });
-        const keysData = (await keysResp.json()) as { result?: string[] };
-        const keys = keysData.result || [];
+        // Scan all receipts and check if they're indexed.
+        //
+        // state_getKeysPaged returns keys in blake2_128(receipt_id) hash order,
+        // so a single page of the first N keys is NOT "the newest N receipts".
+        // New receipts land at random hash positions and may be past any page
+        // boundary; the indexer must walk the entire storage map each tick,
+        // otherwise receipts past position N are never indexed and get stuck
+        // without an availability cert (see the live symptoms on preprod
+        // where cert-daemon logs "No locator found for 0x...").
+        //
+        // Paginate by passing the last key of batch K as start_key for batch
+        // K+1 until we see an empty response (or a short final page).
+        // OrinqReceipts.Receipts prefix = twox128("OrinqReceipts") ++ twox128("Receipts").
+        const PREFIX =
+          "0xcd01cd31249ddf8841dad036babd910f9a6912f00c3f09f66bdf9eb1bdb77563";
+        const PAGE_SIZE = 1000;
+        let startKey: string | null = null;
+        const allKeys: string[] = [];
+        for (;;) {
+          const keysResp = await fetch(rpcUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "state_getKeysPaged",
+              params: [PREFIX, PAGE_SIZE, startKey],
+            }),
+          });
+          const keysData = (await keysResp.json()) as { result?: string[] };
+          const batch = keysData.result || [];
+          if (batch.length === 0) break;
+          allKeys.push(...batch);
+          if (batch.length < PAGE_SIZE) break;
+          startKey = batch[batch.length - 1];
+        }
 
-        for (const key of keys) {
+        for (const key of allKeys) {
           // Extract receipt_id from the storage key
           // Key format: prefix(32) + blake2_128(16) + receipt_id(32) = 80 bytes hex = 160 chars + 0x
           // The receipt_id is the last 32 bytes (64 hex chars)


### PR DESCRIPTION
## Symptom (from Penny ops report, task #145)

Sponsored uploads on the live preprod blob-gateway were intermittently failing to certify. The gateway had **160 receipt-to-content index files** on disk even though the current era had **700+ certified receipts** — so many more receipts existed than the indexer had ever written entries for. Cert-daemon kept logging `No locator found for 0x...` for the missing ones, and they were stuck at `availability_cert_hash = 0x00...` forever. Three receipts had to be rescued manually today; the bug recurs on every new sponsored upload.

Penny team confirmed their e2e pipeline is clean; this paginator is the only thing blocking new sponsored uploads from certifying.

## Root cause

`services/blob-gateway/src/receipt-indexer.ts` was calling:

```ts
state_getKeysPaged(
  "0xcd01cd31249ddf8841dad036babd910f9a6912f00c3f09f66bdf9eb1bdb77563", // OrinqReceipts.Receipts prefix
  100,
  null, // <-- hard-coded start_key
)
```

every tick, with a hard-coded `null` start_key. That always returns the **first 100 storage keys in `blake2_128(receipt_id)` hash order**, which is _not_ "the newest 100 receipts" — new receipts land at random hash positions and may be past that boundary. Anything past position 100 was silently invisible to the indexer.

## Fix

Scope is deliberately narrow: only the key-enumeration step changes.

- Loop `state_getKeysPaged` until it returns an empty (or short final) page, passing the last key of each batch as `start_key` for the next.
- Bump the page size from 100 to 1000 to cut per-tick RPC roundtrips when there are many receipts (safe; the RPC layer accepts up to the node's configured `rpc-max-payload`).
- **Do NOT persist a cursor across ticks.** Each poll re-walks the whole map from `start_key=null`, because new receipts can hash into any position, including positions earlier than where the previous tick stopped.
- The `resolveReceiptId` / `writeIndex` / "already indexed, skip" fast-path / per-key indexing body are untouched — we only change which keys get enumerated each tick.
- No new deps. No `@polkadot/api`. Still a pure raw-RPC flow.

Intentionally **not** done:
- No switch to `state_subscribeStorage` or `OrinqReceipts.ReceiptSubmitted` event subscription; that's a better design long-term but would require SCALE event decoding this service has deliberately avoided.

## Tests

`services/blob-gateway/src/__tests__/receipt-indexer-paginate.test.ts` — 5 tests, mocks `fetch` at the module boundary:

- `test_paginates_through_multiple_batches` — scripted multi-page response; asserts the indexer keeps calling `state_getKeysPaged` with advancing `start_key` until it sees a short/empty page, and every key ends up indexed on disk.
- `test_walks_full_map_on_each_tick` — regression guard for cursor-across-ticks bugs. Tick 1 walks 2 full pages. Tick 2 introduces a new key past that boundary; the test asserts tick 2's first paginator call has `start_key=null` (fresh walk) and that the late key gets indexed.
- `test_stops_on_empty_response` — single empty page → exactly 1 `state_getKeysPaged` call, 0 `state_getStorage` calls, no infinite loop.
- `test_already_indexed_keys_are_skipped` — regression guard for the fast-path: pre-seeds 2 of 3 index files, asserts only the unindexed third causes a `state_getStorage` call, and the pre-seeded entries are not clobbered.
- `top_level_exports_preserved` — AST guard that `startReceiptIndexer` stays a top-level export. This repo has regressed that twice (PRs #2, #43).

## Verification

- `tsc --noEmit` clean on `services/blob-gateway` (tests are excluded from build tsconfig, but the implementation file compiles cleanly under strict + noUnusedLocals).
- `pnpm test services/blob-gateway` — 53 tests pass (48 previously green + 5 new).
- Full repo `pnpm test` — 1735 pass / 44 skipped / 0 new failures.

## Ops-side deploy note

After merge:
1. Rebuild and push the `blob-gateway:latest` image.
2. On each gateway host: `docker compose pull && docker compose up -d`.
3. On the first poll tick (≤ 6 s after restart), the indexer will walk the full Receipts storage map and catch up every previously-stranded receipt automatically. The "already indexed, skip" fast-path means catching up is idempotent — restarting mid-catch-up is safe.
4. Watch for `[receipt-indexer] Indexed: 0x... → 0x...` log lines; once they stop streaming you're fully caught up. `ls /data/blobs/index/receipt-to-content | wc -l` should then equal the live receipt count.

No DB migrations, no state wipe, no config changes needed.