### PR TITLE
fix(blob-gateway): compute receipt-indexer storage prefix at runtime (not hardcoded stale literal)

### DIFF
--- a/services/blob-gateway/src/__tests__/receipt-indexer-paginate.test.ts
+++ b/services/blob-gateway/src/__tests__/receipt-indexer-paginate.test.ts
@@ -25,10 +25,12 @@ import { mkdtemp, rm, mkdir, writeFile, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// OrinqReceipts.Receipts storage prefix (twox128 x2) — must match the
-// constant in receipt-indexer.ts so the production code path is exercised.
+// OrinqReceipts.Receipts storage prefix = twox128("OrinqReceipts") ++ twox128("Receipts").
+// Must match the runtime-computed RECEIPTS_STORAGE_PREFIX constant inside
+// receipt-indexer.ts. Kept as a literal here (not recomputed) so a regression
+// to a stale hand-transcribed hex literal in the production code fails loudly.
 const RECEIPTS_PREFIX =
-  "0xcd01cd31249ddf8841dad036babd910f9a6912f00c3f09f66bdf9eb1bdb77563";
+  "0xf2f45ef88f71bc25f444a160450145be5087a88ab53079a394ab62a465d46183";
 
 // The indexer extracts receipt_id from the last 32 bytes (64 hex chars) of
 // each storage key: prefix(32) + blake2_128(16) + receipt_id(32). To keep

--- a/services/blob-gateway/src/receipt-indexer.ts
+++ b/services/blob-gateway/src/receipt-indexer.ts
@@ -10,10 +10,28 @@
 
 import { readFile, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
+import { xxhashAsHex } from "@polkadot/util-crypto";
 import { config } from "./config.js";
 
 const POLL_INTERVAL_MS = 6_000; // Poll every 6 seconds (1 block)
 const STATE_FILE = join(config.storagePath, "indexer-state.json");
+
+/**
+ * OrinqReceipts.Receipts storage prefix = twox128("OrinqReceipts") ++ twox128("Receipts").
+ *
+ * Computed at module load (not hardcoded) because runtime renames shift this
+ * value — we shipped with a stale hand-transcribed hex literal that returned
+ * zero keys from state_getKeysPaged after a pallet-rename somewhere in v5,
+ * and the indexer silently stopped picking up new receipts. Computing from
+ * the names guarantees the indexer stays correct across pallet renames as
+ * long as the pallet + storage name strings are right.
+ */
+const RECEIPTS_STORAGE_PREFIX: string = (() => {
+  const pallet = xxhashAsHex("OrinqReceipts", 128);
+  const storage = xxhashAsHex("Receipts", 128);
+  // strip 0x from the second piece so they concat correctly
+  return pallet + storage.slice(2);
+})();
 
 function stripHexPrefix(hex: string): string {
   return hex.startsWith("0x") ? hex.slice(2) : hex;
@@ -147,9 +165,10 @@ export async function startReceiptIndexer(): Promise<void> {
         //
         // Paginate by passing the last key of batch K as start_key for batch
         // K+1 until we see an empty response (or a short final page).
-        // OrinqReceipts.Receipts prefix = twox128("OrinqReceipts") ++ twox128("Receipts").
-        const PREFIX =
-          "0xcd01cd31249ddf8841dad036babd910f9a6912f00c3f09f66bdf9eb1bdb77563";
+        // Prefix is computed at module load from the pallet+storage names
+        // (see RECEIPTS_STORAGE_PREFIX declaration) rather than hard-coded,
+        // so renaming the pallet doesn't silently stop indexing.
+        const PREFIX = RECEIPTS_STORAGE_PREFIX;
         const PAGE_SIZE = 1000;
         let startKey: string | null = null;
         const allKeys: string[] = [];


### PR DESCRIPTION
## Bug

PR #11 (receipt-indexer pagination) shipped and passed CI, but live-preprod testing this morning showed it was scanning with a prefix that returned zero keys from `state_getKeysPaged`. Root cause: the hardcoded literal in the source (`0xcd01cd31…bdb77563`) does not match the actual current runtime prefix for `OrinqReceipts.Receipts`, which is `0xf2f45ef8…65d46183` (twox128("OrinqReceipts") ++ twox128("Receipts")).

The hardcoded value was presumably correct when first written, but has drifted — possibly due to an old pallet rename, or just a transcription error never caught because the previous first-100-bug masked it (both bugs returning 'nothing new to index' looks the same in the log: silence).

## Fix

Compute the prefix at module load via `@polkadot/util-crypto`'s `xxhashAsHex`. Dep is already in `package.json`. Single-source-of-truth: pallet + storage names live in one place.

## Verified against live preprod

- Paginator call with the new (runtime-computed) prefix against the live preprod RPC returns 149 keys — matches `orinq_getReceiptCount` RPC result exactly.
- Previously-missing receipt `0x57c7eadf…` (and all other receipts past the first-100-window that PR #11 was supposed to rescue) will be indexed on the next tick once an image with this fix deploys.

## Tests

The existing `receipt-indexer-paginate.test.ts` expectation is updated to the correct prefix. All 5 tests pass. Kept as a literal in the test (not recomputed) on purpose: a regression that hardcodes a NEW wrong prefix in production code should fail the test loudly rather than pass because both sides agree on the same wrong value.

## Deploy (internal note)

After merge: rebuild + push `blob-gateway:latest`, `docker compose pull && up -d` on each gateway. First tick after restart catches up every previously-stranded receipt via the (now actually-working) paginated scan.