### PR TITLE
fix(blob-gateway): register faucet route (was in source but never app.use()'d)

### DIFF
--- a/services/blob-gateway/src/index.ts
+++ b/services/blob-gateway/src/index.ts
@@ -21,6 +21,7 @@ import { startReceiptIndexer } from "./receipt-indexer.js";
 import { initApiTokensDb } from "./api-tokens.js";
 import { registerTokenRoutes } from "./routes/tokens.js";
 import { chainInfoRouter, initChainInfoPoller } from "./routes/chain-info.js";
+import { faucetRouter } from "./routes/faucet.js";
 // initChainInfoPoller is re-exported for consumers that want to pre-warm the
 // cache at startup; we also call it in start() so the first /chain-info hit
 // after cold-start returns 200 instead of 503.
@@ -58,6 +59,7 @@ app.use(batchesRouter);     // Write: resolveAuth(). Read: public.
 app.use(heartbeatsRouter);  // Handles own dual-mode auth (Phase 2)
 app.use(operatorsRouter);   // Invite-only operator registration
 app.use(chainInfoRouter);   // Public: /chain-info — used by flux1 explorer + cert-daemon auto-discovery
+app.use(faucetRouter);      // Public: /faucet/drip — operator onboarding (MATRA + MOTRA bootstrap). Volume-mounted overrides accepted; see ops compose templates.
 registerTokenRoutes(app);   // Bearer-token lifecycle (admin-only)
 
 async function start(): Promise<void> {


### PR DESCRIPTION
## Bug

`services/blob-gateway/src/routes/faucet.ts` exists, compiles, and provides `POST /faucet/drip`. `index.ts` never imported or `app.use()`'d it, so operator onboarding has been returning 404 since migration from the legacy `materios-blob-gateway`.

Discovered today when debugging why operators were hitting `Address already received a drip` messages the live faucet couldn't possibly be returning (because the live faucet returned 404 for every request). Confirmed with direct curl against gateway:3002 — `Cannot POST /faucet/drip`.

## Side effect this surfaced

Our ops deploys bind-mount `faucet-preprod.js` over `/app/dist/routes/faucet.js` for env-specific customizations (IP rate-limit, 1001-MATRA drip amount, MOTRA bootstrap variant). That bind-mount pattern has been a **no-op for days** because the router it's overriding was never registered. After this PR + redeploy, those overrides take effect.

## Fix

Two-line change: `import { faucetRouter } from './routes/faucet.js';` + `app.use(faucetRouter);`.

## After merge

Rebuild + push `blob-gateway:latest`, `docker compose pull && up -d`. `curl -sS -X POST /preprod-blobs/faucet/drip -d '{"address":"<ss58>"}' ` will return the drip tx hash instead of 404. Every new-operator onboarding stops needing manual `//Alice` rescues.