### PR TITLE
feat(blob-gateway): off-chain aura → cert-daemon binding cache (task #94)

### DIFF
--- a/services/blob-gateway/scripts/backfill-task94-bindings.sh
+++ b/services/blob-gateway/scripts/backfill-task94-bindings.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Task #94 — backfill aura → cert-daemon bindings on the running blob-gateway.
+#
+# Usage (run from the gateway-host machine; needs DAEMON_NOTIFY_TOKEN):
+#
+#   GATEWAY_URL="https://materios.fluxpointstudios.com" \
+#   ADMIN_TOKEN="<value of DAEMON_NOTIFY_TOKEN>" \
+#   ./services/blob-gateway/scripts/backfill-task94-bindings.sh
+#
+# This script is idempotent — re-running it is safe. Each binding is a
+# simple POST that overwrites whatever value (or NULL) was there before.
+#
+# CONTEXT: as of task #94 deploy, the live preprod committee has 7 members
+# but only TWO operators run separate aura/cert-daemon keys (the security-
+# correct setup). The other 5 use aura-as-cert-daemon-signer (degenerate),
+# so their heartbeat is picked up by direct lookup with no binding needed.
+# We still register a binding for Hetzner as a degenerate row to make the
+# binding table the canonical source of truth (no implicit mapping).
+
+set -euo pipefail
+
+GATEWAY_URL="${GATEWAY_URL:?missing GATEWAY_URL}"
+ADMIN_TOKEN="${ADMIN_TOKEN:?missing ADMIN_TOKEN}"
+
+# (keyHash, validatorAura, label)
+# The keyHash is the SHA-256 of the api_keys row's plaintext API key —
+# look it up via SELECT key_hash FROM api_keys WHERE name = ? in quota.db.
+declare -a BINDINGS=(
+  # TrueAiData: aura 5Fn3UB... → cert-daemon 5ELL8NY... (label: OnTimeData)
+  "87f4f26fc5f831c22f91a05c8958ddf04abb1adb3162138b4072ec7b46f3c960|5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J|TrueAiData"
+
+  # MacBook: aura 5CoiW8b... → cert-daemon 5GgCBrK... (label: macbook-preprod)
+  "7b3c071e7d15a7ffe36d0ab13462a5bff8e3f4240c5a909c902109797f79a43f|5CoiW8b5wm45shiSagjxyFgpz7DS8pZiESQRVUcxJU1W687J|MacBook"
+
+  # gemtek-preprod: aura == cert-daemon == 5Dd7WuLMyb...
+  "66a45d9b695c5047a7b94fd6428e0b9c4b8ea6b1a4b7f913c3b3d9ae8049f815|5Dd7WuLMyb71NT1Bea6oEZH8Je3MkQzamHVeU4tmQbtPWq2v|Gemtek (degenerate)"
+
+  # node2-preprod: aura == cert-daemon == 5FHyiV88...
+  "80f804755e41795471704daa0517c346c4f03948562e0f937cf07b377fd5c5e7|5FHyiV88YBjxMjjZroQKcjW2nGyvHsGrPYmP7HhUNBxEpdZ7|Node2 (degenerate)"
+
+  # node3-preprod: aura == cert-daemon == 5FNdLcDW...
+  "fbe4299fcc932c8f7e10a0ce8f57099cf24e834d197c47a3f7a43e3362775789|5FNdLcDWmnDxtsUwznPaxFr9u7nop3K2kmYmvTaZRTVQExkT|Node3 (degenerate)"
+
+  # SuNewbie: aura == cert-daemon == 5DPCfuHrPkiUTtrRuKYZcWuRvSsFRi4X47W6BykF9VJFsNso
+  "a322a2322af32a870835b5b249541ed173454b20fa31fdaea9f861d36247dbca|5DPCfuHrPkiUTtrRuKYZcWuRvSsFRi4X47W6BykF9VJFsNso|SuNewbie (degenerate)"
+
+  # NOTE: Hetzner (aura 5ELbHN...) is sig-only registered and does not have
+  # an api_keys row to bind. Its heartbeat is picked up by direct lookup
+  # because aura == cert-daemon signer. No backfill row needed; if the
+  # operator later creates an api_keys entry, they should run:
+  #   curl -XPOST -H "x-admin-token: $TOK" \
+  #     "$GW/admin/api-keys/<their-keyhash>/binding" \
+  #     -d '{"validatorAura":"5ELbHNFv5rJveN4XnfF6zzTEqCiAbLP2mNEhNgF4iX5nS1h7"}'
+)
+
+apply_binding() {
+  local key_hash="$1"
+  local aura="$2"
+  local label="$3"
+  echo "→ binding $label  keyHash=${key_hash:0:16}…  aura=$aura"
+  local out
+  out=$(curl -sS -X POST \
+    -H "Content-Type: application/json" \
+    -H "x-admin-token: $ADMIN_TOKEN" \
+    -d "{\"validatorAura\":\"$aura\"}" \
+    "$GATEWAY_URL/admin/api-keys/$key_hash/binding")
+  echo "  $out"
+}
+
+for entry in "${BINDINGS[@]}"; do
+  IFS="|" read -r kh aura label <<<"$entry"
+  apply_binding "$kh" "$aura" "$label"
+done
+
+echo
+echo "Done. Verify with:"
+echo "  curl -s '$GATEWAY_URL/heartbeats/status' | jq '.bindings'"

--- a/services/blob-gateway/src/__tests__/bearer-auth.test.ts
+++ b/services/blob-gateway/src/__tests__/bearer-auth.test.ts
@@ -11,7 +11,7 @@ import express from "express";
 import Database from "better-sqlite3";
 import { createHash, randomBytes } from "crypto";
 import { initApiTokensDb, issueToken, setApiTokensDb, TOKEN_PREFIX } from "../api-tokens.js";
-import { setQuotaDbForTests, resolveKey } from "../quota.js";
+import { setQuotaDbForTests, resolveKey, migrateBindingColumn } from "../quota.js";
 import { mintAdminTokenForTests, registerTokenRoutes, setOperatorsDbForTests } from "../routes/tokens.js";
 import { bearerAuth } from "../bearer-auth.js";
 
@@ -43,6 +43,8 @@ function setupApp(): MountedApp {
       validator_id TEXT DEFAULT NULL
     );
   `);
+  // Task #94: add bound_validator_aura column so resolveKey() doesn't 500.
+  migrateBindingColumn(quotaDb);
   setQuotaDbForTests(quotaDb);
 
   const tokensDb = new Database(":memory:");
@@ -348,6 +350,7 @@ describe("quota db test hook", () => {
         validator_id TEXT DEFAULT NULL
       );
     `);
+    migrateBindingColumn(db);
     setQuotaDbForTests(db);
     expect(resolveKey("no-such-key")).toBeNull();
   });

--- a/services/blob-gateway/src/__tests__/binding.test.ts
+++ b/services/blob-gateway/src/__tests__/binding.test.ts
@@ -1,0 +1,627 @@
+/**
+ * Task #94 — aura → cert-daemon-signer binding tests.
+ *
+ * Covers:
+ *   - Idempotent migration (run twice on same DB = no-op)
+ *   - Helpers: bindValidatorAura / clearValidatorAuraBinding /
+ *     getApiKeyByHash / getBindingForAura / listAllAuraBindings
+ *   - Admin HTTP endpoints (set / get / clear) with x-admin-token guard,
+ *     SS58 validation, key-hash validation, and 404 for unknown rows
+ *   - /heartbeats/status now returns a top-level `bindings` field
+ *
+ * No live RPC, no live chain. All DBs are in-memory.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../rpc-client.js", () => ({
+  checkFunded: vi.fn(async () => true),
+  checkReceiptStatus: vi.fn(async () => "not_found" as const),
+  disconnectRpc: vi.fn(async () => {}),
+}));
+
+import express from "express";
+import Database from "better-sqlite3";
+import { createHash, randomBytes } from "crypto";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { Keyring } from "@polkadot/api";
+
+import { config } from "../config.js";
+import {
+  setQuotaDbForTests,
+  migrateUsageColumns,
+  migrateBindingColumn,
+  bindValidatorAura,
+  clearValidatorAuraBinding,
+  getApiKeyByHash,
+  getBindingForAura,
+  listAllAuraBindings,
+} from "../quota.js";
+import { registerAdminKeysRoutes } from "../routes/admin-keys.js";
+import { heartbeatsRouter } from "../routes/heartbeats.js";
+import { initHeartbeatDb } from "../heartbeat-store.js";
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+/** Build a quota DB matching the legacy production schema, then run all
+ * migrations the way prod startup does. */
+function makeQuotaDb(): Database.Database {
+  const quotaDb = new Database(":memory:");
+  quotaDb.pragma("journal_mode = WAL");
+  quotaDb.exec(`
+    CREATE TABLE api_keys (
+      key_hash TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+      max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+      max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+      validator_id TEXT DEFAULT NULL
+    );
+    CREATE TABLE quota_daily (
+      key_hash TEXT NOT NULL,
+      day TEXT NOT NULL,
+      receipts INTEGER NOT NULL DEFAULT 0,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (key_hash, day)
+    );
+    CREATE TABLE uploads_inflight (
+      upload_id TEXT PRIMARY KEY,
+      key_hash TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+    CREATE TABLE account_quotas_daily (
+      address TEXT NOT NULL,
+      day TEXT NOT NULL,
+      receipts INTEGER NOT NULL DEFAULT 0,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (address, day)
+    );
+    CREATE TABLE account_uploads_inflight (
+      upload_id TEXT PRIMARY KEY,
+      address TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+  `);
+  migrateUsageColumns(quotaDb);
+  migrateBindingColumn(quotaDb);
+  setQuotaDbForTests(quotaDb);
+  return quotaDb;
+}
+
+function seedKey(
+  quotaDb: Database.Database,
+  opts: { name?: string; ss58?: string | null; aura?: string | null } = {},
+): { keyHash: string; apiKey: string } {
+  const apiKey = randomBytes(32).toString("hex");
+  const keyHash = createHash("sha256").update(apiKey).digest("hex");
+  quotaDb
+    .prepare(
+      `INSERT INTO api_keys
+       (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id, bound_validator_aura)
+       VALUES (?, ?, 1, 100, 1073741824, 5, ?, ?)`,
+    )
+    .run(keyHash, opts.name ?? "binding-test", opts.ss58 ?? null, opts.aura ?? null);
+  return { keyHash, apiKey };
+}
+
+async function fetchJson(
+  app: express.Express,
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { "content-type": "application/json", ...(opts.headers || {}) },
+      };
+      if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let body: unknown;
+          try {
+            body = text ? JSON.parse(text) : null;
+          } catch {
+            body = text;
+          }
+          server.close();
+          resolve({ status: res.status, body });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+// --------------------------------------------------------------------------
+// Migration tests
+// --------------------------------------------------------------------------
+
+describe("migrateBindingColumn", () => {
+  test("test_idempotent_on_legacy_schema", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE api_keys (
+        key_hash TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+        max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+        max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+        validator_id TEXT DEFAULT NULL
+      );
+    `);
+    db.prepare(
+      `INSERT INTO api_keys (key_hash, name) VALUES ('aa', 'pre-migration')`,
+    ).run();
+
+    migrateBindingColumn(db);
+    migrateBindingColumn(db);
+    migrateBindingColumn(db);
+
+    const cols = db.prepare("PRAGMA table_info(api_keys)").all() as Array<{
+      name: string;
+    }>;
+    expect(cols.some((c) => c.name === "bound_validator_aura")).toBe(true);
+
+    // Legacy row has NULL binding by default.
+    const row = db
+      .prepare("SELECT bound_validator_aura FROM api_keys WHERE key_hash = 'aa'")
+      .get() as { bound_validator_aura: string | null };
+    expect(row.bound_validator_aura).toBeNull();
+  });
+
+  test("test_idempotent_on_already_migrated_schema", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE api_keys (
+        key_hash TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+        max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+        max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+        validator_id TEXT DEFAULT NULL,
+        bound_validator_aura TEXT DEFAULT NULL
+      );
+    `);
+    expect(() => migrateBindingColumn(db)).not.toThrow();
+    expect(() => migrateBindingColumn(db)).not.toThrow();
+  });
+});
+
+// --------------------------------------------------------------------------
+// Helper-function tests
+// --------------------------------------------------------------------------
+
+describe("quota binding helpers", () => {
+  let quotaDb: Database.Database;
+  beforeEach(() => {
+    quotaDb = makeQuotaDb();
+  });
+
+  test("test_bindValidatorAura_sets_then_reads_back", () => {
+    const { keyHash } = seedKey(quotaDb, { name: "set-then-read" });
+    const aura = "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J";
+
+    expect(bindValidatorAura(keyHash, aura)).toBe(true);
+
+    const row = getApiKeyByHash(keyHash);
+    expect(row?.boundValidatorAura).toBe(aura);
+  });
+
+  test("test_bindValidatorAura_returns_false_for_unknown_keyHash", () => {
+    const result = bindValidatorAura("0".repeat(64), "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J");
+    expect(result).toBe(false);
+  });
+
+  test("test_clearValidatorAuraBinding_nulls_existing", () => {
+    const aura = "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J";
+    const { keyHash } = seedKey(quotaDb, { name: "clear-test", aura });
+
+    expect(getApiKeyByHash(keyHash)?.boundValidatorAura).toBe(aura);
+    expect(clearValidatorAuraBinding(keyHash)).toBe(true);
+    expect(getApiKeyByHash(keyHash)?.boundValidatorAura).toBeNull();
+  });
+
+  test("test_clearValidatorAuraBinding_idempotent_on_null_row", () => {
+    const { keyHash } = seedKey(quotaDb, { name: "already-null" });
+    expect(clearValidatorAuraBinding(keyHash)).toBe(true); // row exists, no-op write
+    expect(getApiKeyByHash(keyHash)?.boundValidatorAura).toBeNull();
+  });
+
+  test("test_getBindingForAura_returns_first_enabled_row", () => {
+    const aura = "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J";
+    const certDaemonSs58 = "5ELL8NYkKPKqrdXig7KnsAzN82CyomztrXoY6uHsb4tuck7T";
+    seedKey(quotaDb, {
+      name: "OnTimeData",
+      ss58: certDaemonSs58,
+      aura,
+    });
+
+    const lookup = getBindingForAura(aura);
+    expect(lookup).not.toBeNull();
+    expect(lookup?.certDaemonSs58).toBe(certDaemonSs58);
+    expect(lookup?.name).toBe("OnTimeData");
+  });
+
+  test("test_getBindingForAura_returns_null_when_no_binding", () => {
+    seedKey(quotaDb, { name: "no-binding" });
+    expect(getBindingForAura("5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J")).toBeNull();
+  });
+
+  test("test_getBindingForAura_skips_disabled_rows", () => {
+    const aura = "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J";
+    const certDaemonSs58 = "5ELL8NYkKPKqrdXig7KnsAzN82CyomztrXoY6uHsb4tuck7T";
+    const apiKey = randomBytes(32).toString("hex");
+    const keyHash = createHash("sha256").update(apiKey).digest("hex");
+    quotaDb
+      .prepare(
+        `INSERT INTO api_keys
+         (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id, bound_validator_aura)
+         VALUES (?, 'disabled', 0, 100, 1073741824, 5, ?, ?)`,
+      )
+      .run(keyHash, certDaemonSs58, aura);
+
+    expect(getBindingForAura(aura)).toBeNull();
+  });
+
+  test("test_listAllAuraBindings_empty_when_no_bindings", () => {
+    seedKey(quotaDb, { name: "no-binding-1" });
+    seedKey(quotaDb, { name: "no-binding-2" });
+    expect(listAllAuraBindings()).toEqual({});
+  });
+
+  test("test_listAllAuraBindings_returns_aura_to_certdaemon_map", () => {
+    seedKey(quotaDb, {
+      name: "OnTimeData",
+      ss58: "5ELL8NYkKPKqrdXig7KnsAzN82CyomztrXoY6uHsb4tuck7T",
+      aura: "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J",
+    });
+    seedKey(quotaDb, {
+      name: "macbook-preprod",
+      ss58: "5GgCBrKDwMCWckd8P7CNLxy2ARmPHRVE4yjXuTP1vfwNtYzX",
+      aura: "5CoiW8b5wm45shiSagjxyFgpz7DS8pZiESQRVUcxJU1W687J",
+    });
+    seedKey(quotaDb, { name: "no-binding" }); // omitted from result
+    seedKey(quotaDb, {
+      name: "binding-but-no-validator-id",
+      ss58: null,
+      aura: "5SomethingWithoutSignerUsedaaaaaaaaaaaaaaaaaaaaab",
+    }); // omitted from result (validator_id IS NULL)
+
+    const all = listAllAuraBindings();
+    expect(Object.keys(all).length).toBe(2);
+    expect(all["5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J"]).toEqual({
+      certDaemonSs58: "5ELL8NYkKPKqrdXig7KnsAzN82CyomztrXoY6uHsb4tuck7T",
+      label: "OnTimeData",
+    });
+    expect(all["5CoiW8b5wm45shiSagjxyFgpz7DS8pZiESQRVUcxJU1W687J"]).toEqual({
+      certDaemonSs58: "5GgCBrKDwMCWckd8P7CNLxy2ARmPHRVE4yjXuTP1vfwNtYzX",
+      label: "macbook-preprod",
+    });
+  });
+
+  test("test_listAllAuraBindings_degenerate_aura_equals_signer", () => {
+    // Hetzner case: the same SS58 is both validator aura and cert-daemon
+    // signer (operator chose convenience over key-isolation). The schema
+    // accepts this; explorer renders without the "via cert-daemon X" hint
+    // because the aura equals the signer.
+    const ss58 = "5ELbHNFv5rJveN4XnfF6zzTEqCiAbLP2mNEhNgF4iX5nS1h7";
+    seedKey(quotaDb, {
+      name: "Hetzner-cert-daemon",
+      ss58,
+      aura: ss58,
+    });
+    const all = listAllAuraBindings();
+    expect(all[ss58]).toEqual({
+      certDaemonSs58: ss58,
+      label: "Hetzner-cert-daemon",
+    });
+  });
+});
+
+// --------------------------------------------------------------------------
+// Admin endpoint tests
+// --------------------------------------------------------------------------
+
+type MountedAdmin = {
+  app: express.Express;
+  adminToken: string;
+  quotaDb: Database.Database;
+  keyHash: string;
+};
+
+function setupAdminApp(): MountedAdmin {
+  const quotaDb = makeQuotaDb();
+  const { keyHash } = seedKey(quotaDb, {
+    name: "admin-binding-test",
+    ss58: "5ELL8NYkKPKqrdXig7KnsAzN82CyomztrXoY6uHsb4tuck7T",
+  });
+
+  const adminToken = `admin-${randomBytes(16).toString("hex")}`;
+  const app = express();
+  app.use(express.json());
+  registerAdminKeysRoutes(app, { adminToken });
+
+  return { app, adminToken, quotaDb, keyHash };
+}
+
+describe("GET /admin/api-keys/:keyHash", () => {
+  let ctx: MountedAdmin;
+  beforeEach(() => {
+    ctx = setupAdminApp();
+  });
+
+  test("test_401_without_admin_token", async () => {
+    const res = await fetchJson(ctx.app, "GET", `/admin/api-keys/${ctx.keyHash}`);
+    expect(res.status).toBe(401);
+  });
+
+  test("test_401_with_wrong_admin_token", async () => {
+    const res = await fetchJson(ctx.app, "GET", `/admin/api-keys/${ctx.keyHash}`, {
+      headers: { "x-admin-token": "wrong" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("test_400_for_malformed_keyHash", async () => {
+    const res = await fetchJson(ctx.app, "GET", `/admin/api-keys/not-hex`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("test_404_for_unknown_keyHash", async () => {
+    const bogus = "a".repeat(64);
+    const res = await fetchJson(ctx.app, "GET", `/admin/api-keys/${bogus}`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("test_returns_row_with_null_binding_initially", async () => {
+    const res = await fetchJson(ctx.app, "GET", `/admin/api-keys/${ctx.keyHash}`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      keyHash: string;
+      name: string;
+      enabled: boolean;
+      validatorId: string | null;
+      boundValidatorAura: string | null;
+    };
+    expect(body.keyHash).toBe(ctx.keyHash);
+    expect(body.name).toBe("admin-binding-test");
+    expect(body.enabled).toBe(true);
+    expect(body.validatorId).toBe("5ELL8NYkKPKqrdXig7KnsAzN82CyomztrXoY6uHsb4tuck7T");
+    expect(body.boundValidatorAura).toBeNull();
+  });
+});
+
+describe("POST /admin/api-keys/:keyHash/binding", () => {
+  let ctx: MountedAdmin;
+  beforeEach(() => {
+    ctx = setupAdminApp();
+  });
+
+  test("test_401_without_admin_token", async () => {
+    const res = await fetchJson(ctx.app, "POST", `/admin/api-keys/${ctx.keyHash}/binding`, {
+      body: { validatorAura: "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("test_400_for_missing_validatorAura", async () => {
+    const res = await fetchJson(ctx.app, "POST", `/admin/api-keys/${ctx.keyHash}/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: {},
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("test_400_for_invalid_ss58", async () => {
+    const res = await fetchJson(ctx.app, "POST", `/admin/api-keys/${ctx.keyHash}/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { validatorAura: "not-a-valid-address" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("test_404_for_unknown_keyHash", async () => {
+    const bogus = "b".repeat(64);
+    const res = await fetchJson(ctx.app, "POST", `/admin/api-keys/${bogus}/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { validatorAura: "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("test_200_persists_binding", async () => {
+    const aura = "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J";
+    const res = await fetchJson(ctx.app, "POST", `/admin/api-keys/${ctx.keyHash}/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { validatorAura: aura },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      status: string;
+      keyHash: string;
+      boundValidatorAura: string;
+      certDaemonSs58: string | null;
+    };
+    expect(body.status).toBe("bound");
+    expect(body.boundValidatorAura).toBe(aura);
+    expect(body.certDaemonSs58).toBe("5ELL8NYkKPKqrdXig7KnsAzN82CyomztrXoY6uHsb4tuck7T");
+
+    // Verify it's actually persisted via GET.
+    const get = await fetchJson(ctx.app, "GET", `/admin/api-keys/${ctx.keyHash}`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(get.status).toBe(200);
+    expect((get.body as { boundValidatorAura: string }).boundValidatorAura).toBe(aura);
+  });
+
+  test("test_re_binding_overwrites_previous_value", async () => {
+    const a1 = "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J";
+    const a2 = "5CoiW8b5wm45shiSagjxyFgpz7DS8pZiESQRVUcxJU1W687J";
+    await fetchJson(ctx.app, "POST", `/admin/api-keys/${ctx.keyHash}/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { validatorAura: a1 },
+    });
+    await fetchJson(ctx.app, "POST", `/admin/api-keys/${ctx.keyHash}/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { validatorAura: a2 },
+    });
+    const get = await fetchJson(ctx.app, "GET", `/admin/api-keys/${ctx.keyHash}`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect((get.body as { boundValidatorAura: string }).boundValidatorAura).toBe(a2);
+  });
+});
+
+describe("DELETE /admin/api-keys/:keyHash/binding", () => {
+  let ctx: MountedAdmin;
+  beforeEach(() => {
+    ctx = setupAdminApp();
+  });
+
+  test("test_401_without_admin_token", async () => {
+    const res = await fetchJson(ctx.app, "DELETE", `/admin/api-keys/${ctx.keyHash}/binding`);
+    expect(res.status).toBe(401);
+  });
+
+  test("test_400_for_malformed_keyHash", async () => {
+    const res = await fetchJson(ctx.app, "DELETE", `/admin/api-keys/not-hex/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("test_404_for_unknown_keyHash", async () => {
+    const bogus = "c".repeat(64);
+    const res = await fetchJson(ctx.app, "DELETE", `/admin/api-keys/${bogus}/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("test_200_clears_existing_binding", async () => {
+    // Set then clear.
+    await fetchJson(ctx.app, "POST", `/admin/api-keys/${ctx.keyHash}/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: { validatorAura: "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J" },
+    });
+    const del = await fetchJson(ctx.app, "DELETE", `/admin/api-keys/${ctx.keyHash}/binding`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect(del.status).toBe(200);
+    expect((del.body as { status: string }).status).toBe("cleared");
+
+    const get = await fetchJson(ctx.app, "GET", `/admin/api-keys/${ctx.keyHash}`, {
+      headers: { "x-admin-token": ctx.adminToken },
+    });
+    expect((get.body as { boundValidatorAura: string | null }).boundValidatorAura).toBeNull();
+  });
+
+  test("test_503_when_admin_token_unconfigured", async () => {
+    const app = express();
+    app.use(express.json());
+    registerAdminKeysRoutes(app, { adminToken: "" });
+
+    // With no token, every endpoint must 503 — the production behaviour
+    // we expose on misconfigured deployments.
+    const cases: Array<[string, string]> = [
+      ["GET", `/admin/api-keys/${ctx.keyHash}`],
+      ["POST", `/admin/api-keys/${ctx.keyHash}/binding`],
+      ["DELETE", `/admin/api-keys/${ctx.keyHash}/binding`],
+    ];
+    for (const [method, path] of cases) {
+      const res = await fetchJson(app, method, path);
+      expect(res.status).toBe(503);
+    }
+  });
+});
+
+// --------------------------------------------------------------------------
+// /heartbeats/status now exposes the bindings inline
+// --------------------------------------------------------------------------
+
+describe("GET /heartbeats/status with bindings", () => {
+  let tmpStorage: string;
+  let prevStoragePath: string;
+
+  beforeEach(async () => {
+    await cryptoWaitReady();
+    tmpStorage = mkdtempSync(join(tmpdir(), "blob-gateway-binding-test-"));
+    prevStoragePath = config.storagePath;
+    config.storagePath = tmpStorage;
+    initHeartbeatDb();
+    // The /heartbeats/status handler caches its response in a module-level
+    // variable for 10s. Tests run in order against the same module, so we
+    // rely on POST /heartbeats invalidation OR reaching across the boundary.
+    // The cleanest path: invalidate by importing the route's reset hook.
+    // We don't expose one, so we accept that two `GET /heartbeats/status`
+    // tests in a row will see the same cached body if they run within 10s.
+    // To get deterministic results we register one test with a binding and
+    // verify both bindings + empty in a single pass (no second GET).
+  });
+
+  afterEach(() => {
+    config.storagePath = prevStoragePath;
+    rmSync(tmpStorage, { recursive: true, force: true });
+  });
+
+  test("test_status_response_contains_bindings_field", async () => {
+    const quotaDb = makeQuotaDb();
+    seedKey(quotaDb, {
+      name: "OnTimeData",
+      ss58: "5ELL8NYkKPKqrdXig7KnsAzN82CyomztrXoY6uHsb4tuck7T",
+      aura: "5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J",
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use(heartbeatsRouter);
+
+    const res = await fetchJson(app, "GET", "/heartbeats/status");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      validators: Record<string, unknown>;
+      summary: unknown;
+      bindings: Record<string, { certDaemonSs58: string; label: string }>;
+    };
+    expect(body.bindings).toBeDefined();
+    expect(body.bindings["5Fn3UBWziTisjT6cx1K42eqycX5Fz4n9wWw97o5zd3RmAR9J"]).toEqual({
+      certDaemonSs58: "5ELL8NYkKPKqrdXig7KnsAzN82CyomztrXoY6uHsb4tuck7T",
+      label: "OnTimeData",
+    });
+  });
+
+  // NOTE: a separate "empty bindings" test would conflict with the 10s
+  // cache in the route handler. The bindings field with empty {} is
+  // already covered by listAllAuraBindings unit tests above
+  // (test_listAllAuraBindings_empty_when_no_bindings).
+});

--- a/services/blob-gateway/src/__tests__/heartbeats-auth.test.ts
+++ b/services/blob-gateway/src/__tests__/heartbeats-auth.test.ts
@@ -35,7 +35,7 @@ import type { KeyringPair } from "@polkadot/keyring/types";
 
 import { config } from "../config.js";
 import { heartbeatsRouter } from "../routes/heartbeats.js";
-import { setQuotaDbForTests } from "../quota.js";
+import { setQuotaDbForTests, migrateBindingColumn } from "../quota.js";
 import {
   initApiTokensDb,
   issueToken,
@@ -121,6 +121,9 @@ async function setupApp(opts: { registerValidator?: boolean } = {}): Promise<Har
       status TEXT NOT NULL DEFAULT 'active'
     );
   `);
+  // Task #94: add bound_validator_aura column so resolveKey()/resolveKeyByAccount()
+  // don't 500 when the heartbeat handler queries the row.
+  migrateBindingColumn(quotaDb);
   setQuotaDbForTests(quotaDb);
 
   // Real sr25519 validator key — the heartbeat-sig path requires a real

--- a/services/blob-gateway/src/__tests__/upload-auth.test.ts
+++ b/services/blob-gateway/src/__tests__/upload-auth.test.ts
@@ -43,7 +43,7 @@ import { u8aToHex, stringToU8a } from "@polkadot/util";
 
 import { config } from "../config.js";
 import { blobsRouter } from "../routes/blobs.js";
-import { setQuotaDbForTests, migrateUsageColumns } from "../quota.js";
+import { setQuotaDbForTests, migrateUsageColumns, migrateBindingColumn } from "../quota.js";
 import {
   initApiTokensDb,
   issueToken,
@@ -118,6 +118,8 @@ async function setupApp(opts: { registerOperator?: boolean } = {}): Promise<{
   // which is harmless but noisy — the production initQuotaDb does the
   // same migration automatically.
   migrateUsageColumns(quotaDb);
+  // Task #94: add bound_validator_aura column so resolveKey() doesn't 500.
+  migrateBindingColumn(quotaDb);
   setQuotaDbForTests(quotaDb);
 
   // SS58-shape account used by both Bearer and legacy-SS58-as-API-key tests.

--- a/services/blob-gateway/src/__tests__/usage-tracking.test.ts
+++ b/services/blob-gateway/src/__tests__/usage-tracking.test.ts
@@ -42,6 +42,7 @@ import { blobsRouter } from "../routes/blobs.js";
 import {
   setQuotaDbForTests,
   migrateUsageColumns,
+  migrateBindingColumn,
   recordUsage,
   getUsage,
 } from "../quota.js";
@@ -108,6 +109,9 @@ function makeQuotaDb(): Database.Database {
     );
   `);
   migrateUsageColumns(quotaDb);
+  // Task #94: also add the bound_validator_aura column so resolveKey()
+  // doesn't 500 when bearer-auth queries the row.
+  migrateBindingColumn(quotaDb);
   setQuotaDbForTests(quotaDb);
   return quotaDb;
 }

--- a/services/blob-gateway/src/index.ts
+++ b/services/blob-gateway/src/index.ts
@@ -22,6 +22,7 @@ import { initApiTokensDb } from "./api-tokens.js";
 import { registerTokenRoutes } from "./routes/tokens.js";
 import { chainInfoRouter, initChainInfoPoller } from "./routes/chain-info.js";
 import { faucetRouter } from "./routes/faucet.js";
+import { registerAdminKeysRoutes } from "./routes/admin-keys.js";
 // initChainInfoPoller is re-exported for consumers that want to pre-warm the
 // cache at startup; we also call it in start() so the first /chain-info hit
 // after cold-start returns 200 instead of 503.
@@ -61,6 +62,7 @@ app.use(operatorsRouter);   // Invite-only operator registration
 app.use(chainInfoRouter);   // Public: /chain-info — used by flux1 explorer + cert-daemon auto-discovery
 app.use(faucetRouter);      // Public: /faucet/drip — operator onboarding (MATRA + MOTRA bootstrap). Volume-mounted overrides accepted; see ops compose templates.
 registerTokenRoutes(app);   // Bearer-token lifecycle (admin-only)
+registerAdminKeysRoutes(app); // Task #94: api_keys.bound_validator_aura get/set/clear (admin-only)
 
 async function start(): Promise<void> {
   // Initialize sr25519/ed25519 WASM (required for signatureVerify)

--- a/services/blob-gateway/src/quota.ts
+++ b/services/blob-gateway/src/quota.ts
@@ -29,6 +29,13 @@ export interface KeyInfo {
   maxBytesPerDay: number;
   maxConcurrentUploads: number;
   validatorId: string | null;
+  /**
+   * Task #94: SS58 of the validator authoring (aura) key this api_keys row
+   * is bound to, when the operator is running cert-daemon and validator on
+   * SEPARATE keys (security best practice). NULL = no binding, in which case
+   * the explorer falls back to looking up heartbeats by aura SS58 directly.
+   */
+  boundValidatorAura: string | null;
 }
 
 export interface QuotaCheckResult {
@@ -105,7 +112,45 @@ export function initQuotaDb(): void {
   // IF NOT EXISTS on the versions we target; catch "duplicate column name").
   migrateUsageColumns(db);
 
+  // Task #94: aura → cert-daemon-signer binding column. Lets the explorer's
+  // Validators tab join from a committee aura SS58 to the heartbeat-store
+  // entry of the operator's cert-daemon when the operator is using SEPARATE
+  // keys (security best practice). Defaulted NULL so old rows migrate
+  // transparently. See bindValidatorAura() / getBindingForAura() below.
+  migrateBindingColumn(db);
+
   loadKeys();
+}
+
+/**
+ * Task #94 — Idempotent migration: add `bound_validator_aura` column to
+ * `api_keys`. Records the SS58 of a validator's authoring aura key when the
+ * api_keys row belongs to a SEPARATE cert-daemon signer (security-correct
+ * setup: validator aura ≠ cert-daemon signer to keep the authoring key out
+ * of the cert-daemon container's blast radius).
+ *
+ * The explorer joins on this column to render heartbeat status for the
+ * underlying cert-daemon under the validator's aura SS58.
+ *
+ * Exported so tests can exercise the "run twice against the same DB" case
+ * without spinning up full initQuotaDb(). PRAGMA-checked first; ALTER is
+ * still wrapped in try/catch belt-and-suspenders for parallel-startup races.
+ */
+export function migrateBindingColumn(database: Database.Database): void {
+  const cols = database.prepare("PRAGMA table_info(api_keys)").all() as Array<{
+    name: string;
+  }>;
+  if (cols.some((c) => c.name === "bound_validator_aura")) return;
+  try {
+    database.exec(
+      "ALTER TABLE api_keys ADD COLUMN bound_validator_aura TEXT DEFAULT NULL",
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!/duplicate column name/i.test(msg)) {
+      throw err;
+    }
+  }
 }
 
 /**
@@ -163,18 +208,24 @@ function loadKeys(): void {
         maxBytesPerDay?: number;
         maxConcurrentUploads?: number;
         validatorId?: string;
+        boundValidatorAura?: string;
       }>;
 
+      // Task #94: ON CONFLICT preserves bound_validator_aura on existing rows
+      // even when keys.json doesn't carry the field (most rows won't).
+      // Operators who *do* declare a binding via keys.json get it written
+      // through; everyone else's existing binding survives a restart.
       const upsert = db.prepare(`
-        INSERT INTO api_keys (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO api_keys (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id, bound_validator_aura)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(key_hash) DO UPDATE SET
           name = excluded.name,
           enabled = excluded.enabled,
           max_receipts_per_day = excluded.max_receipts_per_day,
           max_bytes_per_day = excluded.max_bytes_per_day,
           max_concurrent_uploads = excluded.max_concurrent_uploads,
-          validator_id = excluded.validator_id
+          validator_id = excluded.validator_id,
+          bound_validator_aura = COALESCE(excluded.bound_validator_aura, api_keys.bound_validator_aura)
       `);
 
       const upsertMany = db.transaction((items: typeof keys) => {
@@ -187,6 +238,7 @@ function loadKeys(): void {
             k.maxBytesPerDay ?? 1073741824,
             k.maxConcurrentUploads ?? 5,
             k.validatorId ?? null,
+            k.boundValidatorAura ?? null,
           );
         }
       });
@@ -214,7 +266,7 @@ function loadKeys(): void {
 export function resolveKey(apiKeyPlaintext: string): KeyInfo | null {
   const kh = hashKey(apiKeyPlaintext);
   const row = db.prepare(
-    "SELECT key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id FROM api_keys WHERE key_hash = ?",
+    "SELECT key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id, bound_validator_aura FROM api_keys WHERE key_hash = ?",
   ).get(kh) as Record<string, unknown> | undefined;
 
   if (!row || !row.enabled) return null;
@@ -227,6 +279,7 @@ export function resolveKey(apiKeyPlaintext: string): KeyInfo | null {
     maxBytesPerDay: row.max_bytes_per_day as number,
     maxConcurrentUploads: row.max_concurrent_uploads as number,
     validatorId: (row.validator_id as string) ?? null,
+    boundValidatorAura: (row.bound_validator_aura as string) ?? null,
   };
 }
 
@@ -342,7 +395,7 @@ export function lookupValidatorInfo(validatorId: string): { name: string } | nul
  */
 export function resolveKeyByAccount(ss58: string): KeyInfo | null {
   const row = db.prepare(
-    `SELECT key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id
+    `SELECT key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id, bound_validator_aura
      FROM api_keys WHERE validator_id = ? AND enabled = 1 LIMIT 1`,
   ).get(ss58) as Record<string, unknown> | undefined;
   if (!row || !row.enabled) return null;
@@ -354,7 +407,168 @@ export function resolveKeyByAccount(ss58: string): KeyInfo | null {
     maxBytesPerDay: row.max_bytes_per_day as number,
     maxConcurrentUploads: row.max_concurrent_uploads as number,
     validatorId: (row.validator_id as string) ?? null,
+    boundValidatorAura: (row.bound_validator_aura as string) ?? null,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Task #94 — aura → cert-daemon-signer binding
+// ---------------------------------------------------------------------------
+//
+// Off-chain cache version (option 2 from task #94): registers the binding
+// without a runtime upgrade. The on-chain authoritative version is a
+// separate later task — when it ships, the explorer can fall back to the
+// chain query and these helpers retire.
+
+export interface ApiKeyRecord {
+  keyHash: string;
+  name: string;
+  enabled: boolean;
+  maxReceiptsPerDay: number;
+  maxBytesPerDay: number;
+  maxConcurrentUploads: number;
+  validatorId: string | null;
+  boundValidatorAura: string | null;
+}
+
+function rowToApiKeyRecord(
+  row: Record<string, unknown> | undefined,
+): ApiKeyRecord | null {
+  if (!row) return null;
+  return {
+    keyHash: row.key_hash as string,
+    name: row.name as string,
+    enabled: !!row.enabled,
+    maxReceiptsPerDay: row.max_receipts_per_day as number,
+    maxBytesPerDay: row.max_bytes_per_day as number,
+    maxConcurrentUploads: row.max_concurrent_uploads as number,
+    validatorId: (row.validator_id as string) ?? null,
+    boundValidatorAura: (row.bound_validator_aura as string) ?? null,
+  };
+}
+
+/**
+ * Look up an api_keys row by its key_hash. Returns null if no row exists.
+ * Used by the admin GET /admin/api-keys/:keyHash introspection endpoint.
+ *
+ * Unlike resolveKey()/resolveKeyByAccount(), this DOES return rows where
+ * enabled = 0 — admin needs visibility into disabled keys for binding ops.
+ */
+export function getApiKeyByHash(keyHash: string): ApiKeyRecord | null {
+  const row = db
+    .prepare(
+      `SELECT key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day,
+              max_concurrent_uploads, validator_id, bound_validator_aura
+       FROM api_keys WHERE key_hash = ?`,
+    )
+    .get(keyHash) as Record<string, unknown> | undefined;
+  return rowToApiKeyRecord(row);
+}
+
+/**
+ * Set the binding from a cert-daemon api_keys row to its operator's
+ * validator authoring (aura) SS58. Returns true if the row was updated,
+ * false if no row exists for the given keyHash.
+ *
+ * The aura SS58 is stored verbatim — callers must validate the format
+ * (checkAddress round-trip) before calling. Same aura can be bound to
+ * multiple cert-daemon rows (degenerate fallback / multi-daemon setups).
+ */
+export function bindValidatorAura(keyHash: string, validatorAura: string): boolean {
+  const result = db
+    .prepare("UPDATE api_keys SET bound_validator_aura = ? WHERE key_hash = ?")
+    .run(validatorAura, keyHash);
+  return result.changes > 0;
+}
+
+/**
+ * Clear the binding for a cert-daemon api_keys row. Returns true if a row
+ * existed (regardless of whether it had a binding). Idempotent: safe to
+ * call on rows that already have NULL.
+ */
+export function clearValidatorAuraBinding(keyHash: string): boolean {
+  const result = db
+    .prepare("UPDATE api_keys SET bound_validator_aura = NULL WHERE key_hash = ?")
+    .run(keyHash);
+  return result.changes > 0;
+}
+
+export interface AuraBindingLookup {
+  /** keyHash of the cert-daemon api_keys row bound to this aura. */
+  keyHash: string;
+  /** Operator-friendly label from the bound api_keys row. */
+  name: string;
+  /** SS58 of the cert-daemon signer (= the api_keys row's validator_id). */
+  certDaemonSs58: string | null;
+}
+
+/**
+ * Reverse lookup: given a validator's authoring (aura) SS58, find the
+ * cert-daemon api_keys row(s) bound to it. Returns the *first* enabled
+ * binding — explorer rendering needs a single answer.
+ *
+ * NOTE: prod almost always has 1:1, but the schema allows N:1 (an operator
+ * could rotate cert-daemon keys without removing the old binding). We
+ * silently take the first to keep the explorer deterministic. Admin tooling
+ * should clean up stale bindings.
+ */
+export function getBindingForAura(validatorAura: string): AuraBindingLookup | null {
+  const row = db
+    .prepare(
+      `SELECT key_hash, name, validator_id
+       FROM api_keys
+       WHERE bound_validator_aura = ? AND enabled = 1
+       ORDER BY key_hash ASC
+       LIMIT 1`,
+    )
+    .get(validatorAura) as
+    | { key_hash: string; name: string; validator_id: string | null }
+    | undefined;
+  if (!row) return null;
+  return {
+    keyHash: row.key_hash,
+    name: row.name,
+    certDaemonSs58: row.validator_id ?? null,
+  };
+}
+
+/**
+ * List all enabled aura→cert-daemon bindings as a map keyed by aura SS58.
+ * Used by the /heartbeats/status endpoint to expose the bindings inline so
+ * the explorer doesn't need a separate round-trip per row.
+ *
+ * Skips rows where validator_id is NULL (no cert-daemon SS58 to point at)
+ * or where multiple cert-daemons claim the same aura — we keep the row
+ * with the lowest key_hash (deterministic via SQL ORDER BY) so explorer
+ * rendering stays stable across requests.
+ */
+export function listAllAuraBindings(): Record<
+  string,
+  { certDaemonSs58: string; label: string }
+> {
+  const rows = db
+    .prepare(
+      `SELECT bound_validator_aura, validator_id, name
+       FROM api_keys
+       WHERE bound_validator_aura IS NOT NULL
+         AND validator_id IS NOT NULL
+         AND enabled = 1
+       ORDER BY key_hash ASC`,
+    )
+    .all() as Array<{
+      bound_validator_aura: string;
+      validator_id: string;
+      name: string;
+    }>;
+  const out: Record<string, { certDaemonSs58: string; label: string }> = {};
+  for (const r of rows) {
+    if (out[r.bound_validator_aura]) continue;
+    out[r.bound_validator_aura] = {
+      certDaemonSs58: r.validator_id,
+      label: r.name,
+    };
+  }
+  return out;
 }
 
 export function finalizeUpload(keyInfo: KeyInfo, contentHash: string): QuotaCheckResult {

--- a/services/blob-gateway/src/routes/admin-keys.ts
+++ b/services/blob-gateway/src/routes/admin-keys.ts
@@ -1,0 +1,185 @@
+/**
+ * Admin routes for `api_keys` introspection + the Task #94
+ * `bound_validator_aura` binding (off-chain cache version).
+ *
+ *   GET    /admin/api-keys/:keyHash             -- read the api_keys row
+ *   POST   /admin/api-keys/:keyHash/binding     -- set bound_validator_aura
+ *   DELETE /admin/api-keys/:keyHash/binding     -- clear bound_validator_aura
+ *
+ * All three endpoints require x-admin-token (same env var as the rest of
+ * our admin endpoints — DAEMON_NOTIFY_TOKEN).
+ *
+ * Background: the explorer's Validators tab keys on aura SS58 and looks up
+ * heartbeats by that exact address. Operators using SEPARATE keys (validator
+ * aura ≠ cert-daemon signer — security best practice) show "No heartbeat"
+ * forever even when their cert-daemon IS healthy. This binding lets the
+ * explorer JOIN from a committee aura to the cert-daemon api_keys row, then
+ * follow validator_id → heartbeat-store entry to render the right status.
+ *
+ * The on-chain authoritative version of this binding is a separate later
+ * task; this off-chain cache lets us register the mapping without a
+ * runtime upgrade.
+ */
+
+import type { Express, Request, Response } from "express";
+import { checkAddress } from "@polkadot/util-crypto";
+import { config } from "../config.js";
+import {
+  bindValidatorAura,
+  clearValidatorAuraBinding,
+  getApiKeyByHash,
+} from "../quota.js";
+import { adminGuard } from "../bearer-auth.js";
+
+/**
+ * Materios uses substrate prefix 42 (the generic substrate prefix), but
+ * @polkadot/util-crypto's `checkAddress(addr, prefix)` rejects with
+ * "Prefix mismatch" if you pass anything that doesn't equal `prefix`. The
+ * explorer reverse-decodes by raw public key anyway, so we accept any
+ * valid SS58 by trying a small allow-list of substrate prefixes. Adding
+ * a new chain just means adding its prefix here.
+ */
+const ALLOWED_SS58_PREFIXES = [42, 0]; // 42 = generic substrate, 0 = Polkadot
+
+const KEY_HASH_REGEX = /^[0-9a-f]{64}$/;
+
+interface RegisterAdminKeysRoutesOpts {
+  /** Admin shared secret (falls back to config.daemonNotifyToken if empty). */
+  adminToken?: string;
+}
+
+function isValidSs58(addr: unknown): addr is string {
+  if (typeof addr !== "string" || addr.length === 0) return false;
+  for (const prefix of ALLOWED_SS58_PREFIXES) {
+    try {
+      const [ok] = checkAddress(addr, prefix);
+      if (ok) return true;
+    } catch {
+      // try next prefix
+    }
+  }
+  return false;
+}
+
+export function registerAdminKeysRoutes(
+  app: Express,
+  opts: RegisterAdminKeysRoutesOpts = {},
+): void {
+  const adminToken = (opts.adminToken || config.daemonNotifyToken || "").trim();
+
+  if (!adminToken) {
+    // Mount as 503 stubs so callers see "misconfigured" instead of 404 —
+    // mirrors the same pattern used in routes/tokens.ts when the admin
+    // token is missing. Surfaces config drift loudly.
+    const stub = (_req: Request, res: Response) => {
+      res.status(503).json({ error: "admin token not configured" });
+    };
+    app.get("/admin/api-keys/:keyHash", stub);
+    app.post("/admin/api-keys/:keyHash/binding", stub);
+    app.delete("/admin/api-keys/:keyHash/binding", stub);
+    return;
+  }
+
+  const guard = adminGuard(adminToken);
+
+  /* ------------------------------------------------------------------------
+   * GET /admin/api-keys/:keyHash
+   * Returns the row including bound_validator_aura. 404 if not found.
+   * ---------------------------------------------------------------------- */
+  app.get("/admin/api-keys/:keyHash", guard, (req: Request, res: Response) => {
+    try {
+      const keyHash = String(req.params.keyHash || "").toLowerCase();
+      if (!KEY_HASH_REGEX.test(keyHash)) {
+        res.status(400).json({ error: "invalid key hash (expected 64 hex chars)" });
+        return;
+      }
+      const row = getApiKeyByHash(keyHash);
+      if (!row) {
+        res.status(404).json({ error: "api_keys row not found" });
+        return;
+      }
+      // Mirror the on-disk shape but use camelCase + boolean for `enabled`
+      // to match how KeyInfo is exposed elsewhere.
+      res.status(200).json({
+        keyHash: row.keyHash,
+        name: row.name,
+        enabled: row.enabled,
+        maxReceiptsPerDay: row.maxReceiptsPerDay,
+        maxBytesPerDay: row.maxBytesPerDay,
+        maxConcurrentUploads: row.maxConcurrentUploads,
+        validatorId: row.validatorId,
+        boundValidatorAura: row.boundValidatorAura,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  /* ------------------------------------------------------------------------
+   * POST /admin/api-keys/:keyHash/binding   { validatorAura }
+   * Sets bound_validator_aura. Validates SS58 shape via checkAddress(any).
+   * Idempotent (re-setting the same value is a no-op for the explorer).
+   * ---------------------------------------------------------------------- */
+  app.post("/admin/api-keys/:keyHash/binding", guard, (req: Request, res: Response) => {
+    try {
+      const keyHash = String(req.params.keyHash || "").toLowerCase();
+      if (!KEY_HASH_REGEX.test(keyHash)) {
+        res.status(400).json({ error: "invalid key hash (expected 64 hex chars)" });
+        return;
+      }
+      const body = (req.body ?? {}) as { validatorAura?: string };
+      const validatorAura = body.validatorAura;
+      if (!isValidSs58(validatorAura)) {
+        res.status(400).json({ error: "missing or invalid validatorAura (expected SS58 address)" });
+        return;
+      }
+      const updated = bindValidatorAura(keyHash, validatorAura);
+      if (!updated) {
+        res.status(404).json({ error: "api_keys row not found" });
+        return;
+      }
+      // Audit log — never log secrets, but the binding itself is public info
+      // (both SS58s are on-chain identities).
+      console.log(
+        `[blob-gateway] api-key binding set keyHash=${keyHash.slice(0, 16)}... aura=${validatorAura}`,
+      );
+      const row = getApiKeyByHash(keyHash);
+      res.status(200).json({
+        status: "bound",
+        keyHash,
+        boundValidatorAura: validatorAura,
+        certDaemonSs58: row?.validatorId ?? null,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  /* ------------------------------------------------------------------------
+   * DELETE /admin/api-keys/:keyHash/binding
+   * Clears bound_validator_aura. Idempotent — succeeds on rows already NULL.
+   * ---------------------------------------------------------------------- */
+  app.delete("/admin/api-keys/:keyHash/binding", guard, (req: Request, res: Response) => {
+    try {
+      const keyHash = String(req.params.keyHash || "").toLowerCase();
+      if (!KEY_HASH_REGEX.test(keyHash)) {
+        res.status(400).json({ error: "invalid key hash (expected 64 hex chars)" });
+        return;
+      }
+      const updated = clearValidatorAuraBinding(keyHash);
+      if (!updated) {
+        res.status(404).json({ error: "api_keys row not found" });
+        return;
+      }
+      console.log(
+        `[blob-gateway] api-key binding cleared keyHash=${keyHash.slice(0, 16)}...`,
+      );
+      res.status(200).json({ status: "cleared", keyHash });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+}

--- a/services/blob-gateway/src/routes/heartbeats.ts
+++ b/services/blob-gateway/src/routes/heartbeats.ts
@@ -16,7 +16,7 @@
 import { Router, type Request, type Response } from "express";
 import { signatureVerify } from "@polkadot/util-crypto";
 import { stringToU8a } from "@polkadot/util";
-import { lookupValidatorInfo } from "../quota.js";
+import { lookupValidatorInfo, listAllAuraBindings } from "../quota.js";
 import { resolveAuth } from "../auth.js";
 import {
   upsertHeartbeat,
@@ -40,6 +40,20 @@ const MIN_POST_INTERVAL_MS = 10_000; // 10 seconds
 interface StatusResponse {
   validators: Record<string, ValidatorStatus>;
   summary: { total: number; online: number; degraded: number; offline: number };
+  /**
+   * Task #94 — aura → cert-daemon-signer bindings. The explorer's Validators
+   * tab uses these to render heartbeat status for operators running cert-
+   * daemon and validator on SEPARATE keys.
+   *
+   * Each entry maps a validator's authoring (aura) SS58 to the SS58 of the
+   * cert-daemon signer whose heartbeat status should be displayed for that
+   * validator. The cert-daemon SS58 is the api_keys.validator_id of the
+   * row whose bound_validator_aura matches the aura.
+   *
+   * Empty object when no bindings have been registered. Forward-compatible:
+   * old explorer instances ignore the field, new ones JOIN by aura SS58.
+   */
+  bindings: Record<string, { certDaemonSs58: string; label: string }>;
 }
 
 interface ValidatorStatus {
@@ -332,6 +346,18 @@ heartbeatsRouter.get("/heartbeats/status", (_req: Request, res: Response) => {
       };
     }
 
+    // Task #94: pull bindings inline so the explorer doesn't need a second
+    // round-trip per validator row. Empty object when nothing is registered.
+    let bindings: Record<string, { certDaemonSs58: string; label: string }> = {};
+    try {
+      bindings = listAllAuraBindings();
+    } catch (err) {
+      // Defensive: a "no such column" on bound_validator_aura would mean
+      // migrateBindingColumn() didn't run — log and continue with an empty
+      // map so the rest of the response is still served.
+      console.warn("[blob-gateway] listAllAuraBindings failed:", err);
+    }
+
     const response: StatusResponse = {
       validators,
       summary: {
@@ -340,6 +366,7 @@ heartbeatsRouter.get("/heartbeats/status", (_req: Request, res: Response) => {
         degraded,
         offline,
       },
+      bindings,
     };
 
     cachedStatusResponse = response;


### PR DESCRIPTION
See commit message and task #94 summary above. 29 new tests pass. Migration is idempotent, admin endpoints gated by DAEMON_NOTIFY_TOKEN, heartbeats/status now exposes bindings inline.