### PR TITLE
fix(anchors-materios): canonical chunk-Merkle base_root_sha256 (cert-daemon parity)

### DIFF
--- a/examples/materios-e2e/e2e-flow.ts
+++ b/examples/materios-e2e/e2e-flow.ts
@@ -37,6 +37,7 @@ import {
   waitForCertification,
   waitForAnchor,
   verifyReceipt,
+  computeBaseRoot,
 } from "@fluxpointstudios/orynq-sdk-anchors-materios";
 
 import { createHash } from "crypto";
@@ -149,31 +150,14 @@ async function main() {
   hr();
 
   // =========================================================================
-  // Step 2: Submit receipt to chain
+  // Step 2: Build the blob and submit receipt to chain
   // =========================================================================
-  log("STEP 2", "Submitting receipt to Materios chain...");
+  log("STEP 2", "Building blob + submitting receipt to Materios chain...");
 
-  const contentHash =
-    "0x" +
-    createHash("sha256")
-      .update(Buffer.from(bundle.rootHash.replace(/^0x/, ""), "hex"))
-      .digest("hex");
-
-  const result = await submitReceipt(provider, {
-    contentHash,
-    rootHash: "0x" + bundle.rootHash.replace(/^0x/, ""),
-    manifestHash: "0x" + bundle.manifestHash.replace(/^0x/, ""),
-  });
-
-  log("STEP 2", `Receipt ID:  ${result.receiptId}`);
-  log("STEP 2", `Block:       ${result.blockHash} (#${result.blockNumber})`);
-  hr();
-
-  // =========================================================================
-  // Step 3: Provision blob data for cert daemon
-  // =========================================================================
-  log("STEP 3", "Provisioning blob data for cert daemon...");
-
+  // The bytes the cert daemon will pull back from the gateway. Build them
+  // FIRST so the chain hashes can be derived from these exact bytes — the
+  // trace-bundle's own rootHash is for trace-bundle audit, not for the
+  // receipt's `base_root_sha256`.
   const content = Buffer.from(
     JSON.stringify({
       rootHash: bundle.rootHash,
@@ -182,6 +166,29 @@ async function main() {
       timestamp: new Date().toISOString(),
     }),
   );
+
+  const contentHash =
+    "0x" + createHash("sha256").update(content).digest("hex");
+
+  // Canonical chunk-Merkle root over the same chunks the cert daemon will
+  // re-hash. Byte-for-byte identical to `daemon/merkle.py`.
+  const baseRoot = computeBaseRoot(content);
+
+  const result = await submitReceipt(provider, {
+    contentHash,
+    rootHash: baseRoot,
+    manifestHash: "0x" + bundle.manifestHash.replace(/^0x/, ""),
+  });
+
+  log("STEP 2", `Receipt ID:  ${result.receiptId}`);
+  log("STEP 2", `Block:       ${result.blockHash} (#${result.blockNumber})`);
+  log("STEP 2", `base_root:   ${baseRoot}`);
+  hr();
+
+  // =========================================================================
+  // Step 3: Provision blob data for cert daemon
+  // =========================================================================
+  log("STEP 3", "Provisioning blob data for cert daemon...");
 
   const { manifest, chunks } = prepareBlobData(result.receiptId, content);
   const receiptDir = join(BLOB_DIR, result.receiptId);

--- a/examples/materios-loadtest/loadtest.ts
+++ b/examples/materios-loadtest/loadtest.ts
@@ -37,6 +37,7 @@ import {
   isCertified,
   waitForMotra,
   queryMotraBalance,
+  computeBaseRoot,
 } from "../../packages/anchors-materios/dist/index.js";
 
 import type { BlobGatewayConfig } from "../../packages/anchors-materios/dist/index.js";
@@ -110,12 +111,34 @@ function log(tag: string, msg: string) {
   console.log(`[${ts}] ${tag.padEnd(8)} ${msg}`);
 }
 
-function generateHashes() {
-  const content = Buffer.from(`loadtest-${Date.now()}-${Math.random()}`);
-  const contentHash = "0x" + createHash("sha256").update(content).digest("hex");
-  const rootHash = "0x" + createHash("sha256").update(Buffer.from("root-" + contentHash)).digest("hex");
-  const manifestHash = "0x" + createHash("sha256").update(Buffer.from("manifest-" + contentHash)).digest("hex");
-  return { contentHash, rootHash, manifestHash };
+/**
+ * Build a self-consistent receipt envelope: generates the content bytes that
+ * will be uploaded to the gateway AND derives the on-chain hashes from those
+ * exact bytes. `rootHash` is the canonical chunk-Merkle root the cert daemon
+ * will recompute when it pulls the chunks back — this is what makes the
+ * receipt pass strict ROOT_VERIFIED.
+ */
+function generatePayload(): {
+  content: Buffer;
+  contentHash: string;
+  rootHash: string;
+  manifestHash: string;
+} {
+  // 1-4 KB of pseudo-random content per receipt, deterministic w.r.t. time.
+  const size = 1024 + Math.floor(Math.random() * 3072);
+  const content = randomBytes(size);
+  const contentHash =
+    "0x" + createHash("sha256").update(content).digest("hex");
+  const rootHash = computeBaseRoot(content);
+  // Manifest hash placeholder — cert daemon doesn't verify this; only the
+  // sponsored-receipt flow + uploadBlobs path compute the real storage
+  // locator hash.
+  const manifestHash =
+    "0x" +
+    createHash("sha256")
+      .update(Buffer.from("manifest-" + contentHash))
+      .digest("hex");
+  return { content, contentHash, rootHash, manifestHash };
 }
 
 async function queryCongestion(provider: MateriosProvider): Promise<CongestionSample> {
@@ -150,19 +173,20 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function writeBlobData(receiptId: string): Promise<void> {
+async function writeBlobData(
+  receiptId: string,
+  contentHash: string,
+  content: Buffer,
+): Promise<void> {
   if (!WITH_BLOBS && !BLOB_GATEWAY) return;
-
-  // Generate 1-4KB of random content
-  const size = 1024 + Math.floor(Math.random() * 3072);
-  const content = randomBytes(size);
 
   const { manifest, chunks } = prepareBlobData(receiptId, content);
 
-  // If gateway is configured, upload via HTTP instead of writing to disk
+  // If gateway is configured, upload via HTTP instead of writing to disk.
+  // The gateway keys blobs by contentHash, NOT receiptId.
   if (BLOB_GATEWAY) {
     const result = await uploadBlobs(
-      receiptId.replace(/^0x/, ""),
+      contentHash.replace(/^0x/, ""),
       manifest,
       chunks,
       BLOB_GATEWAY,
@@ -212,10 +236,14 @@ async function runSequential(mode: "baseline" | "burst") {
 
   try {
     for (let i = 0; i < COUNT; i++) {
-      const hashes = generateHashes();
+      const payload = generatePayload();
 
       try {
-        const result = await submitReceipt(provider, hashes);
+        const result = await submitReceipt(provider, {
+          contentHash: payload.contentHash,
+          rootHash: payload.rootHash,
+          manifestHash: payload.manifestHash,
+        });
         const sample = await queryCongestion(provider);
         congestion.push(sample);
 
@@ -228,7 +256,11 @@ async function runSequential(mode: "baseline" | "burst") {
         };
         receipts.push(entry);
 
-        await writeBlobData(result.receiptId);
+        await writeBlobData(
+          result.receiptId,
+          payload.contentHash,
+          payload.content,
+        );
 
         log("SUBMIT", `#${i + 1} receipt=${result.receiptId.slice(0, 18)}... block=#${result.blockNumber} congestion=${sample.congestionRate}`);
       } catch (err: unknown) {
@@ -277,10 +309,18 @@ async function runParallel() {
         const globalIdx = batch * SIGNERS.length + idx;
         if (globalIdx >= COUNT) return;
 
-        const hashes = generateHashes();
+        const payload = generatePayload();
         try {
-          const result = await submitReceipt(provider, hashes);
-          await writeBlobData(result.receiptId);
+          const result = await submitReceipt(provider, {
+            contentHash: payload.contentHash,
+            rootHash: payload.rootHash,
+            manifestHash: payload.manifestHash,
+          });
+          await writeBlobData(
+            result.receiptId,
+            payload.contentHash,
+            payload.content,
+          );
           return {
             receiptId: result.receiptId,
             block: result.blockNumber,

--- a/packages/anchors-materios/package.json
+++ b/packages/anchors-materios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxpointstudios/orynq-sdk-anchors-materios",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Materios blockchain anchor support for Orynq SDK - submits and verifies anchors via Substrate extrinsics",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/anchors-materios/src/__tests__/base-root.test.ts
+++ b/packages/anchors-materios/src/__tests__/base-root.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression tests pinning the canonical `base_root_sha256` pre-image.
+ *
+ * These tests guarantee that the SDK computes `base_root_sha256` byte-for-byte
+ * identical to cert-daemon's `daemon/merkle.py` (the source of truth).
+ *
+ * Cross-layer verified: the pinned hex values in this file were computed by
+ * running `daemon/merkle.py` against the same fixtures from a Python REPL.
+ *
+ * If these tests fail, the cert daemon's strict ROOT_VERIFIED gate will reject
+ * receipts produced by this SDK. Do NOT change the pinned values without also
+ * updating cert-daemon — the algorithm is consensus-critical.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createHash } from "crypto";
+import {
+  computeBaseRoot,
+  prepareBlobData,
+} from "../receipt.js";
+import { merkleRoot } from "../merkle.js";
+
+const CHUNK_SIZE = 256 * 1024;
+
+function sha256Hex(b: Buffer): string {
+  return createHash("sha256").update(b).digest("hex");
+}
+
+describe("computeBaseRoot — canonical chunk-Merkle (cert-daemon parity)", () => {
+  it("single-chunk: blob 'hello world' -> base_root == sha256(content)", () => {
+    // Single-chunk case: per cert-daemon merkle_root, a single leaf is returned
+    // verbatim with no further hashing. So base_root must equal the leaf hash,
+    // which equals sha256(chunk_bytes), which equals sha256(content) when the
+    // content fits in one chunk.
+    const content = Buffer.from("hello world");
+    const root = computeBaseRoot(content);
+
+    // Pinned canonical value (computed by Python cert-daemon merkle.py).
+    expect(root).toBe(
+      "0xb94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+    );
+
+    // Cross-check: equals sha256(content) for single-leaf case.
+    expect(root).toBe("0x" + sha256Hex(content));
+  });
+
+  it("three-chunk: deterministic byte pattern -> pinned hex", () => {
+    // Build content that produces exactly 3 distinct chunks at the default
+    // CHUNK_SIZE (256 KiB). Each chunk is filled with a unique byte value so
+    // the three leaf hashes are distinct.
+    const buf = Buffer.alloc(3 * CHUNK_SIZE);
+    for (let i = 0; i < CHUNK_SIZE; i++) buf[i] = 0;
+    for (let i = CHUNK_SIZE; i < 2 * CHUNK_SIZE; i++) buf[i] = 1;
+    for (let i = 2 * CHUNK_SIZE; i < 3 * CHUNK_SIZE; i++) buf[i] = 2;
+
+    const root = computeBaseRoot(buf);
+
+    // Pinned canonical value (computed by Python cert-daemon merkle.py).
+    expect(root).toBe(
+      "0xcff7222bfb3b15ac46d49664992dea6d9bd55ec3da34f0bf12fe255e49c354f6",
+    );
+
+    // Cross-check: walk the algorithm by hand against canonical leaves.
+    const leaf0 = sha256Hex(Buffer.alloc(CHUNK_SIZE, 0));
+    const leaf1 = sha256Hex(Buffer.alloc(CHUNK_SIZE, 1));
+    const leaf2 = sha256Hex(Buffer.alloc(CHUNK_SIZE, 2));
+    expect(leaf0).toBe(
+      "8a39d2abd3999ab73c34db2476849cddf303ce389b35826850f9a700589b4a90",
+    );
+    expect(leaf1).toBe(
+      "f317dd9d6ba01c465d82e4c4d55d01d270dda69db4a01a64c587a5593ac6084d",
+    );
+    expect(leaf2).toBe(
+      "b1026d9249014c863c3a8daf11dec61bd4d4abcfdc7f1a62181cf743d4b6a12e",
+    );
+
+    // And the SDK-level merkleRoot helper should produce the same value when
+    // given those leaves as hex strings.
+    expect(merkleRoot([leaf0, leaf1, leaf2])).toBe(root);
+  });
+
+  it("matches prepareBlobData chunk hashes", () => {
+    // Using the same 3-chunk fixture, compute via prepareBlobData (the path
+    // that uploadBlobs actually uses) and confirm the leaves match what
+    // merkleRoot should hash.
+    const buf = Buffer.alloc(3 * CHUNK_SIZE);
+    for (let i = 0; i < CHUNK_SIZE; i++) buf[i] = 0;
+    for (let i = CHUNK_SIZE; i < 2 * CHUNK_SIZE; i++) buf[i] = 1;
+    for (let i = 2 * CHUNK_SIZE; i < 3 * CHUNK_SIZE; i++) buf[i] = 2;
+
+    const dummyReceiptId = "0x" + "00".repeat(32);
+    const { manifest, chunks } = prepareBlobData(dummyReceiptId, buf);
+
+    expect(manifest.chunk_count).toBe(3);
+    expect(chunks).toHaveLength(3);
+
+    // The chunk-store hashes used by the gateway/daemon are sha256(chunk_bytes)
+    // — the same leaves the Merkle tree hashes over.
+    const leavesFromManifest = manifest.chunks.map((c) => c.sha256);
+    expect(leavesFromManifest).toEqual([
+      "8a39d2abd3999ab73c34db2476849cddf303ce389b35826850f9a700589b4a90",
+      "f317dd9d6ba01c465d82e4c4d55d01d270dda69db4a01a64c587a5593ac6084d",
+      "b1026d9249014c863c3a8daf11dec61bd4d4abcfdc7f1a62181cf743d4b6a12e",
+    ]);
+
+    expect(merkleRoot(leavesFromManifest)).toBe(
+      "0xcff7222bfb3b15ac46d49664992dea6d9bd55ec3da34f0bf12fe255e49c354f6",
+    );
+
+    // computeBaseRoot must produce the same value end-to-end.
+    expect(computeBaseRoot(buf)).toBe(
+      "0xcff7222bfb3b15ac46d49664992dea6d9bd55ec3da34f0bf12fe255e49c354f6",
+    );
+  });
+
+  it("respects custom chunkSize", () => {
+    // A blob smaller than CHUNK_SIZE always single-chunks; with a smaller
+    // chunkSize it must split into multiple chunks and produce the
+    // multi-leaf root, not the single-leaf shortcut.
+    const content = Buffer.from("hello world"); // 11 bytes
+    const singleRoot = computeBaseRoot(content);
+    const splitRoot = computeBaseRoot(content, 4); // 3 chunks: "hell", "o wo", "rld"
+
+    expect(singleRoot).not.toBe(splitRoot);
+    // Single-leaf path returns sha256(content).
+    expect(singleRoot).toBe("0x" + sha256Hex(content));
+    // Split path: leaves = [sha256("hell"), sha256("o wo"), sha256("rld")],
+    // merkle root with duplicate-last on odd layer.
+    const l0 = sha256Hex(Buffer.from("hell"));
+    const l1 = sha256Hex(Buffer.from("o wo"));
+    const l2 = sha256Hex(Buffer.from("rld"));
+    expect(splitRoot).toBe(merkleRoot([l0, l1, l2]));
+  });
+
+  it("empty buffer is treated as a single empty chunk (matches prepareBlobData)", () => {
+    // prepareBlobData's loop `for (i; i*chunkSize < content.length)` produces
+    // ZERO chunks for an empty buffer. To stay consistent, computeBaseRoot of
+    // empty content uses the cert-daemon empty-list rule: 32 zero bytes.
+    const root = computeBaseRoot(Buffer.alloc(0));
+    expect(root).toBe("0x" + "00".repeat(32));
+  });
+});

--- a/packages/anchors-materios/src/index.ts
+++ b/packages/anchors-materios/src/index.ts
@@ -44,7 +44,17 @@ export { submitAnchor } from "./submitter.js";
 export { getAnchor, anchorExists } from "./verifier.js";
 
 // Receipt submission and querying
-export { submitReceipt, getReceipt, isCertified, prepareBlobData, queryMotraBalance, uploadBlobs, submitCertifiedReceipt } from "./receipt.js";
+export {
+  submitReceipt,
+  getReceipt,
+  isCertified,
+  prepareBlobData,
+  queryMotraBalance,
+  uploadBlobs,
+  submitCertifiedReceipt,
+  computeBaseRoot,
+  DEFAULT_CHUNK_SIZE,
+} from "./receipt.js";
 
 // Polling / waiting
 export { waitForCertification, waitForAnchor, computeCheckpointLeaf, waitForMotra, getCertificationStatus } from "./polling.js";

--- a/packages/anchors-materios/src/receipt.ts
+++ b/packages/anchors-materios/src/receipt.ts
@@ -20,7 +20,62 @@ import type {
 } from "./types.js";
 import { waitForCertification, waitForAnchor } from "./polling.js";
 import { stripPrefix, ensureHex, isZeroHash } from "./hex.js";
+import { merkleRoot } from "./merkle.js";
 import { u8aToHex, stringToU8a } from "@polkadot/util";
+
+/**
+ * Default blob chunk size used by `prepareBlobData` and `computeBaseRoot`.
+ *
+ * Must match the cert daemon's chunk-store layout. Changing this is a
+ * consensus-breaking change for the `base_root_sha256` field on receipts.
+ */
+export const DEFAULT_CHUNK_SIZE = 256 * 1024;
+
+/**
+ * Compute the canonical `base_root_sha256` for a blob.
+ *
+ * This produces a value byte-for-byte identical to cert-daemon's
+ * `daemon/merkle.py` so the strict ROOT_VERIFIED gate accepts receipts
+ * submitted via this SDK.
+ *
+ * Algorithm (mirroring `daemon/merkle.py`):
+ *   1. Split `content` into `chunkSize`-byte chunks (last chunk may be short).
+ *   2. Hash each chunk: `leaf_i = sha256(chunk_i_bytes)` over RAW bytes.
+ *   3. Build a binary Merkle tree:
+ *        - 0 leaves   -> 32 zero bytes
+ *        - 1 leaf     -> that leaf, returned as-is (NO extra hashing)
+ *        - N > 1      -> pair `sha256(left || right)`; duplicate last on
+ *                        odd levels; recurse upward.
+ *
+ * @param content   The full blob bytes that will be uploaded to the gateway.
+ * @param chunkSize Optional chunk size; defaults to {@link DEFAULT_CHUNK_SIZE}.
+ *                  Must match the chunk size used at upload time.
+ * @returns         Hex-encoded 32-byte root, prefixed with `0x`.
+ */
+export function computeBaseRoot(
+  content: Buffer,
+  chunkSize: number = DEFAULT_CHUNK_SIZE,
+): string {
+  if (content.length === 0) {
+    // Matches Python `if not leaf_hashes: return b'\x00' * 32`. The chunking
+    // loop in `prepareBlobData` produces zero chunks for an empty blob, which
+    // would otherwise produce an undefined root.
+    return ensureHex("0".repeat(64));
+  }
+
+  const leafHashes: string[] = [];
+  for (let i = 0; i * chunkSize < content.length; i++) {
+    const start = i * chunkSize;
+    const chunk = content.subarray(start, start + chunkSize);
+    leafHashes.push(createHash("sha256").update(chunk).digest("hex"));
+  }
+
+  // `merkleRoot` is the canonical implementation:
+  //   - single leaf returned as-is (no extra hashing)
+  //   - raw-byte concat for internal nodes
+  //   - duplicate-last on odd levels
+  return merkleRoot(leafHashes);
+}
 
 /**
  * Submit a receipt to the Materios chain.
@@ -28,12 +83,20 @@ import { u8aToHex, stringToU8a } from "@polkadot/util";
  * The receipt is stored on-chain and the cert daemon committee will
  * attempt to locate and verify the blob data, then attest availability.
  *
+ * The `input.rootHash` field is sent verbatim as `base_root_sha256` on the
+ * extrinsic. Callers MUST set it to the canonical chunk-Merkle root computed
+ * by {@link computeBaseRoot} (or use {@link submitCertifiedReceipt} which
+ * does it automatically). Sending any other value will fail the cert
+ * daemon's strict ROOT_VERIFIED gate.
+ *
  * @example
  * ```ts
+ * const baseRoot = computeBaseRoot(content);
+ * const contentHash = "0x" + createHash("sha256").update(content).digest("hex");
  * const result = await submitReceipt(provider, {
- *   contentHash: bundle.rootHash,
- *   rootHash: bundle.rootHash,
- *   manifestHash: bundle.manifestHash,
+ *   contentHash,
+ *   rootHash: baseRoot,
+ *   manifestHash,
  * });
  * console.log("Receipt ID:", result.receiptId);
  * ```
@@ -435,9 +498,18 @@ export async function submitCertifiedReceipt(
   }
 
   // 3. Submit receipt on-chain
+  //
+  // CRITICAL: `base_root_sha256` MUST be the canonical chunk-Merkle root over
+  // the same chunks the gateway just stored. Anything else (the old
+  // `input.rootHash || contentHashHex` fallback, a trace-bundle root, an
+  // ad-hoc sha256 of the content hash, etc.) will fail the cert-daemon's
+  // strict ROOT_VERIFIED gate. We compute it here from `manifest.chunks` so
+  // it is *always* in sync with the bytes the gateway received in step 2.
+  const baseRoot = merkleRoot(manifest.chunks.map((c) => c.sha256));
+
   const receiptInput: ReceiptInput = {
     contentHash: effectiveContentHash,
-    rootHash: input.rootHash || contentHashHex,
+    rootHash: baseRoot,
     manifestHash: uploadResult.storageLocatorHash || input.manifestHash || contentHashHex,
   };
   const submitResult = await submitReceipt(provider, receiptInput);

--- a/packages/anchors-materios/src/types.ts
+++ b/packages/anchors-materios/src/types.ts
@@ -64,7 +64,21 @@ export interface AnchorRecord {
 export interface ReceiptInput {
   /** SHA-256 content hash of the data being anchored */
   contentHash: string;
-  /** Base root hash (SHA-256 Merkle root of the data tree) */
+  /**
+   * `base_root_sha256` — the SHA-256 chunk-Merkle root over the same chunks
+   * uploaded to the blob gateway.
+   *
+   * MUST be computed exactly as cert-daemon's `daemon/merkle.py` does:
+   *   - leaf_i = sha256(chunk_i_bytes) over RAW bytes
+   *   - 1 leaf -> returned as-is (no extra hashing)
+   *   - N > 1  -> sha256(left || right) raw-byte concat, duplicate-last on odd levels
+   *
+   * The canonical helper is {@link computeBaseRoot} (in `receipt.ts`); use
+   * {@link submitCertifiedReceipt} to have the SDK derive this for you from
+   * the upload chunks. Ad-hoc values (sha256(content), trace-bundle root,
+   * sha256("root-" + contentHash), etc.) will fail the cert-daemon's strict
+   * ROOT_VERIFIED gate.
+   */
   rootHash: string;
   /** Manifest hash describing the data layout */
   manifestHash: string;

--- a/packages/orynq-mcp/src/tools/anchor-materios-submit.ts
+++ b/packages/orynq-mcp/src/tools/anchor-materios-submit.ts
@@ -99,9 +99,16 @@ export function registerAnchorMateriosSubmit(
           status: "dry-run",
           wouldSubmit: {
             rpcUrl: config.materiosRpcUrl,
-            contentHash: bundle.rootHash,
-            rootHash: bundle.rootHash,
-            manifestHash: bundle.manifestHash,
+            // The SDK derives `contentHash` from the JSON content the
+            // operator persists to the blob gateway, NOT bundle.rootHash.
+            // The real `base_root_sha256` is the chunk-Merkle over those
+            // same chunks (computed inside submitCertifiedReceipt), not
+            // the trace-bundle's own root. Both are reported as
+            // "<derived from blob content>" here so the dry-run isn't
+            // misleading.
+            contentHash: "<derived from blob content>",
+            rootHash: "<derived: chunk-Merkle of upload chunks>",
+            manifestHash: "<derived: SHA-256 of manifest JSON>",
             blobGatewayUrl,
             waitForL1Anchor,
             timeoutSeconds,
@@ -152,14 +159,22 @@ export function registerAnchorMateriosSubmit(
             blobGateway.signerKeypair = signerKeypair;
           }
 
+          // `submitCertifiedReceipt` derives the on-chain hashes from the
+          // `content` Buffer:
+          //   - `contentHash`        = sha256(content)
+          //   - `base_root_sha256`   = chunk-Merkle over upload chunks
+          //                            (computed internally; `input.rootHash`
+          //                            is IGNORED — kept here for type-shape
+          //                            only)
+          //   - `manifestHash`       = sha256(manifest JSON), filled by upload
+          // The trace-bundle's own rootHash/manifestHash are for trace-bundle
+          // audit, not for the receipt's on-chain shape.
           const result = await submitCertifiedReceipt(
             provider,
             {
-              contentHash: bundle.rootHash,
-              rootHash: bundle.rootHash,
-              // `manifestHash` is optional on TraceBundle; fall back to rootHash
-              // so we always submit a non-empty string to the pallet.
-              manifestHash: bundle.manifestHash ?? bundle.rootHash,
+              contentHash: "",
+              rootHash: "",
+              manifestHash: "",
             },
             content,
             {


### PR DESCRIPTION
## Summary

- Makes every SDK receipt submission compute `base_root_sha256` byte-for-byte identical to cert-daemon's `daemon/merkle.py` (the consensus source of truth). Adds `computeBaseRoot(content, chunkSize?)` helper, fixes `submitCertifiedReceipt` to derive the root from upload chunks, and removes the `input.rootHash || contentHashHex` fallback that produced wrong roots for any blob > 1 chunk. Examples + MCP tool updated to stop passing trace-bundle / bespoke `sha256("root-" + contentHash)` values.
- Pins canonical pre-image with regression tests: single-chunk `"hello world"` -> `b94d27b9...e2efcde9`; three-chunk @ 256 KiB deterministic pattern -> `cff7222b...49c354f6`. Cross-layer verified against `daemon/merkle.py` — byte-identical.
- Bumps `@fluxpointstudios/orynq-sdk-anchors-materios` 0.3.0 -> 0.3.1. After this lands and callers propagate, the strict ROOT_VERIFIED gate (PR #8 in operator-kit, task #220) can be re-deployed.

## Behavioral note

`ReceiptInput.rootHash` is still accepted by `submitReceipt` for back-compat. Callers who were already computing it correctly are unaffected. Callers using `submitCertifiedReceipt` get the correct value silently — `input.rootHash` is now ignored. JSDoc on `ReceiptInput.rootHash` updated to flag this and point at `computeBaseRoot()`.

## Companion patch (separate PR)

`tools/receipt-builder/src/hash/merkle.ts` lives in the `materios` repo (not orynq-sdk). The hex-vs-raw fix + matching 3-chunk regression vector are queued there as a separate change.

## Test plan

- [x] `pnpm vitest run packages/anchors-materios` -> 30/30 pass (5 new + 25 existing)
- [x] Cross-layer parity: SDK `computeBaseRoot` output matches Python `daemon/merkle.py` on both pinned fixtures
- [x] `pnpm typecheck` clean for `anchors-materios` and `orynq-mcp`
- [x] `pnpm build` clean for `anchors-materios`
- [x] Full repo `pnpm vitest run` -> 1773/1818 pass; the 1 unrelated failure is an EADDRINUSE port collision in `client-auto-pay.integration.test.ts` (pre-existing, not touched here)
- [ ] Human review before merge — task brief explicitly says don't auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)