### PR TITLE
fix(blob-gateway-tests): unblock main — add migrateBindingColumn to manifest-roothash fixture

### DIFF
--- a/services/blob-gateway/src/__tests__/manifest-roothash.test.ts
+++ b/services/blob-gateway/src/__tests__/manifest-roothash.test.ts
@@ -32,7 +32,7 @@ import { join } from "path";
 
 import { config } from "../config.js";
 import { blobsRouter } from "../routes/blobs.js";
-import { setQuotaDbForTests, migrateUsageColumns } from "../quota.js";
+import { setQuotaDbForTests, migrateUsageColumns, migrateBindingColumn } from "../quota.js";
 import {
   initApiTokensDb,
   issueToken,
@@ -100,6 +100,12 @@ async function setupApp(): Promise<{
     );
   `);
   migrateUsageColumns(quotaDb);
+  // Task #94: required by resolveKey()/resolveKeyByAccount() — they SELECT
+  // bound_validator_aura, so the column has to exist on the hand-built
+  // fixture too. Without this, every POST /blobs/:contentHash/manifest
+  // 500s on auth resolution. Was missed when #93 + #94 were merged in
+  // parallel without test-fixture co-evolution.
+  migrateBindingColumn(quotaDb);
   setQuotaDbForTests(quotaDb);
 
   const ss58 = "5OperatorRoothashTestaaaaaaaaaaaaaaaaaaaaaaaaab";


### PR DESCRIPTION
## Summary

- 11/11 tests in \`manifest-roothash.test.ts\` started failing on \`main\` after #18 + #19 merged in parallel
- Root cause: #19 added a SELECT on \`bound_validator_aura\` that #18's hand-built test fixture didn't have
- Fix: 2 lines — import \`migrateBindingColumn\` and call it on the fixture
- Full blob-gateway suite now 125/125 (was 114/125 on main)

## Test plan

- [x] \`pnpm vitest run services/blob-gateway/src/__tests__/manifest-roothash.test.ts\` — 11/11 pass
- [x] \`pnpm vitest run services/blob-gateway\` — 125/125 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)