### PR TITLE
fix(anchors-materios): use Authorization: Bearer for matra_ tokens (v6 gateway)

### DIFF
--- a/packages/anchors-materios/src/__tests__/auth-headers.test.ts
+++ b/packages/anchors-materios/src/__tests__/auth-headers.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildAuthHeaders } from "../receipt.js";
+
+const FAKE_HASH = "0x" + "ab".repeat(32);
+
+describe("buildAuthHeaders", () => {
+  it("uses Authorization: Bearer for matra_-prefixed tokens (v6 gateway path)", () => {
+    const headers = buildAuthHeaders(
+      { baseUrl: "https://example/gateway", apiKey: "matra_abc123" },
+      FAKE_HASH,
+    );
+    expect(headers).toEqual({ Authorization: "Bearer matra_abc123" });
+  });
+
+  it("uses x-api-key for legacy (non-matra_) keys", () => {
+    const headers = buildAuthHeaders(
+      { baseUrl: "https://example/gateway", apiKey: "legacy-key-without-prefix" },
+      FAKE_HASH,
+    );
+    expect(headers).toEqual({ "x-api-key": "legacy-key-without-prefix" });
+  });
+
+  it("returns sr25519 signature headers when no apiKey is provided", () => {
+    const fakeSig = new Uint8Array(64).fill(0xab);
+    const headers = buildAuthHeaders(
+      {
+        baseUrl: "https://example/gateway",
+        signerKeypair: {
+          address: "5FXCG7by7UuQZpbHMi1kRtQfgDSpA83D2GH82kaWHuMMFu2m",
+          sign: () => fakeSig,
+        },
+      },
+      FAKE_HASH,
+    );
+    expect(headers["x-uploader-address"]).toBe(
+      "5FXCG7by7UuQZpbHMi1kRtQfgDSpA83D2GH82kaWHuMMFu2m",
+    );
+    expect(headers["x-upload-sig"]).toBe("0x" + "ab".repeat(64));
+    expect(headers["x-upload-ts"]).toMatch(/^\d+$/);
+    expect(headers).not.toHaveProperty("Authorization");
+    expect(headers).not.toHaveProperty("x-api-key");
+  });
+
+  it("apiKey wins when both apiKey and signerKeypair are set", () => {
+    const headers = buildAuthHeaders(
+      {
+        baseUrl: "https://example/gateway",
+        apiKey: "matra_token_xyz",
+        signerKeypair: {
+          address: "5FXCG7by7UuQZpbHMi1kRtQfgDSpA83D2GH82kaWHuMMFu2m",
+          sign: () => new Uint8Array(64),
+        },
+      },
+      FAKE_HASH,
+    );
+    expect(headers).toEqual({ Authorization: "Bearer matra_token_xyz" });
+  });
+
+  it("returns empty headers when neither apiKey nor signerKeypair is provided", () => {
+    const headers = buildAuthHeaders(
+      { baseUrl: "https://example/gateway" },
+      FAKE_HASH,
+    );
+    expect(headers).toEqual({});
+  });
+});

--- a/packages/anchors-materios/src/polling.ts
+++ b/packages/anchors-materios/src/polling.ts
@@ -243,7 +243,13 @@ async function scanForAnchorWithGateway(
           // Query batch metadata from gateway for multi-leaf match
           try {
             const headers: Record<string, string> = {};
-            if (gateway.apiKey) headers["x-api-key"] = gateway.apiKey;
+            if (gateway.apiKey) {
+              if (gateway.apiKey.startsWith("matra_")) {
+                headers["Authorization"] = `Bearer ${gateway.apiKey}`;
+              } else {
+                headers["x-api-key"] = gateway.apiKey;
+              }
+            }
             const res = await fetch(
               `${gateway.baseUrl}/batches/${stripPrefix(anchorId)}`,
               { headers },

--- a/packages/anchors-materios/src/receipt.ts
+++ b/packages/anchors-materios/src/receipt.ts
@@ -316,9 +316,18 @@ export async function queryMotraBalance(
 
 /**
  * Build auth headers for gateway requests (API key or sr25519 signature).
+ *
+ * Tokens prefixed with `matra_` are routed by the gateway's resolveAuth path
+ * which only accepts `Authorization: Bearer ...`. Legacy keys (no prefix) keep
+ * the `x-api-key` header for back-compat with pre-v6 deployments.
+ *
+ * Exported for unit testing; not part of the public package API.
  */
-function buildAuthHeaders(gateway: BlobGatewayConfig, contentHash: string): Record<string, string> {
+export function buildAuthHeaders(gateway: BlobGatewayConfig, contentHash: string): Record<string, string> {
   if (gateway.apiKey) {
+    if (gateway.apiKey.startsWith("matra_")) {
+      return { "Authorization": `Bearer ${gateway.apiKey}` };
+    }
     return { "x-api-key": gateway.apiKey };
   }
   if (gateway.signerKeypair) {

--- a/packages/anchors-materios/src/verify.ts
+++ b/packages/anchors-materios/src/verify.ts
@@ -272,7 +272,13 @@ async function findAnchorViaBatchMetadata(
           // Query batch metadata from gateway
           try {
             const headers: Record<string, string> = {};
-            if (gateway.apiKey) headers["x-api-key"] = gateway.apiKey;
+            if (gateway.apiKey) {
+              if (gateway.apiKey.startsWith("matra_")) {
+                headers["Authorization"] = `Bearer ${gateway.apiKey}`;
+              } else {
+                headers["x-api-key"] = gateway.apiKey;
+              }
+            }
             const res = await fetch(
               `${gateway.baseUrl}/batches/${stripPrefix(anchorId)}`,
               { headers },


### PR DESCRIPTION
## Summary

The v6 gateway reset retired the permissive legacy auth path that accepted `x-api-key` for `matra_`-prefixed tokens. The gateway's current `resolveAuth` only validates `matra_` tokens via `Authorization: Bearer ...`. The SDK was sending `x-api-key` unconditionally, so sponsored-tier tokens silently fell through to sig-only auth (3 concurrent / 10-daily caps), which surfaces to clients as persistent `429 Concurrent upload limit exceeded` errors that look like gateway congestion rather than auth misrouting.

## Reproduced end-to-end

| With | Result |
|---|---|
| `x-api-key: matra_…` (pre-fix) | `401 Invalid or disabled API key` |
| `Authorization: Bearer matra_…` (post-fix) | `201` → receipt submitted → cert-daemon attests |

Verified by anchoring 18 backlog manifests across two workspaces (Penny + Agent T) — all landed on chain at Materios blocks 23097–23418. Most certified on the first poll; a few hit the SDK's 600s certification timeout but were already on chain (`orinq_getReceiptsByContent` confirmed) and reconciled post-hoc.

## Changes

Touches all three SDK call sites that author auth headers:

- `src/receipt.ts` — manifest + chunk uploads. Existing `buildAuthHeaders` helper extended; `export`ed for direct unit testing.
- `src/polling.ts` — anchor batch metadata fetch in `waitForAnchor`.
- `src/verify.ts` — anchor batch metadata fetch in `verifyReceipt`.

The dispatch is a one-line prefix check:

```ts
if (gateway.apiKey.startsWith("matra_")) {
  return { "Authorization": `Bearer ${gateway.apiKey}` };
}
return { "x-api-key": gateway.apiKey };
```

## Compat

- Legacy keys (no `matra_` prefix) still emit `x-api-key` — pre-v6 deployments unaffected.
- `signerKeypair` path unchanged.
- No public API surface added; `buildAuthHeaders` is exported but documented as test-only.

## Why now / motivation

Penny's daily orynq self-anchor cron stopped landing receipts on Apr 18 — initially hard to debug because the failure mode was a `429` that looked like congestion (the docs/memory pointed at gateway slot leaks for the same symptom). After confirming gateway slots were healthy, the `current: 3 / limit: 3` consistency revealed it was always falling through to sig auth. The Materios ops team (@Bradymck via Discord, 2026-04-30) confirmed the v6 reset wiped `operators.db` and that sponsored-tier tokens require Bearer specifically — at which point this two-line dispatch became the obvious fix.

## Tests

```
$ pnpm exec vitest run packages/anchors-materios

✓ packages/anchors-materios/tests/submitter.test.ts          (1 test)
✓ packages/anchors-materios/src/__tests__/merkle.test.ts     (22 tests)
✓ packages/anchors-materios/src/__tests__/auth-headers.test.ts (5 tests)
✓ packages/anchors-materios/tests/provider.test.ts           (2 tests)

Test Files  4 passed (4)
     Tests  30 passed (30)
```

`auth-headers.test.ts` covers:
- Bearer header for `matra_` prefix
- `x-api-key` for legacy (non-prefixed) keys
- sr25519 signature fallback when no apiKey
- apiKey precedence when both apiKey and signerKeypair are configured
- Empty headers when neither is configured

`pnpm typecheck` clean.

## Test plan

- [ ] Sanity-check the `matra_` prefix is the right gating signal (rather than e.g. inspecting token length / presence of `_`)
- [ ] Confirm the `tools/orynq` consumer of the published SDK picks up the fix on next release