### PR TITLE
feat(blob-gateway): per-token usage metering (Phase 1 of billing)

### DIFF
--- a/services/blob-gateway/src/__tests__/upload-auth.test.ts
+++ b/services/blob-gateway/src/__tests__/upload-auth.test.ts
@@ -43,7 +43,7 @@ import { u8aToHex, stringToU8a } from "@polkadot/util";
 
 import { config } from "../config.js";
 import { blobsRouter } from "../routes/blobs.js";
-import { setQuotaDbForTests } from "../quota.js";
+import { setQuotaDbForTests, migrateUsageColumns } from "../quota.js";
 import {
   initApiTokensDb,
   issueToken,
@@ -112,6 +112,12 @@ async function setupApp(opts: { registerOperator?: boolean } = {}): Promise<{
       status TEXT NOT NULL DEFAULT 'active'
     );
   `);
+  // Phase 1 billing: add lifetime_* columns so recordUsage() from the
+  // manifest/chunk handlers has a column to UPDATE. Without this, the
+  // in-test handler emits a warn-log ("no such column: lifetime_receipts")
+  // which is harmless but noisy — the production initQuotaDb does the
+  // same migration automatically.
+  migrateUsageColumns(quotaDb);
   setQuotaDbForTests(quotaDb);
 
   // SS58-shape account used by both Bearer and legacy-SS58-as-API-key tests.

--- a/services/blob-gateway/src/__tests__/usage-tracking.test.ts
+++ b/services/blob-gateway/src/__tests__/usage-tracking.test.ts
@@ -1,0 +1,621 @@
+/**
+ * Phase 1 billing — per-token usage metering tests.
+ *
+ * No billing enforcement; these tests only verify that:
+ *   - `recordUsage()` bumps lifetime_receipts / lifetime_bytes / last_used_at
+ *     atomically on an in-memory SQLite DB (same semantics as prod quota.db).
+ *   - `getUsage()` reads those counters back.
+ *   - The `GET /auth/token/:hash/usage` admin route returns the usage JSON
+ *     shape and is gated by x-admin-token (same guard as DELETE).
+ *   - The integration path (POST manifest → PUT chunk via Bearer) actually
+ *     credits the right token's lifetime counters.
+ *
+ * Migration idempotency is also covered: repeated `migrateUsageColumns()`
+ * against an already-migrated handle is a no-op, which mirrors what the
+ * prod blob-gateway does on every restart.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+// rpc-client + notify mocks mirror upload-auth.test.ts so the sig-only and
+// sponsored-receipt hot paths don't try to open WebSockets or POST to any
+// daemon. Tests that touch only quota.ts directly won't exercise these,
+// but the integration tests do.
+vi.mock("../rpc-client.js", () => ({
+  checkFunded: vi.fn(async () => true),
+  checkReceiptStatus: vi.fn(async () => "not_found" as const),
+  disconnectRpc: vi.fn(async () => {}),
+}));
+vi.mock("../notify.js", () => ({
+  notifyDaemon: vi.fn(async () => {}),
+}));
+
+import express from "express";
+import Database from "better-sqlite3";
+import { createHash, randomBytes } from "crypto";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { config } from "../config.js";
+import { blobsRouter } from "../routes/blobs.js";
+import {
+  setQuotaDbForTests,
+  migrateUsageColumns,
+  recordUsage,
+  getUsage,
+} from "../quota.js";
+import {
+  initApiTokensDb,
+  issueToken,
+  setApiTokensDb,
+} from "../api-tokens.js";
+import { registerTokenRoutes } from "../routes/tokens.js";
+
+// --------------------------------------------------------------------------
+// Shared DB fixtures
+// --------------------------------------------------------------------------
+
+/**
+ * Build an in-memory quota DB with the full schema (api_keys includes the
+ * Phase 1 usage columns via `migrateUsageColumns`). Returns the handle
+ * AND injects it into quota.ts via `setQuotaDbForTests` so callers of
+ * recordUsage/getUsage operate on this DB.
+ */
+function makeQuotaDb(): Database.Database {
+  const quotaDb = new Database(":memory:");
+  quotaDb.pragma("journal_mode = WAL");
+  // Match the non-phase-1 columns from initQuotaDb. We deliberately create
+  // the legacy shape first so migrateUsageColumns has something to alter —
+  // same situation the first production restart after this PR will face.
+  quotaDb.exec(`
+    CREATE TABLE api_keys (
+      key_hash TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+      max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+      max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+      validator_id TEXT DEFAULT NULL
+    );
+    CREATE TABLE quota_daily (
+      key_hash TEXT NOT NULL,
+      day TEXT NOT NULL,
+      receipts INTEGER NOT NULL DEFAULT 0,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (key_hash, day)
+    );
+    CREATE TABLE uploads_inflight (
+      upload_id TEXT PRIMARY KEY,
+      key_hash TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+    CREATE TABLE account_quotas_daily (
+      address TEXT NOT NULL,
+      day TEXT NOT NULL,
+      receipts INTEGER NOT NULL DEFAULT 0,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (address, day)
+    );
+    CREATE TABLE account_uploads_inflight (
+      upload_id TEXT PRIMARY KEY,
+      address TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+  `);
+  migrateUsageColumns(quotaDb);
+  setQuotaDbForTests(quotaDb);
+  return quotaDb;
+}
+
+/** Insert a single api_keys row and return its hash. */
+function seedKey(
+  quotaDb: Database.Database,
+  opts: {
+    plaintext?: string;
+    name?: string;
+    ss58?: string | null;
+    maxReceipts?: number;
+    maxBytes?: number;
+  } = {},
+): { apiKey: string; keyHash: string } {
+  const plaintext = opts.plaintext ?? randomBytes(32).toString("hex");
+  const keyHash = createHash("sha256").update(plaintext).digest("hex");
+  quotaDb
+    .prepare(
+      `INSERT INTO api_keys
+       (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id)
+       VALUES (?, ?, 1, ?, ?, 5, ?)`,
+    )
+    .run(
+      keyHash,
+      opts.name ?? "usage-test",
+      opts.maxReceipts ?? 100,
+      opts.maxBytes ?? 1073741824,
+      opts.ss58 ?? null,
+    );
+  return { apiKey: plaintext, keyHash };
+}
+
+// --------------------------------------------------------------------------
+// Unit tests — recordUsage / getUsage / migration idempotency
+// --------------------------------------------------------------------------
+
+describe("quota.recordUsage", () => {
+  let quotaDb: Database.Database;
+  beforeEach(() => {
+    quotaDb = makeQuotaDb();
+  });
+
+  test("test_recordUsage_bumps_receipts_and_last_used_at", () => {
+    const { keyHash } = seedKey(quotaDb, { name: "receipts" });
+    const before = quotaDb
+      .prepare("SELECT lifetime_receipts, last_used_at FROM api_keys WHERE key_hash = ?")
+      .get(keyHash) as { lifetime_receipts: number; last_used_at: string | null };
+    expect(before.lifetime_receipts).toBe(0);
+    expect(before.last_used_at).toBeNull();
+
+    recordUsage(keyHash, 0, 1);
+
+    const after = quotaDb
+      .prepare("SELECT lifetime_receipts, lifetime_bytes, last_used_at FROM api_keys WHERE key_hash = ?")
+      .get(keyHash) as {
+        lifetime_receipts: number;
+        lifetime_bytes: number;
+        last_used_at: string | null;
+      };
+    expect(after.lifetime_receipts).toBe(1);
+    expect(after.lifetime_bytes).toBe(0);
+    expect(after.last_used_at).not.toBeNull();
+    // ISO-8601 string shape: "YYYY-MM-DDTHH:MM:SS.sssZ"
+    expect(after.last_used_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/);
+  });
+
+  test("test_recordUsage_bumps_bytes", () => {
+    const { keyHash } = seedKey(quotaDb, { name: "bytes" });
+    recordUsage(keyHash, 1234, 0);
+    const row = quotaDb
+      .prepare("SELECT lifetime_receipts, lifetime_bytes FROM api_keys WHERE key_hash = ?")
+      .get(keyHash) as { lifetime_receipts: number; lifetime_bytes: number };
+    expect(row.lifetime_receipts).toBe(0);
+    expect(row.lifetime_bytes).toBe(1234);
+  });
+
+  test("test_recordUsage_is_idempotent_within_transaction", () => {
+    // better-sqlite3 is synchronous — the "concurrent" case is really a
+    // sequence of back-to-back calls. We assert the += math doesn't drift:
+    // 100 calls of (64 bytes, 0 receipts) and 100 calls of (0 bytes, 1 receipt)
+    // must land at (6400, 100) exactly, regardless of interleaving.
+    const { keyHash } = seedKey(quotaDb, { name: "idempotent" });
+    for (let i = 0; i < 100; i++) {
+      recordUsage(keyHash, 64, 0);
+      recordUsage(keyHash, 0, 1);
+    }
+    const row = quotaDb
+      .prepare("SELECT lifetime_receipts, lifetime_bytes FROM api_keys WHERE key_hash = ?")
+      .get(keyHash) as { lifetime_receipts: number; lifetime_bytes: number };
+    expect(row.lifetime_receipts).toBe(100);
+    expect(row.lifetime_bytes).toBe(100 * 64);
+  });
+
+  test("test_recordUsage_unknown_keyHash_is_silent_noop", () => {
+    // Missing rows must not crash — they represent a registration race
+    // and we'd rather swallow than 500 an upload.
+    expect(() => recordUsage("deadbeef".repeat(8), 42, 1)).not.toThrow();
+  });
+
+  test("test_recordUsage_negative_and_nan_bytes_are_coerced_to_zero", () => {
+    const { keyHash } = seedKey(quotaDb, { name: "sanitize" });
+    recordUsage(keyHash, -5, 0);
+    recordUsage(keyHash, Number.NaN, 0);
+    const row = quotaDb
+      .prepare("SELECT lifetime_bytes FROM api_keys WHERE key_hash = ?")
+      .get(keyHash) as { lifetime_bytes: number };
+    expect(row.lifetime_bytes).toBe(0);
+  });
+});
+
+describe("quota.getUsage", () => {
+  let quotaDb: Database.Database;
+  beforeEach(() => {
+    quotaDb = makeQuotaDb();
+  });
+
+  test("test_getUsage_returns_latest_counters", () => {
+    const { keyHash } = seedKey(quotaDb, {
+      name: "latest",
+      maxReceipts: 500,
+      maxBytes: 999,
+    });
+    recordUsage(keyHash, 100, 1);
+    recordUsage(keyHash, 200, 0);
+    recordUsage(keyHash, 300, 1);
+    const snap = getUsage(keyHash);
+    expect(snap).not.toBeNull();
+    expect(snap!.lifetime_receipts).toBe(2);
+    expect(snap!.lifetime_bytes).toBe(600);
+    expect(snap!.lifetime_matra_debited).toBe(0);
+    expect(snap!.max_receipts_per_day).toBe(500);
+    expect(snap!.max_bytes_per_day).toBe(999);
+    expect(snap!.last_used_at).not.toBeNull();
+  });
+
+  test("test_getUsage_nonexistent_key_returns_null", () => {
+    expect(getUsage("deadbeef".repeat(8))).toBeNull();
+  });
+
+  test("test_getUsage_returns_zeroes_for_fresh_row", () => {
+    const { keyHash } = seedKey(quotaDb, { name: "fresh" });
+    const snap = getUsage(keyHash);
+    expect(snap).not.toBeNull();
+    expect(snap!.lifetime_receipts).toBe(0);
+    expect(snap!.lifetime_bytes).toBe(0);
+    expect(snap!.lifetime_matra_debited).toBe(0);
+    expect(snap!.last_used_at).toBeNull();
+  });
+});
+
+describe("quota.migrateUsageColumns idempotency", () => {
+  test("test_idempotent_migration", () => {
+    // Fresh legacy-schema DB. First migrate: adds 4 columns. Second: no-op.
+    // Third (belt + suspenders): still no-op. Verify counters survive.
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE api_keys (
+        key_hash TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+        max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+        max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+        validator_id TEXT DEFAULT NULL
+      );
+    `);
+    db.prepare(
+      `INSERT INTO api_keys (key_hash, name) VALUES ('aa', 'pre-migration')`,
+    ).run();
+
+    migrateUsageColumns(db);
+    migrateUsageColumns(db);
+    migrateUsageColumns(db);
+
+    const cols = db.prepare("PRAGMA table_info(api_keys)").all() as Array<{
+      name: string;
+    }>;
+    const names = new Set(cols.map((c) => c.name));
+    expect(names.has("lifetime_receipts")).toBe(true);
+    expect(names.has("lifetime_bytes")).toBe(true);
+    expect(names.has("lifetime_matra_debited")).toBe(true);
+    expect(names.has("last_used_at")).toBe(true);
+
+    // Row that pre-existed the migration must show DEFAULT 0 via SELECT.
+    const row = db
+      .prepare(
+        "SELECT lifetime_receipts, lifetime_bytes, lifetime_matra_debited, last_used_at FROM api_keys WHERE key_hash = 'aa'",
+      )
+      .get() as {
+        lifetime_receipts: number;
+        lifetime_bytes: number;
+        lifetime_matra_debited: number;
+        last_used_at: string | null;
+      };
+    expect(row.lifetime_receipts).toBe(0);
+    expect(row.lifetime_bytes).toBe(0);
+    expect(row.lifetime_matra_debited).toBe(0);
+    expect(row.last_used_at).toBeNull();
+  });
+});
+
+// --------------------------------------------------------------------------
+// Admin endpoint tests — GET /auth/token/:hash/usage
+// --------------------------------------------------------------------------
+
+type MountedAdmin = {
+  app: express.Express;
+  adminToken: string;
+  tokensDb: Database.Database;
+  quotaDb: Database.Database;
+  ss58: string;
+  tokenHash: string;
+  keyHash: string;
+};
+
+function setupAdminApp(): MountedAdmin {
+  const quotaDb = makeQuotaDb();
+
+  const tokensDb = new Database(":memory:");
+  tokensDb.pragma("journal_mode = WAL");
+  initApiTokensDb(tokensDb);
+  setApiTokensDb(tokensDb);
+
+  const ss58 = "5UsageAdminTestaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab";
+  // api_keys row bound to the account (validator_id = ss58) — same shape
+  // operators.db registration produces in production.
+  const { keyHash } = seedKey(quotaDb, {
+    name: "usage-admin",
+    ss58,
+    maxReceipts: 42,
+    maxBytes: 7777,
+  });
+
+  const { tokenHash } = issueToken(tokensDb, {
+    accountSs58: ss58,
+    label: "usage-label",
+  });
+
+  const adminToken = `admin-${randomBytes(16).toString("hex")}`;
+
+  const app = express();
+  app.use(express.json());
+  registerTokenRoutes(app, { adminToken });
+
+  return { app, adminToken, tokensDb, quotaDb, ss58, tokenHash, keyHash };
+}
+
+async function fetchJson(
+  app: express.Express,
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { "content-type": "application/json", ...(opts.headers || {}) },
+      };
+      if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let body: unknown;
+          try {
+            body = text ? JSON.parse(text) : null;
+          } catch {
+            body = text;
+          }
+          server.close();
+          resolve({ status: res.status, body });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+describe("GET /auth/token/:hash/usage", () => {
+  let ctx: MountedAdmin;
+  beforeEach(() => {
+    ctx = setupAdminApp();
+  });
+
+  test("test_admin_endpoint_401_without_admin_token", async () => {
+    const res = await fetchJson(ctx.app, "GET", `/auth/token/${ctx.tokenHash}/usage`);
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  test("test_admin_endpoint_401_with_wrong_admin_token", async () => {
+    const res = await fetchJson(ctx.app, "GET", `/auth/token/${ctx.tokenHash}/usage`, {
+      headers: { "x-admin-token": "not-the-real-admin-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("test_admin_endpoint_returns_usage_json", async () => {
+    // Seed some usage so we can assert non-zero values came through.
+    recordUsage(ctx.keyHash, 500, 1);
+    recordUsage(ctx.keyHash, 250, 0);
+
+    const res = await fetchJson(ctx.app, "GET", `/auth/token/${ctx.tokenHash}/usage`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      tokenHash: string;
+      accountSs58: string;
+      label: string | null;
+      lifetime: { receipts: number; bytes: number; matra_debited: number };
+      today: { receipts: number; bytes: number };
+      caps: { max_receipts_per_day: number; max_bytes_per_day: number };
+      last_used_at: string | null;
+    };
+    expect(body.tokenHash).toBe(ctx.tokenHash);
+    expect(body.accountSs58).toBe(ctx.ss58);
+    expect(body.label).toBe("usage-label");
+    expect(body.lifetime.receipts).toBe(1);
+    expect(body.lifetime.bytes).toBe(750);
+    expect(body.lifetime.matra_debited).toBe(0);
+    expect(body.today.receipts).toBe(0); // recordUsage doesn't touch quota_daily
+    expect(body.today.bytes).toBe(0);
+    expect(body.caps.max_receipts_per_day).toBe(42);
+    expect(body.caps.max_bytes_per_day).toBe(7777);
+    expect(body.last_used_at).not.toBeNull();
+  });
+
+  test("test_admin_endpoint_404_for_unknown_token_hash", async () => {
+    const bogus = "a".repeat(64);
+    const res = await fetchJson(ctx.app, "GET", `/auth/token/${bogus}/usage`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("test_admin_endpoint_400_for_malformed_hash", async () => {
+    const res = await fetchJson(ctx.app, "GET", `/auth/token/not-hex/usage`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Integration tests — POST manifest + PUT chunk credit the right token
+// --------------------------------------------------------------------------
+
+type MountedUpload = {
+  app: express.Express;
+  quotaDb: Database.Database;
+  tokensDb: Database.Database;
+  keyHash: string;
+  bearerToken: string;
+  tmpStorage: string;
+  prevStoragePath: string;
+};
+
+function setupUploadApp(): MountedUpload {
+  const tmpStorage = mkdtempSync(join(tmpdir(), "blob-gateway-usage-test-"));
+  const prevStoragePath = config.storagePath;
+  config.storagePath = tmpStorage;
+
+  const quotaDb = makeQuotaDb();
+  const tokensDb = new Database(":memory:");
+  tokensDb.pragma("journal_mode = WAL");
+  initApiTokensDb(tokensDb);
+  setApiTokensDb(tokensDb);
+
+  const ss58 = "5UsageUploadTestaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab";
+  const { keyHash } = seedKey(quotaDb, { name: "usage-upload", ss58 });
+
+  const { token: bearerToken } = issueToken(tokensDb, {
+    accountSs58: ss58,
+    label: "usage-upload",
+  });
+
+  const app = express();
+  // Raw body parser for chunk uploads (mirrors prod index.ts ordering).
+  app.put(
+    "/blobs/:contentHash/chunks/:i",
+    express.raw({ type: "*/*", limit: `${config.maxChunkBytes}` }),
+  );
+  app.use(express.json({ limit: "2mb" }));
+  app.use(blobsRouter);
+
+  return { app, quotaDb, tokensDb, keyHash, bearerToken, tmpStorage, prevStoragePath };
+}
+
+function buildSingleChunkManifest(payload = Buffer.from("usage-hello-world")): {
+  manifest: { chunks: Array<{ index: number; sha256: string; size: number }> };
+  chunk: Buffer;
+  contentHash: string;
+} {
+  const sha = createHash("sha256").update(payload).digest("hex");
+  return {
+    manifest: { chunks: [{ index: 0, sha256: sha, size: payload.length }] },
+    chunk: payload,
+    contentHash: sha,
+  };
+}
+
+async function fetchRaw(
+  app: express.Express,
+  method: string,
+  path: string,
+  opts: {
+    headers?: Record<string, string>;
+    jsonBody?: unknown;
+    rawBody?: Buffer;
+  } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { ...(opts.headers || {}) },
+      };
+      if (opts.rawBody !== undefined) {
+        init.body = opts.rawBody;
+        (init.headers as Record<string, string>)["content-type"] =
+          (init.headers as Record<string, string>)["content-type"] ?? "application/octet-stream";
+        (init.headers as Record<string, string>)["content-length"] = String(opts.rawBody.length);
+      } else if (opts.jsonBody !== undefined) {
+        init.body = JSON.stringify(opts.jsonBody);
+        (init.headers as Record<string, string>)["content-type"] = "application/json";
+      }
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let body: unknown;
+          try {
+            body = text ? JSON.parse(text) : null;
+          } catch {
+            body = text;
+          }
+          server.close();
+          resolve({ status: res.status, body });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+describe("upload routes: usage metering", () => {
+  let ctx: MountedUpload;
+  beforeEach(() => {
+    ctx = setupUploadApp();
+  });
+  afterEach(() => {
+    config.storagePath = ctx.prevStoragePath;
+    rmSync(ctx.tmpStorage, { recursive: true, force: true });
+  });
+
+  test("test_manifest_upload_records_receipt_count", async () => {
+    const { manifest, contentHash } = buildSingleChunkManifest();
+    const res = await fetchRaw(ctx.app, "POST", `/blobs/${contentHash}/manifest`, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      jsonBody: manifest,
+    });
+    expect(res.status).toBe(201);
+
+    const snap = getUsage(ctx.keyHash);
+    expect(snap).not.toBeNull();
+    expect(snap!.lifetime_receipts).toBe(1);
+    // No chunk has been uploaded yet, so bytes stay at 0.
+    expect(snap!.lifetime_bytes).toBe(0);
+    expect(snap!.last_used_at).not.toBeNull();
+  });
+
+  test("test_chunk_upload_records_bytes", async () => {
+    const { manifest, chunk, contentHash } = buildSingleChunkManifest();
+    const manifestRes = await fetchRaw(ctx.app, "POST", `/blobs/${contentHash}/manifest`, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      jsonBody: manifest,
+    });
+    expect(manifestRes.status).toBe(201);
+
+    const chunkRes = await fetchRaw(ctx.app, "PUT", `/blobs/${contentHash}/chunks/0`, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+      rawBody: chunk,
+    });
+    expect(chunkRes.status).toBe(200);
+
+    const snap = getUsage(ctx.keyHash);
+    expect(snap).not.toBeNull();
+    // One receipt (manifest), one chunk worth of bytes (chunk body).
+    expect(snap!.lifetime_receipts).toBe(1);
+    expect(snap!.lifetime_bytes).toBe(chunk.length);
+  });
+});

--- a/services/blob-gateway/src/quota.ts
+++ b/services/blob-gateway/src/quota.ts
@@ -98,7 +98,48 @@ export function initQuotaDb(): void {
     db.exec("ALTER TABLE api_keys ADD COLUMN validator_id TEXT DEFAULT NULL");
   }
 
+  // Phase 1 billing: additive usage-metering columns. All defaults are 0 /
+  // NULL so existing rows migrate transparently. The ALTER statements are
+  // each wrapped in their own try/catch via migrateUsageColumns() so repeated
+  // startup is a no-op on already-migrated DBs (SQLite's ADD COLUMN lacks
+  // IF NOT EXISTS on the versions we target; catch "duplicate column name").
+  migrateUsageColumns(db);
+
   loadKeys();
+}
+
+/**
+ * Idempotent migration: add Phase 1 usage-metering columns to `api_keys`.
+ *
+ * Exported so tests can exercise the "run twice against the same DB" case
+ * without spinning up full initQuotaDb(). Safe to call on a freshly-created
+ * table too — each column is checked via PRAGMA first, and we still wrap
+ * the ALTERs in try/catch as belt-and-suspenders for concurrent startup.
+ */
+export function migrateUsageColumns(database: Database.Database): void {
+  const cols = database.prepare("PRAGMA table_info(api_keys)").all() as Array<{
+    name: string;
+  }>;
+  const have = new Set(cols.map((c) => c.name));
+  const adds: Array<[string, string]> = [
+    ["lifetime_receipts", "INTEGER NOT NULL DEFAULT 0"],
+    ["lifetime_bytes", "INTEGER NOT NULL DEFAULT 0"],
+    ["lifetime_matra_debited", "INTEGER NOT NULL DEFAULT 0"],
+    ["last_used_at", "TEXT"],
+  ];
+  for (const [name, type] of adds) {
+    if (have.has(name)) continue;
+    try {
+      database.exec(`ALTER TABLE api_keys ADD COLUMN ${name} ${type}`);
+    } catch (err) {
+      // SQLite surfaces a "duplicate column name" when a parallel startup
+      // beat us to it. Anything else is a real error.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/duplicate column name/i.test(msg)) {
+        throw err;
+      }
+    }
+  }
 }
 
 function hashKey(plaintext: string): string {
@@ -426,6 +467,127 @@ export function recordAccountChunkBytes(address: string, contentHash: string, ch
   });
 
   return txn();
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 billing: lifetime usage metering (per-keyHash, non-enforced).
+// ---------------------------------------------------------------------------
+//
+// Intent: observe what each Bearer/API-key actually consumes so Phase 2 can
+// price against real data. No debits, no enforcement, no 402s. The existing
+// daily-quota enforcement path is untouched.
+//
+// Split metering from enforcement so we can keep these counters at the
+// bottom of a successful upload path without making them part of the check
+// transaction. If a chunk PUT gets admitted and then we crash, the counter
+// lags by one call — acceptable for metering, not for billing (Phase 2 will
+// promote this to a transactional debit).
+
+export interface UsageSnapshot {
+  /** Cumulative receipts (each completed manifest POST counts 1). */
+  lifetime_receipts: number;
+  /** Cumulative bytes (sum of chunk PUT body lengths). */
+  lifetime_bytes: number;
+  /** Reserved for Phase 2; always 0 until billing enforcement ships. */
+  lifetime_matra_debited: number;
+  /** ISO-8601 timestamp of the last recordUsage() call. */
+  last_used_at: string | null;
+  /** Daily cap snapshot so consumers can compute remaining budget. */
+  max_receipts_per_day: number;
+  max_bytes_per_day: number;
+}
+
+/**
+ * Atomically increment the lifetime counters for a keyHash.
+ *
+ * @param keyHash       sha256-hex of the API key (matches api_keys.key_hash).
+ * @param bytes         Byte-count to add to lifetime_bytes (>= 0).
+ * @param receiptCount  0 or 1. Pass 1 exactly once per completed manifest
+ *                      POST; pass 0 on every chunk PUT. Any other value is
+ *                      coerced to {0,1} to keep the counter monotonic.
+ *
+ * No-op (silent) if the keyHash doesn't exist in api_keys. Phase 2 may
+ * flip that to a strict error; for now missing rows indicate an in-flight
+ * registration race and we'd rather keep uploads succeeding.
+ */
+export function recordUsage(
+  keyHash: string,
+  bytes: number,
+  receiptCount: 0 | 1,
+): void {
+  const safeBytes = Number.isFinite(bytes) && bytes > 0 ? Math.floor(bytes) : 0;
+  const safeReceipts = receiptCount === 1 ? 1 : 0;
+  const nowIso = new Date().toISOString();
+  const txn = db.transaction(() => {
+    db.prepare(
+      `UPDATE api_keys
+       SET lifetime_receipts = lifetime_receipts + ?,
+           lifetime_bytes = lifetime_bytes + ?,
+           last_used_at = ?
+       WHERE key_hash = ?`,
+    ).run(safeReceipts, safeBytes, nowIso, keyHash);
+  });
+  txn();
+}
+
+/**
+ * Read the current lifetime counters + daily caps for a keyHash.
+ *
+ * Returns null if the key is not in api_keys — consumers should treat null
+ * as "unknown key" (e.g. HTTP 404 on the admin introspection endpoint).
+ */
+export function getUsage(keyHash: string): UsageSnapshot | null {
+  const row = db
+    .prepare(
+      `SELECT
+         COALESCE(lifetime_receipts, 0) AS lifetime_receipts,
+         COALESCE(lifetime_bytes, 0) AS lifetime_bytes,
+         COALESCE(lifetime_matra_debited, 0) AS lifetime_matra_debited,
+         last_used_at,
+         max_receipts_per_day,
+         max_bytes_per_day
+       FROM api_keys WHERE key_hash = ?`,
+    )
+    .get(keyHash) as
+    | {
+        lifetime_receipts: number;
+        lifetime_bytes: number;
+        lifetime_matra_debited: number;
+        last_used_at: string | null;
+        max_receipts_per_day: number;
+        max_bytes_per_day: number;
+      }
+    | undefined;
+  if (!row) return null;
+  return {
+    lifetime_receipts: row.lifetime_receipts,
+    lifetime_bytes: row.lifetime_bytes,
+    lifetime_matra_debited: row.lifetime_matra_debited,
+    last_used_at: row.last_used_at,
+    max_receipts_per_day: row.max_receipts_per_day,
+    max_bytes_per_day: row.max_bytes_per_day,
+  };
+}
+
+/**
+ * Read today's per-key counters from quota_daily (the existing enforcement
+ * table — we reuse it rather than inventing a parallel aggregation).
+ * Missing row = 0 bytes / 0 receipts today, which matches what the
+ * enforcement path would treat as "fresh day".
+ */
+export function getDailyUsage(
+  keyHash: string,
+  isoDay: string = today(),
+): { receipts_today: number; bytes_today: number } {
+  const row = db
+    .prepare(
+      "SELECT receipts, bytes FROM quota_daily WHERE key_hash = ? AND day = ?",
+    )
+    .get(keyHash, isoDay) as { receipts: number; bytes: number } | undefined;
+  return {
+    receipts_today: row?.receipts ?? 0,
+    bytes_today: row?.bytes ?? 0,
+  };
 }
 
 /**

--- a/services/blob-gateway/src/routes/blobs.ts
+++ b/services/blob-gateway/src/routes/blobs.ts
@@ -9,6 +9,7 @@ import { config } from "../config.js";
 import {
   startUpload, recordChunkBytes, finalizeUpload,
   startAccountUpload, recordAccountChunkBytes, finalizeAccountUpload,
+  recordUsage,
 } from "../quota.js";
 import { resolveAuth } from "../auth.js";
 import { notifySponsoredReceiptSubmitter, isSponsoredTier } from "../sponsored-receipts.js";
@@ -74,6 +75,20 @@ blobsRouter.post("/blobs/:contentHash/manifest", async (req: Request, res: Respo
       if (!quotaCheck.allowed) {
         res.status(429).json({ error: quotaCheck.error, limit: quotaCheck.limit, current: quotaCheck.current });
         return;
+      }
+      // Phase 1 billing: count one receipt per admitted manifest POST.
+      // Bytes are attributed in the chunk leg. Not gated on saveManifest
+      // success — startUpload() already recorded the intent in the inflight
+      // table, and in practice saveManifest() failure is a disk error that
+      // the error handler converts to 500; we accept minor drift in the
+      // pathological crash-between-these-two-calls case.
+      try {
+        recordUsage(auth.keyInfo.keyHash, 0, 1);
+      } catch (err) {
+        console.warn(
+          `[blob-gateway] recordUsage(manifest) failed for ${auth.keyInfo.name}:`,
+          err,
+        );
       }
     } else {
       // Account-based quota — covers sig-only, registered-validator, and
@@ -243,6 +258,21 @@ blobsRouter.put("/blobs/:contentHash/chunks/:i", async (req: Request, res: Respo
     }
 
     await saveChunk(contentHash, chunkIndex, data);
+
+    // Phase 1 billing: credit bytes to the Bearer/API-key holder. Skipped
+    // for sig-only / registered-validator (no key-hash to attribute to —
+    // those use account-based quotas and will get their own meter in
+    // Phase 2 if/when we want to bill sig-only uploaders).
+    if (useKeyedQuotas && auth && auth.keyInfo) {
+      try {
+        recordUsage(auth.keyInfo.keyHash, data.length, 0);
+      } catch (err) {
+        console.warn(
+          `[blob-gateway] recordUsage(chunk) failed for ${auth.keyInfo.name}:`,
+          err,
+        );
+      }
+    }
 
     // Check if upload is now complete and finalize quota
     const statusAfter = await getStatus(contentHash);

--- a/services/blob-gateway/src/routes/tokens.ts
+++ b/services/blob-gateway/src/routes/tokens.ts
@@ -24,6 +24,7 @@ import {
   TOKEN_PREFIX,
 } from "../api-tokens.js";
 import { adminGuard } from "../bearer-auth.js";
+import { resolveKeyByAccount, getUsage, getDailyUsage } from "../quota.js";
 
 const SS58_SHAPE = /^[15][a-zA-Z0-9]{45,47}$/;
 
@@ -57,6 +58,9 @@ export function registerTokenRoutes(app: Express, opts: RegisterTokenRoutesOpts 
       res.status(503).json({ error: "admin token not configured" });
     });
     app.get("/auth/tokens", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    app.get("/auth/token/:hash/usage", (_req, res) => {
       res.status(503).json({ error: "admin token not configured" });
     });
     return;
@@ -141,6 +145,84 @@ export function registerTokenRoutes(app: Express, opts: RegisterTokenRoutesOpts 
         includeRevoked,
       });
       res.status(200).json({ tokens });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  /**
+   * GET /auth/token/:hash/usage  (admin-only)
+   *
+   * Phase 1 billing introspection. Returns the lifetime + today's usage
+   * for the api_keys row bound to this token's SS58. The join is:
+   *
+   *   :hash (tokenHash from api_tokens)
+   *     → api_tokens.account_ss58
+   *     → api_keys.validator_id
+   *     → api_keys.key_hash
+   *     → lifetime_receipts, lifetime_bytes, lifetime_matra_debited
+   *
+   * 404 if either the token hash is unknown or the operator has no
+   * api_keys row yet (e.g. a Bearer was minted but the operator hasn't
+   * been granted a keyed-quota entry — this currently falls back to
+   * account-based quotas, which we'll surface in a future Phase 1.x).
+   */
+  app.get("/auth/token/:hash/usage", guard, (req: Request, res: Response) => {
+    try {
+      const hash = String(req.params.hash || "").toLowerCase();
+      if (!/^[0-9a-f]{64}$/.test(hash)) {
+        res.status(400).json({ error: "invalid token hash (expected 64 hex chars)" });
+        return;
+      }
+
+      const tokensDb = getApiTokensDb();
+      const tokenRow = tokensDb
+        .prepare(
+          `SELECT account_ss58, label FROM api_tokens WHERE token_hash = ?`,
+        )
+        .get(hash) as { account_ss58: string; label: string | null } | undefined;
+      if (!tokenRow) {
+        res.status(404).json({ error: "token not found" });
+        return;
+      }
+
+      const keyInfo = resolveKeyByAccount(tokenRow.account_ss58);
+      if (!keyInfo) {
+        res.status(404).json({ error: "no api_keys row bound to this account" });
+        return;
+      }
+
+      const usage = getUsage(keyInfo.keyHash);
+      if (!usage) {
+        // Defensive: resolveKeyByAccount() just handed us a keyHash so
+        // getUsage() should never miss — but treat missing as 404 rather
+        // than leaking an internal-consistency 500.
+        res.status(404).json({ error: "usage row missing for key_hash" });
+        return;
+      }
+
+      const daily = getDailyUsage(keyInfo.keyHash);
+
+      res.status(200).json({
+        tokenHash: hash,
+        accountSs58: tokenRow.account_ss58,
+        label: tokenRow.label,
+        lifetime: {
+          receipts: usage.lifetime_receipts,
+          bytes: usage.lifetime_bytes,
+          matra_debited: usage.lifetime_matra_debited,
+        },
+        today: {
+          receipts: daily.receipts_today,
+          bytes: daily.bytes_today,
+        },
+        caps: {
+          max_receipts_per_day: usage.max_receipts_per_day,
+          max_bytes_per_day: usage.max_bytes_per_day,
+        },
+        last_used_at: usage.last_used_at,
+      });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       res.status(500).json({ error: message });


### PR DESCRIPTION
## Summary

Phase 1 of the Materios gateway billing plan: usage metering on Bearer tokens, no enforcement. We sponsor all API usage today; before we pick a pricing model (prepaid balance, tier subscription, on-chain settlement) we need to see what operators actually consume. This PR is the metering rail — zero commitment to a pricing shape, full visibility into usage-per-token.

- Adds lifetime counters (`lifetime_receipts`, `lifetime_bytes`, `lifetime_matra_debited`, `last_used_at`) to `api_keys` via an idempotent `ALTER TABLE` migration that runs on every startup.
- Wires the manifest POST and chunk PUT handlers (keyed-quota branch only) to call `recordUsage()` after success. Sig-only and registered-validator tiers are untouched — they use account-based quotas and will get their own meter in a later phase if we want to bill them.
- Exposes `GET /auth/token/:hash/usage` (admin-gated, same `x-admin-token` guard as DELETE/POST/GET on `/auth/*`).

## Files

| File | Delta |
|---|---|
| `services/blob-gateway/src/quota.ts` | `migrateUsageColumns`, `recordUsage`, `getUsage`, `getDailyUsage`, `UsageSnapshot` |
| `services/blob-gateway/src/routes/blobs.ts` | call `recordUsage` on manifest + chunk (keyed branch only) |
| `services/blob-gateway/src/routes/tokens.ts` | `GET /auth/token/:hash/usage` admin route |
| `services/blob-gateway/src/__tests__/usage-tracking.test.ts` | 16 new tests |
| `services/blob-gateway/src/__tests__/upload-auth.test.ts` | migrate in-test quota DB so the new `recordUsage` calls don't warn-log |

## Test plan

- [x] `npx vitest run services/blob-gateway` — 7 files, 69 tests pass (53 existing + 16 new)
- [x] `npx tsc --noEmit` clean on `services/blob-gateway`
- [x] `pnpm -w typecheck` clean (no cross-package regressions)
- [x] AST guardrail: `grep -n '^export' services/blob-gateway/src/quota.ts` shows `recordUsage` (line 513) and `getUsage` (line 539) as top-level named exports
- [x] Idempotent migration tested: `migrateUsageColumns()` runs three times against the same handle, counters still zero

## Example curl — the new endpoint

(a) no admin token, 401:
```bash
$ curl -s -o /dev/null -w "%{http_code}\n" \
    https://materios-gateway/auth/token/aaaa...aaaa/usage
401
```

(b) with admin token, 200 + usage JSON:
```bash
$ curl -s \
    -H "x-admin-token: $DAEMON_NOTIFY_TOKEN" \
    https://materios-gateway/auth/token/aaaa...aaaa/usage
{
  "tokenHash": "aaaa...aaaa",
  "accountSs58": "5Operator...",
  "label": "prod-worker",
  "lifetime": { "receipts": 37, "bytes": 1245678, "matra_debited": 0 },
  "today":    { "receipts": 2,  "bytes": 65536 },
  "caps":     { "max_receipts_per_day": 100, "max_bytes_per_day": 1073741824 },
  "last_used_at": "2026-04-22T12:39:42.381Z"
}
```

## Out of scope (Phase 2+ flags)

- **No 402 / enforcement / rate-limit-by-cost.** `lifetime_matra_debited` is a reserved column that always reads 0 until Phase 2 flips on billing.
- **Sig-only and registered-validator tiers are not metered per key.** They have no token to attribute to; they use account-based quotas (`account_quotas_daily`) and will be metered separately if and when we want to bill them.
- **No new DB file.** We extend the existing `quota.db` that `initQuotaDb()` already opens. `api_tokens` lives in a separate `operators.db`; the two tables are joined via SS58 (`api_tokens.account_ss58 ↔ api_keys.validator_id`).
- **Existing rows migrate via DEFAULT 0.** No synthetic back-fill; counters fill in over time.

## Notes for Phase 2/3 agents

- `lifetime_matra_debited` is wired to the JSON response shape but always reads 0; Phase 2 should change `recordUsage` to also pass a `matraDebited` delta.
- The `:hash` path param in the new endpoint is a **tokenHash** (sha256 of the plaintext Bearer), NOT an `api_keys.key_hash`. The route resolves the tokenHash to account_ss58 to api_keys row via `resolveKeyByAccount()`.
- If an operator has a Bearer but no `api_keys` row (unregistered account), the endpoint returns 404. Phase 1.x may want to also surface per-account usage for that case.
- `recordUsage()` is best-effort — a missing `api_keys` row is a silent no-op so we never 500 an upload on a registration race. Phase 2 billing should promote this to a strict transactional debit.

Do NOT merge — please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)