### PR TITLE
feat(blob-gateway): tenant-bound /billing/usage with full compute aggregation (tasks #112 + #119)

### DIFF
--- a/services/blob-gateway/src/__tests__/billing_aggregate.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_aggregate.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Pure-function tests for `billing/aggregate.ts`. NO IO, NO chain, NO db.
+ *
+ * Synthetic fixtures here exercise the aggregate counters, the cursor
+ * round-trip, and edge cases (empty input, mixed states). The route-level
+ * test (`billing_route.test.ts`) covers the wiring; this file pins the
+ * MATH so future refactors of the aggregator can't silently regress.
+ */
+
+import { describe, test, expect } from "vitest";
+import {
+  aggregateRecords,
+  buildNextCursor,
+  decodeCursor,
+  type AggregatableRecord,
+} from "../billing/aggregate.js";
+
+function rec(over: Partial<AggregatableRecord> = {}): AggregatableRecord {
+  return {
+    worker_id: "worker-1",
+    tenant_id: "ten-test-1",
+    period_start_ms: 1_700_000_000_000,
+    period_end_ms: 1_700_000_000_000 + 60_000,
+    cpu_seconds: 10,
+    ram_gb_hours: 1,
+    disk_gb_hours: 0.5,
+    net_bytes_in: 100,
+    net_bytes_out: 50,
+    gpu_seconds: 0,
+    attestation_status: "pending",
+    cardano_anchor_tx: null,
+    ...over,
+  };
+}
+
+describe("aggregateRecords", () => {
+  test("empty input → zero-aggregate with null first/last", () => {
+    const out = aggregateRecords([]);
+    expect(out).toEqual({
+      record_count: 0,
+      certified_count: 0,
+      anchored_count: 0,
+      cpu_seconds_total: 0,
+      ram_gb_hours_total: 0,
+      disk_gb_hours_total: 0,
+      net_bytes_in_total: 0,
+      net_bytes_out_total: 0,
+      gpu_seconds_total: 0,
+      first_record_ms: null,
+      last_record_ms: null,
+      unique_workers: 0,
+    });
+  });
+
+  test("single record → all sums match input, first==last", () => {
+    const r = rec({ period_start_ms: 100, cpu_seconds: 7.5, gpu_seconds: 3 });
+    const out = aggregateRecords([r]);
+    expect(out.record_count).toBe(1);
+    expect(out.cpu_seconds_total).toBeCloseTo(7.5, 6);
+    expect(out.gpu_seconds_total).toBeCloseTo(3, 6);
+    expect(out.first_record_ms).toBe(100);
+    expect(out.last_record_ms).toBe(100);
+    expect(out.unique_workers).toBe(1);
+  });
+
+  test("certified+anchored counts respect the inclusion order", () => {
+    const records: AggregatableRecord[] = [
+      // certified + anchored
+      rec({
+        attestation_status: "certified",
+        cardano_anchor_tx: "0x" + "ab".repeat(32),
+      }),
+      // certified + not yet anchored
+      rec({ attestation_status: "certified", cardano_anchor_tx: null }),
+      // pending
+      rec({ attestation_status: "pending", cardano_anchor_tx: null }),
+      // unknown (chain RPC failed)
+      rec({ attestation_status: "unknown", cardano_anchor_tx: null }),
+    ];
+    const out = aggregateRecords(records);
+    expect(out.record_count).toBe(4);
+    expect(out.certified_count).toBe(2);
+    expect(out.anchored_count).toBe(1);
+  });
+
+  test("sums float fields with reasonable precision", () => {
+    const out = aggregateRecords([
+      rec({ ram_gb_hours: 0.1, disk_gb_hours: 0.2 }),
+      rec({ ram_gb_hours: 0.2, disk_gb_hours: 0.3 }),
+      rec({ ram_gb_hours: 0.3, disk_gb_hours: 0.5 }),
+    ]);
+    // Standard JS FP — accept tiny drift, hence toBeCloseTo.
+    expect(out.ram_gb_hours_total).toBeCloseTo(0.6, 6);
+    expect(out.disk_gb_hours_total).toBeCloseTo(1.0, 6);
+  });
+
+  test("net_bytes_* stays integer-exact at moderate scale", () => {
+    const out = aggregateRecords([
+      rec({ net_bytes_in: 1_000_000, net_bytes_out: 2_000_000 }),
+      rec({ net_bytes_in: 3_000_000, net_bytes_out: 4_000_000 }),
+    ]);
+    expect(out.net_bytes_in_total).toBe(4_000_000);
+    expect(out.net_bytes_out_total).toBe(6_000_000);
+    expect(Number.isInteger(out.net_bytes_in_total)).toBe(true);
+  });
+
+  test("first/last record bookends across multiple", () => {
+    const out = aggregateRecords([
+      rec({ period_start_ms: 200 }),
+      rec({ period_start_ms: 100 }),
+      rec({ period_start_ms: 300 }),
+    ]);
+    expect(out.first_record_ms).toBe(100);
+    expect(out.last_record_ms).toBe(300);
+  });
+
+  test("unique_workers counts distinct worker_id", () => {
+    const out = aggregateRecords([
+      rec({ worker_id: "a" }),
+      rec({ worker_id: "b" }),
+      rec({ worker_id: "a" }),
+      rec({ worker_id: "c" }),
+    ]);
+    expect(out.unique_workers).toBe(3);
+  });
+});
+
+describe("cursor round-trip", () => {
+  test("buildNextCursor returns null when records < page_size (last page)", () => {
+    const out = buildNextCursor(
+      [{ period_start_ms: 1, content_hash: "a".repeat(64) }],
+      10,
+    );
+    expect(out).toBeNull();
+  });
+
+  test("buildNextCursor returns null when is_final=true even on full page", () => {
+    const out = buildNextCursor(
+      [
+        { period_start_ms: 1, content_hash: "a".repeat(64) },
+        { period_start_ms: 2, content_hash: "b".repeat(64) },
+      ],
+      2,
+      /* is_final = */ true,
+    );
+    expect(out).toBeNull();
+  });
+
+  test("buildNextCursor returns opaque base64url when records == page_size", () => {
+    const out = buildNextCursor(
+      [
+        { period_start_ms: 1, content_hash: "a".repeat(64) },
+        { period_start_ms: 2, content_hash: "b".repeat(64) },
+      ],
+      2,
+    );
+    expect(out).toBeTruthy();
+    expect(typeof out).toBe("string");
+    // base64url → no '+', '/', '='
+    expect(out).not.toMatch(/[+/=]/);
+  });
+
+  test("decodeCursor round-trips a buildNextCursor output", () => {
+    const last = { period_start_ms: 12345, content_hash: "f".repeat(64) };
+    const cur = buildNextCursor([last], 1);
+    expect(cur).toBeTruthy();
+    const decoded = decodeCursor(cur as string);
+    expect(decoded).toEqual(last);
+  });
+
+  test("decodeCursor returns null on malformed input", () => {
+    expect(decodeCursor("")).toBeNull();
+    expect(decodeCursor("@@@@")).toBeNull();
+    expect(decodeCursor("notbase64")).toBeNull();
+    // Valid base64 but JSON is wrong shape:
+    const bad = Buffer.from(JSON.stringify({ p: "x", h: "y" })).toString("base64");
+    expect(decodeCursor(bad.replace(/=+$/, ""))).toBeNull();
+  });
+
+  test("decodeCursor rejects malformed content_hash", () => {
+    const bad = Buffer.from(
+      JSON.stringify({ p: 1, h: "not-hex" }),
+    ).toString("base64");
+    expect(decodeCursor(bad.replace(/=+$/, ""))).toBeNull();
+  });
+});

--- a/services/blob-gateway/src/__tests__/billing_anchor_resolver.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_anchor_resolver.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for `billing/anchor_resolver.ts`. NO chain, NO live cert-daemon.
+ *
+ * Builds synthetic checkpoint-history.json + anchor-worker.log files in a
+ * tmpdir, then exercises:
+ *   - happy path: cert_hash → root → tx_hash
+ *   - missing log: cert_hash → root → null tx_hash
+ *   - missing history file: every cert_hash → null
+ *   - malformed history: every cert_hash → null
+ *   - parser handles multiple anchor lines, latest wins per root20
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  resolveAnchorTxs,
+  resetAnchorResolverForTests,
+  parseAnchorWorkerLog,
+} from "../billing/anchor_resolver.js";
+
+interface CtxFx {
+  dir: string;
+  history: string;
+  log: string;
+}
+
+function setup(): CtxFx {
+  const dir = mkdtempSync(join(tmpdir(), "anchor-resolver-test-"));
+  return {
+    dir,
+    history: join(dir, "checkpoint-history.json"),
+    log: join(dir, "anchor-worker.log"),
+  };
+}
+
+function teardown(ctx: CtxFx): void {
+  rmSync(ctx.dir, { recursive: true, force: true });
+}
+
+describe("parseAnchorWorkerLog", () => {
+  test("extracts root20 → tx_hash from canonical line", () => {
+    const text = `[anchor-worker] anchored root=64cdf1c4495bb797ba5a... as tx 37c6510e622e58fd12c61a2c806a6949399d6a74a27c1308a6caf3e76177e671 [burst-head, cache=0]
+[anchor-worker] anchored root=839844b7e248930d4e13... as tx a426cdcb6e8d11ca8ac39ddce7a6e24044dc988dad406d8f3c60a9aa7bd7c146 [burst-head, cache=1]`;
+    const map = parseAnchorWorkerLog(text);
+    expect(map.size).toBe(2);
+    expect(map.get("64cdf1c4495bb797ba5a")).toBe(
+      "37c6510e622e58fd12c61a2c806a6949399d6a74a27c1308a6caf3e76177e671",
+    );
+    expect(map.get("839844b7e248930d4e13")).toBe(
+      "a426cdcb6e8d11ca8ac39ddce7a6e24044dc988dad406d8f3c60a9aa7bd7c146",
+    );
+  });
+
+  test("ignores non-matching lines", () => {
+    const text = `random log noise
+[anchor-worker] anchor failed
+[anchor-worker] anchored root=839844b7e248930d4e13... as tx a426cdcb6e8d11ca8ac39ddce7a6e24044dc988dad406d8f3c60a9aa7bd7c146`;
+    const map = parseAnchorWorkerLog(text);
+    expect(map.size).toBe(1);
+  });
+
+  test("later line for same root wins", () => {
+    const text = `[anchor-worker] anchored root=839844b7e248930d4e13... as tx aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+[anchor-worker] anchored root=839844b7e248930d4e13... as tx bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`;
+    const map = parseAnchorWorkerLog(text);
+    expect(map.get("839844b7e248930d4e13")).toBe("b".repeat(64));
+  });
+});
+
+describe("resolveAnchorTxs", () => {
+  let ctx: CtxFx;
+  beforeEach(() => {
+    ctx = setup();
+    resetAnchorResolverForTests();
+  });
+  afterEach(() => {
+    teardown(ctx);
+    resetAnchorResolverForTests();
+  });
+
+  test("history + log present → resolves cert_hash to tx", async () => {
+    const certHashFull =
+      "5d5471680874bead8b75a6d8eef32047a1806d767520510f01082950d2151825";
+    const rootFull =
+      "c3f526ab59203761bf974fa177b934623ee24b0ac15627a37f803baa6440403a";
+    const root20 = rootFull.slice(0, 20);
+    const txFull =
+      "deadbeef".repeat(8); // 64 hex
+    const history = [
+      {
+        timestamp: 1,
+        root_hash: rootFull,
+        manifest_hash: "ff".repeat(32),
+        manifest: {},
+        leaves: [
+          {
+            receipt_id: "0x" + "00".repeat(32),
+            cert_hash: certHashFull,
+            block_num: 1,
+            leaf_hash: "ee".repeat(32),
+          },
+        ],
+      },
+    ];
+    writeFileSync(ctx.history, JSON.stringify(history));
+    writeFileSync(
+      ctx.log,
+      `[anchor-worker] anchored root=${root20}... as tx ${txFull} [burst-head, cache=0]\n`,
+    );
+
+    const out = await resolveAnchorTxs([certHashFull], {
+      cert_history_path: ctx.history,
+      anchor_worker_log_path: ctx.log,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(txFull);
+  });
+
+  test("history present, log missing → null tx", async () => {
+    const certHashFull =
+      "5d5471680874bead8b75a6d8eef32047a1806d767520510f01082950d2151825";
+    const history = [
+      {
+        timestamp: 1,
+        root_hash:
+          "c3f526ab59203761bf974fa177b934623ee24b0ac15627a37f803baa6440403a",
+        manifest_hash: "ff".repeat(32),
+        manifest: {},
+        leaves: [{ cert_hash: certHashFull }],
+      },
+    ];
+    writeFileSync(ctx.history, JSON.stringify(history));
+    // do NOT write log
+
+    const out = await resolveAnchorTxs([certHashFull], {
+      cert_history_path: ctx.history,
+      anchor_worker_log_path: ctx.log,
+    });
+    expect(out[0]).toBeNull();
+  });
+
+  test("history file missing → every cert_hash maps to null (no throw)", async () => {
+    const out = await resolveAnchorTxs(["0x" + "ab".repeat(32)], {
+      cert_history_path: join(ctx.dir, "no-such-history.json"),
+      anchor_worker_log_path: join(ctx.dir, "no-such-log"),
+    });
+    expect(out[0]).toBeNull();
+  });
+
+  test("malformed history JSON → every cert_hash maps to null (no throw)", async () => {
+    writeFileSync(ctx.history, "{not_valid_json");
+    const out = await resolveAnchorTxs(["0x" + "ab".repeat(32)], {
+      cert_history_path: ctx.history,
+      anchor_worker_log_path: ctx.log,
+    });
+    expect(out[0]).toBeNull();
+  });
+
+  test("malformed history root: not an array → every cert_hash maps to null", async () => {
+    writeFileSync(ctx.history, JSON.stringify({ checkpoints: [] }));
+    const out = await resolveAnchorTxs(["0x" + "ab".repeat(32)], {
+      cert_history_path: ctx.history,
+      anchor_worker_log_path: ctx.log,
+    });
+    expect(out[0]).toBeNull();
+  });
+
+  test("nullish cert_hash in input → returns null at that position", async () => {
+    writeFileSync(ctx.history, JSON.stringify([]));
+    const out = await resolveAnchorTxs([null, "0x" + "ab".repeat(32), null], {
+      cert_history_path: ctx.history,
+      anchor_worker_log_path: ctx.log,
+    });
+    expect(out).toEqual([null, null, null]);
+  });
+
+  test("with-prefix and lowercase normalisation", async () => {
+    const certHashFull =
+      "5d5471680874bead8b75a6d8eef32047a1806d767520510f01082950d2151825";
+    const rootFull =
+      "c3f526ab59203761bf974fa177b934623ee24b0ac15627a37f803baa6440403a";
+    const txFull = "ab".repeat(32);
+    const history = [
+      {
+        timestamp: 1,
+        root_hash: rootFull.toUpperCase(),
+        manifest_hash: "ff".repeat(32),
+        manifest: {},
+        leaves: [{ cert_hash: certHashFull.toUpperCase() }],
+      },
+    ];
+    writeFileSync(ctx.history, JSON.stringify(history));
+    writeFileSync(
+      ctx.log,
+      `[anchor-worker] anchored root=${rootFull.slice(0, 20)}... as tx ${txFull} [burst-head]\n`,
+    );
+
+    // input with 0x prefix + uppercase
+    const out = await resolveAnchorTxs(["0x" + certHashFull.toUpperCase()], {
+      cert_history_path: ctx.history,
+      anchor_worker_log_path: ctx.log,
+    });
+    expect(out[0]).toBe(txFull);
+  });
+
+  test("empty input → empty output", async () => {
+    const out = await resolveAnchorTxs([]);
+    expect(out).toEqual([]);
+  });
+});

--- a/services/blob-gateway/src/__tests__/billing_live_preprod.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_live_preprod.test.ts
@@ -1,0 +1,437 @@
+/**
+ * LIVE PREPROD end-to-end test for `GET /billing/usage`.
+ *
+ * Runs ONLY when `LIVE_PREPROD=1` is set. Per the convention captured in
+ * `feedback_intent_settlement_chain_tdd.md`, chain-side validation tests
+ * hit the live preprod chain with NO mocks. The path here:
+ *
+ *   1. Boot a local express app with the metering + billing routers, an
+ *      in-memory worker_bounds db, and a real Bearer token. Sponsored-
+ *      receipt-submitter URL is left unset — the metering route's pure
+ *      forwarding leg isn't needed for THIS test (we submit on-chain
+ *      directly via @polkadot/api with //Alice).
+ *
+ *   2. Submit 3 valid `compute_metering_v1` records via `POST /metering/submit`
+ *      with the SAME tenant_id. Each has a different worker key + period
+ *      window (1h, contiguous, ending 30s ago).
+ *
+ *   3. For each accepted record: directly submit `submit_receipt_v2` to
+ *      preprod with //Alice as signer, so the on-chain receipt appears.
+ *      schema_hash = SCHEMA_HASH_HEX is passed verbatim. (We can't rely on
+ *      the sponsored-receipt-submitter being reachable from this test
+ *      process; the metering live test does the same.)
+ *
+ *   4. Wait briefly (5-10s) for cert-daemon to potentially pick up the
+ *      receipts. Don't fail if it's slow — the pending state is a valid
+ *      assertion target too.
+ *
+ *   5. Call `GET /billing/usage?tenant_id=...&start_ms=...&end_ms=...&include_records=true`.
+ *      Assert: 200, `aggregate.record_count >= 3`, aggregate sums match
+ *      input, AT LEAST one record's attestation_status is one of
+ *      ["certified", "pending"] (NOT "unknown" — chain RPC must be
+ *      reachable for this test to be meaningful).
+ *
+ *   6. Optional: check anchor_resolver path. Won't fail if the SSH-into-
+ *      cert-daemon-container path is unavailable in the test env; just
+ *      verifies that the field exists in the response and is null OR a
+ *      well-formed Cardano tx hash.
+ *
+ * Gating: `LIVE_PREPROD=1`. Skipped on CI by default. Run locally with:
+ *
+ *   LIVE_PREPROD=1 pnpm vitest run \
+ *     services/blob-gateway/src/__tests__/billing_live_preprod.test.ts
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createHash } from "crypto";
+import { ApiPromise, Keyring, WsProvider } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+
+import { config } from "../config.js";
+import { meteringRouter } from "../routes/metering.js";
+import { billingRouter } from "../routes/billing.js";
+import {
+  initWorkerBoundsDb,
+  setWorkerBoundsDbForTests,
+} from "../worker_bounds.js";
+import {
+  canonicalBody,
+  SCHEMA_VERSION,
+  SCHEMA_HASH_HEX,
+  type ComputeMeteringV1,
+} from "../schemas/compute_metering_v1.js";
+import {
+  initApiTokensDb,
+  setApiTokensDb,
+  issueToken,
+} from "../api-tokens.js";
+import {
+  setQuotaDbForTests,
+  migrateBindingColumn,
+} from "../quota.js";
+
+const PREPROD_WSS = "wss://materios.fluxpointstudios.com/preprod-rpc";
+const LIVE = process.env.LIVE_PREPROD === "1";
+
+const RECEIPT_APPEAR_DEADLINE_MS = 60_000;
+const CERT_PROBE_DEADLINE_MS = 30_000;
+
+interface AppCtx {
+  app: express.Express;
+  storage: string;
+  prevStorage: string;
+  prevSubmitterUrl: string;
+  prevRpcUrl: string;
+  workerBoundsDb: Database.Database;
+  quotaDb: Database.Database;
+  tokensDb: Database.Database;
+  bearerToken: string;
+}
+
+function setupApp(): AppCtx {
+  const storage = mkdtempSync(join(tmpdir(), "billing-live-test-"));
+  const prevStorage = config.storagePath;
+  config.storagePath = storage;
+
+  const prevSubmitterUrl = config.sponsoredReceiptSubmitterUrl;
+  config.sponsoredReceiptSubmitterUrl = "";
+
+  // Point the chain-query wrapper at preprod for this test.
+  const prevRpcUrl = config.materiosRpcUrl;
+  config.materiosRpcUrl = PREPROD_WSS;
+
+  const workerBoundsDb = new Database(":memory:");
+  initWorkerBoundsDb(workerBoundsDb);
+  setWorkerBoundsDbForTests(workerBoundsDb);
+
+  const quotaDb = new Database(":memory:");
+  quotaDb.pragma("journal_mode = WAL");
+  quotaDb.exec(`
+    CREATE TABLE api_keys (
+      key_hash TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+      max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+      max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+      validator_id TEXT DEFAULT NULL
+    );
+  `);
+  migrateBindingColumn(quotaDb);
+  setQuotaDbForTests(quotaDb);
+
+  const tokensDb = new Database(":memory:");
+  tokensDb.pragma("journal_mode = WAL");
+  initApiTokensDb(tokensDb);
+  setApiTokensDb(tokensDb);
+
+  const ss58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"; // //Alice
+  const tok = issueToken(tokensDb, {
+    accountSs58: ss58,
+    label: "billing-live-test",
+  });
+
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.use(meteringRouter);
+  app.use(billingRouter);
+
+  return {
+    app,
+    storage,
+    prevStorage,
+    prevSubmitterUrl,
+    prevRpcUrl,
+    workerBoundsDb,
+    quotaDb,
+    tokensDb,
+    bearerToken: tok.token,
+  };
+}
+
+function teardown(ctx: AppCtx): void {
+  config.storagePath = ctx.prevStorage;
+  config.sponsoredReceiptSubmitterUrl = ctx.prevSubmitterUrl;
+  config.materiosRpcUrl = ctx.prevRpcUrl;
+  rmSync(ctx.storage, { recursive: true, force: true });
+  ctx.workerBoundsDb.close();
+  ctx.quotaDb.close();
+  ctx.tokensDb.close();
+}
+
+interface FetchInit {
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+async function call(
+  app: express.Express,
+  method: string,
+  path: string,
+  init: FetchInit = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const headers: Record<string, string> = {
+        ...(init.headers ?? {}),
+      };
+      const opts: RequestInit = { method, headers };
+      if (init.body !== undefined) {
+        if (!headers["content-type"]) headers["content-type"] = "application/json";
+        opts.body = JSON.stringify(init.body);
+      }
+      fetch(url, opts)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+function computeReceiptId(contentHashHex: string): string {
+  return (
+    "0x" +
+    createHash("sha256")
+      .update(Buffer.from(contentHashHex, "hex"))
+      .digest("hex")
+  );
+}
+
+const describeMaybe = LIVE ? describe : describe.skip;
+
+describeMaybe("GET /billing/usage — LIVE preprod end-to-end", () => {
+  let appCtx: AppCtx;
+  let api: ApiPromise;
+
+  beforeAll(async () => {
+    await cryptoWaitReady();
+    appCtx = setupApp();
+    const provider = new WsProvider(PREPROD_WSS, 5000);
+    api = await ApiPromise.create({ provider, noInitWarn: true });
+    const chain = (await api.rpc.system.chain()).toString();
+    if (!/preprod/i.test(chain)) {
+      throw new Error(
+        `LIVE_PREPROD pointed at unexpected chain "${chain}" — refusing to run`,
+      );
+    }
+    // eslint-disable-next-line no-console
+    console.log(`[billing-live] connected to "${chain}"`);
+  }, 60_000);
+
+  afterAll(async () => {
+    if (api) await api.disconnect();
+    if (appCtx) teardown(appCtx);
+  });
+
+  test(
+    "submit 3 records → on-chain → query → aggregate matches",
+    async () => {
+      const keyring = new Keyring({ type: "sr25519" });
+      const tenantId = "ten-blive-" + Date.now().toString(36);
+      const alice = keyring.addFromUri("//Alice");
+
+      const baseEnd = Date.now() - 30_000;
+      // 3 records, contiguous 5-min windows.
+      const submitted: Array<{
+        contentHash: string;
+        rec: ComputeMeteringV1;
+      }> = [];
+
+      for (let i = 0; i < 3; i++) {
+        const periodEnd = baseEnd - i * 5 * 60_000;
+        const periodStart = periodEnd - 5 * 60_000;
+        const workerPair = keyring.addFromUri(
+          "//ComputeWorkerLiveBilling" + Date.now() + "_" + i,
+        );
+        const baseBody = {
+          schema_version: SCHEMA_VERSION,
+          worker_id: "wkr-blive-" + Date.now().toString(36) + "-" + i,
+          tenant_id: tenantId,
+          period_start: periodStart,
+          period_end: periodEnd,
+          cpu_seconds: 12 + i,
+          ram_gb_hours: 0.1 + i * 0.01,
+          disk_gb_hours: 0.05,
+          net_bytes_in: 4096 + i * 1000,
+          net_bytes_out: 2048 + i * 500,
+          gpu_seconds: 0,
+          worker_pubkey: u8aToHex(workerPair.publicKey, undefined, false),
+        } as const;
+        const cb = canonicalBody(baseBody);
+        const sig = u8aToHex(workerPair.sign(cb), undefined, false);
+        const rec: ComputeMeteringV1 = { ...baseBody, worker_signature: sig };
+        const r = await call(appCtx.app, "POST", "/metering/submit", { body: rec });
+        expect(r.status).toBe(200);
+        const body = r.body as { content_hash: string };
+        submitted.push({ contentHash: body.content_hash, rec });
+      }
+      // eslint-disable-next-line no-console
+      console.log(
+        `[billing-live] submitted ${submitted.length} records for tenant ${tenantId}`,
+      );
+
+      // Submit each receipt on-chain with //Alice. Build by hand to set
+      // schema_hash explicitly (SDK's submitReceipt zeroes schema_hash
+      // — see metering_live_preprod.test.ts comment).
+      for (const s of submitted) {
+        const contentHashHex = s.contentHash;
+        const receiptId = computeReceiptId(contentHashHex);
+        const tx = (
+          api.tx as unknown as Record<
+            string,
+            Record<string, (...args: unknown[]) => unknown>
+          >
+        ).orinqReceipts.submitReceipt(
+          receiptId,
+          "0x" + contentHashHex,
+          "0x" + contentHashHex,
+          null,
+          null,
+          "0x" + contentHashHex,
+          "0x" + "00".repeat(32),
+          "0x" + "00".repeat(32),
+          "0x" + "00".repeat(32),
+          "0x" + "00".repeat(32),
+          "0x" + SCHEMA_HASH_HEX,
+        );
+        await new Promise<void>((resolve, reject) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tx as any).signAndSend(
+            alice,
+            { nonce: -1 },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ({ status, dispatchError }: any) => {
+              if (dispatchError) {
+                if (dispatchError.isModule) {
+                  const decoded = api.registry.findMetaError(
+                    dispatchError.asModule,
+                  );
+                  reject(
+                    new Error(
+                      `dispatch ${decoded.section}.${decoded.name}`,
+                    ),
+                  );
+                } else {
+                  reject(new Error(`dispatch ${String(dispatchError)}`));
+                }
+                return;
+              }
+              if (status.isInBlock) resolve();
+            },
+          );
+        });
+      }
+
+      // Wait for at least the first receipt to appear on chain.
+      // eslint-disable-next-line no-console
+      console.log(`[billing-live] receipts submitted, waiting for chain visibility`);
+      const deadline = Date.now() + RECEIPT_APPEAR_DEADLINE_MS;
+      while (Date.now() < deadline) {
+        const rid = computeReceiptId(submitted[0].contentHash);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result: any = await (api.query as any).orinqReceipts.receipts(rid);
+        if (!result.isEmpty) break;
+        await new Promise((r) => setTimeout(r, 3000));
+      }
+
+      // Optional: give cert-daemon a moment to pick up — don't fail.
+      await new Promise((r) => setTimeout(r, CERT_PROBE_DEADLINE_MS));
+
+      // Query the billing endpoint.
+      const start = Math.min(...submitted.map((s) => s.rec.period_start)) - 1000;
+      const end = Math.max(...submitted.map((s) => s.rec.period_end)) + 1000;
+      const res = await call(
+        appCtx.app,
+        "GET",
+        `/billing/usage?tenant_id=${tenantId}&start_ms=${start}&end_ms=${end}&include_records=true`,
+        { headers: { authorization: `Bearer ${appCtx.bearerToken}` } },
+      );
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        tenant_id: string;
+        aggregate: {
+          record_count: number;
+          certified_count: number;
+          anchored_count: number;
+          cpu_seconds_total: number;
+          ram_gb_hours_total: number;
+          net_bytes_in_total: number;
+          net_bytes_out_total: number;
+          unique_workers: number;
+        };
+        records: Array<{
+          worker_id: string;
+          content_hash: string;
+          schema_hash: string;
+          attestation_status: string;
+          attestation_cert_hash: string | null;
+          cardano_anchor_tx: string | null;
+          metrics: { cpu_seconds: number };
+        }>;
+        audit_trail: { schema_hash: string };
+      };
+
+      expect(body.tenant_id).toBe(tenantId);
+      expect(body.aggregate.record_count).toBe(3);
+      expect(body.audit_trail.schema_hash).toBe(SCHEMA_HASH_HEX);
+      expect(body.records).toHaveLength(3);
+
+      // Aggregate input sums match input records.
+      const expected_cpu = submitted.reduce((a, b) => a + b.rec.cpu_seconds, 0);
+      const expected_in = submitted.reduce((a, b) => a + b.rec.net_bytes_in, 0);
+      expect(body.aggregate.cpu_seconds_total).toBeCloseTo(expected_cpu, 6);
+      expect(body.aggregate.net_bytes_in_total).toBe(expected_in);
+      expect(body.aggregate.unique_workers).toBe(3);
+
+      // At least ONE record must NOT be "unknown" — chain RPC must be
+      // reachable for this test to be meaningful. We don't insist on
+      // certification (cert-daemon timing is independent of this route).
+      const reachable = body.records.some(
+        (r) => r.attestation_status !== "unknown",
+      );
+      expect(reachable).toBe(true);
+
+      // Each record's schema_hash echoes the constant.
+      for (const r of body.records) {
+        expect(r.schema_hash).toBe(SCHEMA_HASH_HEX);
+      }
+      // eslint-disable-next-line no-console
+      console.log(
+        `[billing-live] terminal aggregate=${JSON.stringify(body.aggregate)}`,
+      );
+      // eslint-disable-next-line no-console
+      for (const r of body.records) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[billing-live] record worker=${r.worker_id} status=${r.attestation_status} cert=${r.attestation_cert_hash} anchor=${r.cardano_anchor_tx}`,
+        );
+      }
+    },
+    /* timeout: */ RECEIPT_APPEAR_DEADLINE_MS + CERT_PROBE_DEADLINE_MS + 60_000,
+  );
+});

--- a/services/blob-gateway/src/__tests__/billing_route.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_route.test.ts
@@ -1,0 +1,1052 @@
+/**
+ * In-process integration tests for `GET /billing/usage`.
+ *
+ * The route is wired against:
+ *   - real schema validator (compute_metering_v1)
+ *   - real worker_bounds.ts in-memory sqlite
+ *   - real bearer-auth middleware (in-memory api_keys / api_tokens dbs)
+ *   - in-memory aggregate function (no mock)
+ *   - **mocked chain RPC** — `queryReceiptStatuses` is overridden via
+ *     module mock so we don't need a live Materios node here. The
+ *     LIVE_PREPROD test exercises the full chain leg end-to-end.
+ *   - **mocked anchor resolver** — same reason; we point the resolver at
+ *     a tmp checkpoint-history.json + log file so the mtime cache logic
+ *     is exercised under controlled inputs.
+ *
+ * What we cover:
+ *   - happy path (auth, params, full record echo, audit_trail)
+ *   - empty range → 200 zero-aggregate
+ *   - tenant isolation (records for other tenants must not leak)
+ *   - param validation: missing, malformed, out-of-window, bad cursor
+ *   - pagination round-trip across two pages
+ *   - large result set (page_size cap)
+ *   - replay-friendly: same query → same result (idempotent reads)
+ *   - mixed states: one certified+anchored, one certified-only, one pending
+ *
+ * What we DO NOT cover here (covered elsewhere):
+ *   - chain RPC failure (covered by chain_query_unit.test.ts? — exercised
+ *     here via the `apiOverride` injection path of `queryReceiptStatuses`)
+ *   - LIVE preprod end-to-end (covered by `billing_live_preprod.test.ts`)
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  vi,
+} from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Keyring } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+import { createHash, randomBytes } from "crypto";
+
+import { config } from "../config.js";
+import { meteringRouter } from "../routes/metering.js";
+import {
+  initWorkerBoundsDb,
+  setWorkerBoundsDbForTests,
+} from "../worker_bounds.js";
+import {
+  canonicalBody,
+  SCHEMA_VERSION,
+  SCHEMA_HASH_HEX,
+  type ComputeMeteringV1,
+} from "../schemas/compute_metering_v1.js";
+import {
+  initApiTokensDb,
+  setApiTokensDb,
+  issueToken,
+} from "../api-tokens.js";
+import {
+  setQuotaDbForTests,
+  migrateBindingColumn,
+} from "../quota.js";
+
+// We mock the chain query to avoid a live RPC dependency in the route
+// tests. The aggregate test pins the math; this test pins the wiring.
+vi.mock("../billing/chain_query.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../billing/chain_query.js")>();
+  return {
+    ...actual,
+    queryReceiptStatuses: vi.fn(),
+  };
+});
+
+// Mock anchor resolver too — synthetic checkpoint-history.json + log
+// generation is covered by anchor_resolver_unit.test.ts.
+vi.mock("../billing/anchor_resolver.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../billing/anchor_resolver.js")>();
+  return {
+    ...actual,
+    resolveAnchorTxs: vi.fn(),
+  };
+});
+
+import { billingRouter } from "../routes/billing.js";
+import {
+  queryReceiptStatuses,
+  type ChainStatus,
+} from "../billing/chain_query.js";
+import { resolveAnchorTxs } from "../billing/anchor_resolver.js";
+
+const queryReceiptStatusesMock = vi.mocked(queryReceiptStatuses);
+const resolveAnchorTxsMock = vi.mocked(resolveAnchorTxs);
+
+let keyring: Keyring;
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+  keyring = new Keyring({ type: "sr25519" });
+});
+
+interface BuildOpts {
+  worker_id?: string;
+  tenant_id?: string;
+  period_start?: number;
+  period_end?: number;
+  cpu_seconds?: number;
+  ram_gb_hours?: number;
+  disk_gb_hours?: number;
+  net_bytes_in?: number;
+  net_bytes_out?: number;
+  gpu_seconds?: number;
+  uri?: string;
+}
+
+function buildSigned(opts: BuildOpts = {}): ComputeMeteringV1 {
+  const pair = keyring.addFromUri(opts.uri ?? "//ComputeWorker0");
+  const now = Date.now();
+  const period_end = opts.period_end ?? now - 5000;
+  const period_start = opts.period_start ?? period_end - 3_600_000;
+  const body = {
+    schema_version: SCHEMA_VERSION,
+    worker_id: opts.worker_id ?? "worker-int-001",
+    tenant_id: opts.tenant_id ?? "tenant-acme-1",
+    period_start,
+    period_end,
+    cpu_seconds: opts.cpu_seconds ?? 30,
+    ram_gb_hours: opts.ram_gb_hours ?? 0.5,
+    disk_gb_hours: opts.disk_gb_hours ?? 1,
+    net_bytes_in: opts.net_bytes_in ?? 1024,
+    net_bytes_out: opts.net_bytes_out ?? 512,
+    gpu_seconds: opts.gpu_seconds ?? 0,
+    worker_pubkey: u8aToHex(pair.publicKey, undefined, false),
+  } as const;
+  const cb = canonicalBody(body);
+  const sig = u8aToHex(pair.sign(cb), undefined, false);
+  return { ...body, worker_signature: sig };
+}
+
+interface Ctx {
+  app: express.Express;
+  storage: string;
+  prevStorage: string;
+  prevSubmitterUrl: string;
+  workerBoundsDb: Database.Database;
+  quotaDb: Database.Database;
+  tokensDb: Database.Database;
+  /** Plaintext bearer token authorised to call /billing/usage. */
+  bearerToken: string;
+}
+
+async function setupApp(): Promise<Ctx> {
+  const storage = mkdtempSync(join(tmpdir(), "billing-test-"));
+  const prevStorage = config.storagePath;
+  config.storagePath = storage;
+
+  // Sponsored-receipt submitter must be UNCONFIGURED for these tests
+  // (otherwise notifySponsoredReceiptSubmitter would try to fetch a real
+  // URL and time-out 5s into each test). Leave it empty so the metering
+  // route just persists locally.
+  const prevSubmitterUrl = config.sponsoredReceiptSubmitterUrl;
+  config.sponsoredReceiptSubmitterUrl = "";
+
+  const workerBoundsDb = new Database(":memory:");
+  initWorkerBoundsDb(workerBoundsDb);
+  setWorkerBoundsDbForTests(workerBoundsDb);
+
+  // Bearer auth machinery — quota.db (api_keys) + api_tokens.db tables.
+  const quotaDb = new Database(":memory:");
+  quotaDb.pragma("journal_mode = WAL");
+  quotaDb.exec(`
+    CREATE TABLE api_keys (
+      key_hash TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+      max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+      max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+      validator_id TEXT DEFAULT NULL
+    );
+  `);
+  migrateBindingColumn(quotaDb);
+  setQuotaDbForTests(quotaDb);
+
+  const tokensDb = new Database(":memory:");
+  tokensDb.pragma("journal_mode = WAL");
+  initApiTokensDb(tokensDb);
+  setApiTokensDb(tokensDb);
+
+  // Mint a Bearer token for an arbitrary SS58 — we only need a valid
+  // bearer to satisfy bearerAuth({required:true}); the route doesn't
+  // currently enforce tenant_id ↔ bearer binding (deferred follow-up).
+  const ss58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"; // //Alice
+  const tok = issueToken(tokensDb, {
+    accountSs58: ss58,
+    label: "billing-route-test",
+  });
+
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.use(meteringRouter);
+  app.use(billingRouter);
+
+  return {
+    app,
+    storage,
+    prevStorage,
+    prevSubmitterUrl,
+    workerBoundsDb,
+    quotaDb,
+    tokensDb,
+    bearerToken: tok.token,
+  };
+}
+
+async function teardown(ctx: Ctx): Promise<void> {
+  config.storagePath = ctx.prevStorage;
+  config.sponsoredReceiptSubmitterUrl = ctx.prevSubmitterUrl;
+  rmSync(ctx.storage, { recursive: true, force: true });
+  ctx.workerBoundsDb.close();
+  ctx.quotaDb.close();
+  ctx.tokensDb.close();
+}
+
+interface FetchInit {
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+async function call(
+  app: express.Express,
+  method: string,
+  path: string,
+  init: FetchInit = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const headers: Record<string, string> = {
+        ...(init.headers ?? {}),
+      };
+      const opts: RequestInit = { method, headers };
+      if (init.body !== undefined) {
+        headers["content-type"] = "content-type" in headers ? headers["content-type"] : "application/json";
+        opts.body = JSON.stringify(init.body);
+      }
+      fetch(url, opts)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+/** Helper: submit a record AND receive its content_hash. */
+async function submitOne(
+  ctx: Ctx,
+  opts: BuildOpts = {},
+): Promise<{ content_hash: string; record: ComputeMeteringV1 }> {
+  const r = buildSigned(opts);
+  const res = await call(ctx.app, "POST", "/metering/submit", { body: r });
+  if (res.status !== 200) {
+    throw new Error(
+      `submit failed ${res.status}: ${JSON.stringify(res.body)}`,
+    );
+  }
+  const body = res.body as { content_hash: string };
+  return { content_hash: body.content_hash, record: r };
+}
+
+beforeEach(() => {
+  // Default mocks: every receipt is "unknown" (chain RPC degraded), no
+  // anchor txs. Specific tests override per-call.
+  queryReceiptStatusesMock.mockImplementation(async (hashes) =>
+    hashes.map((h) => ({
+      content_hash: h,
+      receipt_id: "0x" + createHash("sha256").update(Buffer.from(h, "hex")).digest("hex"),
+      status: "unknown",
+      cert_hash: null,
+    } satisfies ChainStatus)),
+  );
+  resolveAnchorTxsMock.mockImplementation(async (certs) =>
+    certs.map(() => null),
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /billing/usage — auth", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("missing Bearer → 401", async () => {
+    const res = await call(
+      ctx.app,
+      "GET",
+      "/billing/usage?tenant_id=tenant-acme-1&start_ms=1&end_ms=2",
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("malformed Bearer → 401", async () => {
+    const res = await call(
+      ctx.app,
+      "GET",
+      "/billing/usage?tenant_id=tenant-acme-1&start_ms=1&end_ms=2",
+      { headers: { authorization: "Bearer matra_not_a_real_token" } },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("valid Bearer → 200 even with zero records", async () => {
+    const res = await call(
+      ctx.app,
+      "GET",
+      "/billing/usage?tenant_id=tenant-empty-1&start_ms=1&end_ms=2",
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { aggregate: { record_count: number } }).aggregate.record_count).toBe(0);
+  });
+});
+
+describe("GET /billing/usage — query-param validation", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  function authed(path: string) {
+    return call(ctx.app, "GET", path, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+    });
+  }
+
+  test("missing tenant_id → 400 with field=tenant_id", async () => {
+    const r = await authed("/billing/usage?start_ms=1&end_ms=2");
+    expect(r.status).toBe(400);
+    expect((r.body as { field: string }).field).toBe("tenant_id");
+  });
+
+  test("missing start_ms → 400 with field=start_ms", async () => {
+    const r = await authed("/billing/usage?tenant_id=tenant-acme-1&end_ms=2");
+    expect(r.status).toBe(400);
+    expect((r.body as { field: string }).field).toBe("start_ms");
+  });
+
+  test("missing end_ms → 400 with field=end_ms", async () => {
+    const r = await authed("/billing/usage?tenant_id=tenant-acme-1&start_ms=1");
+    expect(r.status).toBe(400);
+    expect((r.body as { field: string }).field).toBe("end_ms");
+  });
+
+  test("malformed tenant_id → 400 BAD_PARAM", async () => {
+    const r = await authed("/billing/usage?tenant_id=BAD_UPPER&start_ms=1&end_ms=2");
+    expect(r.status).toBe(400);
+    expect((r.body as { error: string }).error).toBe("BAD_PARAM");
+    expect((r.body as { field: string }).field).toBe("tenant_id");
+  });
+
+  test("non-integer start_ms → 400", async () => {
+    const r = await authed(
+      "/billing/usage?tenant_id=tenant-acme-1&start_ms=abc&end_ms=2",
+    );
+    expect(r.status).toBe(400);
+    expect((r.body as { field: string }).field).toBe("start_ms");
+  });
+
+  test("end_ms <= start_ms → 400 BAD_WINDOW", async () => {
+    const r = await authed(
+      "/billing/usage?tenant_id=tenant-acme-1&start_ms=10&end_ms=5",
+    );
+    expect(r.status).toBe(400);
+    expect((r.body as { error: string }).error).toBe("BAD_WINDOW");
+  });
+
+  test("end_ms === start_ms → 400 BAD_WINDOW", async () => {
+    const r = await authed(
+      "/billing/usage?tenant_id=tenant-acme-1&start_ms=10&end_ms=10",
+    );
+    expect(r.status).toBe(400);
+    expect((r.body as { error: string }).error).toBe("BAD_WINDOW");
+  });
+
+  test("window > 90 days → 400 BAD_WINDOW", async () => {
+    const ninety = 90 * 24 * 60 * 60 * 1000;
+    const r = await authed(
+      `/billing/usage?tenant_id=tenant-acme-1&start_ms=0&end_ms=${ninety + 1}`,
+    );
+    expect(r.status).toBe(400);
+    expect((r.body as { error: string }).error).toBe("BAD_WINDOW");
+  });
+
+  test("window === 90 days → accepted", async () => {
+    const ninety = 90 * 24 * 60 * 60 * 1000;
+    const r = await authed(
+      `/billing/usage?tenant_id=tenant-acme-1&start_ms=0&end_ms=${ninety}`,
+    );
+    expect(r.status).toBe(200);
+  });
+
+  test("page_size out of range → 400", async () => {
+    const r = await authed(
+      "/billing/usage?tenant_id=tenant-acme-1&start_ms=1&end_ms=2&page_size=999",
+    );
+    expect(r.status).toBe(400);
+    expect((r.body as { field: string }).field).toBe("page_size");
+  });
+
+  test("negative page_size → 400", async () => {
+    const r = await authed(
+      "/billing/usage?tenant_id=tenant-acme-1&start_ms=1&end_ms=2&page_size=-1",
+    );
+    expect(r.status).toBe(400);
+  });
+
+  test("malformed cursor → 400", async () => {
+    const r = await authed(
+      "/billing/usage?tenant_id=tenant-acme-1&start_ms=1&end_ms=2&cursor=garbage!@#",
+    );
+    expect(r.status).toBe(400);
+    expect((r.body as { field: string }).field).toBe("cursor");
+  });
+});
+
+describe("GET /billing/usage — happy path", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("nonexistent tenant in window → 200 zero-aggregate (NOT 404)", async () => {
+    const res = await call(
+      ctx.app,
+      "GET",
+      "/billing/usage?tenant_id=nope-no-such&start_ms=1&end_ms=2",
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const b = res.body as {
+      tenant_id: string;
+      aggregate: { record_count: number; first_record_ms: null };
+      records?: unknown[];
+    };
+    expect(b.tenant_id).toBe("nope-no-such");
+    expect(b.aggregate.record_count).toBe(0);
+    expect(b.aggregate.first_record_ms).toBeNull();
+    // include_records defaults false → no records[] in body
+    expect(b.records).toBeUndefined();
+  });
+
+  test("aggregate sums match input across multiple records", async () => {
+    const tenant = "tenant-sumtest";
+    // Three records, each 1h apart, same worker.
+    const baseEnd = Date.now() - 60_000;
+    await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-sum-1",
+      uri: "//ComputeWorkerSum",
+      cpu_seconds: 10,
+      ram_gb_hours: 0.1,
+      net_bytes_in: 1000,
+      net_bytes_out: 2000,
+      period_end: baseEnd - 2 * 3_600_000,
+      period_start: baseEnd - 3 * 3_600_000,
+    });
+    await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-sum-1",
+      uri: "//ComputeWorkerSum",
+      cpu_seconds: 20,
+      ram_gb_hours: 0.2,
+      net_bytes_in: 3000,
+      net_bytes_out: 4000,
+      period_end: baseEnd - 1 * 3_600_000,
+      period_start: baseEnd - 2 * 3_600_000,
+    });
+    await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-sum-1",
+      uri: "//ComputeWorkerSum",
+      cpu_seconds: 30,
+      ram_gb_hours: 0.3,
+      net_bytes_in: 5000,
+      net_bytes_out: 6000,
+      period_end: baseEnd,
+      period_start: baseEnd - 1 * 3_600_000,
+    });
+
+    const start = baseEnd - 5 * 3_600_000;
+    const end = baseEnd + 1000;
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${start}&end_ms=${end}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const b = res.body as {
+      aggregate: {
+        record_count: number;
+        cpu_seconds_total: number;
+        ram_gb_hours_total: number;
+        net_bytes_in_total: number;
+        net_bytes_out_total: number;
+        unique_workers: number;
+      };
+      records: Array<{ content_hash: string; metrics: { cpu_seconds: number } }>;
+      audit_trail: { schema_hash: string; gateway_db_query_ms: number };
+    };
+    expect(b.aggregate.record_count).toBe(3);
+    expect(b.aggregate.cpu_seconds_total).toBeCloseTo(60, 6);
+    expect(b.aggregate.ram_gb_hours_total).toBeCloseTo(0.6, 6);
+    expect(b.aggregate.net_bytes_in_total).toBe(9000);
+    expect(b.aggregate.net_bytes_out_total).toBe(12000);
+    expect(b.aggregate.unique_workers).toBe(1);
+    expect(b.records).toHaveLength(3);
+    expect(b.audit_trail.schema_hash).toBe(SCHEMA_HASH_HEX);
+    expect(b.audit_trail.gateway_db_query_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  test("tenant isolation: tenant A's query never sees tenant B records", async () => {
+    const baseEnd = Date.now() - 60_000;
+    await submitOne(ctx, {
+      tenant_id: "tenant-iso-a",
+      worker_id: "wkr-iso-a",
+      uri: "//ComputeWorkerIsoA",
+      period_start: baseEnd - 3_600_000,
+      period_end: baseEnd,
+    });
+    await submitOne(ctx, {
+      tenant_id: "tenant-iso-b",
+      worker_id: "wkr-iso-b",
+      uri: "//ComputeWorkerIsoB",
+      period_start: baseEnd - 3_600_000,
+      period_end: baseEnd,
+    });
+    const start = baseEnd - 5 * 3_600_000;
+    const end = baseEnd + 1000;
+    const aRes = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=tenant-iso-a&start_ms=${start}&end_ms=${end}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(aRes.status).toBe(200);
+    const ab = aRes.body as {
+      aggregate: { record_count: number };
+      records: Array<{ worker_id: string }>;
+    };
+    expect(ab.aggregate.record_count).toBe(1);
+    expect(ab.records[0].worker_id).toBe("wkr-iso-a");
+  });
+
+  test("time-window: records with period_start === start_ms are included", async () => {
+    const tenant = "tenant-window";
+    const baseEnd = Date.now() - 60_000;
+    const periodStart = baseEnd - 3_600_000;
+    await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-window-1",
+      uri: "//ComputeWorkerWindow1",
+      period_start: periodStart,
+      period_end: baseEnd,
+    });
+
+    // start_ms === record's period_start → included (inclusive lower bound)
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${periodStart}&end_ms=${periodStart + 3_600_001}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    expect(
+      (res.body as { aggregate: { record_count: number } }).aggregate.record_count,
+    ).toBe(1);
+  });
+
+  test("time-window: records with period_start === end_ms are EXCLUDED", async () => {
+    const tenant = "tenant-window-ex";
+    const baseEnd = Date.now() - 60_000;
+    const periodStart = baseEnd - 3_600_000;
+    await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-window-2",
+      uri: "//ComputeWorkerWindow2",
+      period_start: periodStart,
+      period_end: baseEnd,
+    });
+
+    // end_ms === period_start → record at upper boundary is EXCLUDED.
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${periodStart - 1000}&end_ms=${periodStart}`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    expect(
+      (res.body as { aggregate: { record_count: number } }).aggregate.record_count,
+    ).toBe(0);
+  });
+
+  test("idempotent reads: same query → same result twice", async () => {
+    const tenant = "tenant-idem";
+    const baseEnd = Date.now() - 60_000;
+    await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-idem-1",
+      uri: "//ComputeWorkerIdem",
+      period_start: baseEnd - 3_600_000,
+      period_end: baseEnd,
+    });
+    const url = `/billing/usage?tenant_id=${tenant}&start_ms=${baseEnd - 5 * 3_600_000}&end_ms=${baseEnd + 1000}&include_records=true`;
+    const r1 = await call(ctx.app, "GET", url, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+    });
+    const r2 = await call(ctx.app, "GET", url, {
+      headers: { authorization: `Bearer ${ctx.bearerToken}` },
+    });
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    // Strip the period.now_ms field which IS time-dependent; everything
+    // else MUST be byte-identical for a "verifiable" billing query.
+    const stripNow = (b: unknown): unknown => {
+      const obj = JSON.parse(JSON.stringify(b)) as {
+        period: { now_ms: number };
+        audit_trail: {
+          gateway_db_query_ms: number;
+          chain_query_ms: number;
+          anchor_resolution_ms: number;
+        };
+      };
+      obj.period.now_ms = 0;
+      // Audit-trail timing fields are also non-deterministic; zero them.
+      obj.audit_trail.gateway_db_query_ms = 0;
+      obj.audit_trail.chain_query_ms = 0;
+      obj.audit_trail.anchor_resolution_ms = 0;
+      return obj;
+    };
+    expect(stripNow(r1.body)).toEqual(stripNow(r2.body));
+  });
+});
+
+describe("GET /billing/usage — chain status integration", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("certified+anchored vs certified+not-anchored vs pending", async () => {
+    const tenant = "tenant-mixed";
+    const baseEnd = Date.now() - 60_000;
+    const a = await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-mixed-a",
+      uri: "//ComputeWorkerMixedA",
+      period_start: baseEnd - 3 * 3_600_000,
+      period_end: baseEnd - 2 * 3_600_000,
+    });
+    const b = await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-mixed-b",
+      uri: "//ComputeWorkerMixedB",
+      period_start: baseEnd - 2 * 3_600_000,
+      period_end: baseEnd - 1 * 3_600_000,
+    });
+    const c = await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-mixed-c",
+      uri: "//ComputeWorkerMixedC",
+      period_start: baseEnd - 1 * 3_600_000,
+      period_end: baseEnd,
+    });
+
+    const certHashA = "0x" + "aa".repeat(32);
+    const certHashB = "0x" + "bb".repeat(32);
+    const txA = "cc".repeat(32);
+
+    queryReceiptStatusesMock.mockImplementation(async (hashes) =>
+      hashes.map((h) => {
+        if (h === a.content_hash) {
+          return {
+            content_hash: h,
+            receipt_id: "0x" + createHash("sha256").update(Buffer.from(h, "hex")).digest("hex"),
+            status: "certified",
+            cert_hash: certHashA,
+          };
+        }
+        if (h === b.content_hash) {
+          return {
+            content_hash: h,
+            receipt_id: "0x" + createHash("sha256").update(Buffer.from(h, "hex")).digest("hex"),
+            status: "certified",
+            cert_hash: certHashB,
+          };
+        }
+        // c is still pending
+        return {
+          content_hash: h,
+          receipt_id: "0x" + createHash("sha256").update(Buffer.from(h, "hex")).digest("hex"),
+          status: "pending",
+          cert_hash: null,
+        };
+      }),
+    );
+    resolveAnchorTxsMock.mockImplementation(async (certs) =>
+      certs.map((cert) => {
+        if (cert === certHashA) return txA;
+        return null;
+      }),
+    );
+
+    const start = baseEnd - 5 * 3_600_000;
+    const end = baseEnd + 1000;
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${start}&end_ms=${end}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      aggregate: {
+        record_count: number;
+        certified_count: number;
+        anchored_count: number;
+      };
+      records: Array<{
+        content_hash: string;
+        attestation_status: string;
+        attestation_cert_hash: string | null;
+        cardano_anchor_tx: string | null;
+      }>;
+    };
+    expect(body.aggregate.record_count).toBe(3);
+    expect(body.aggregate.certified_count).toBe(2);
+    expect(body.aggregate.anchored_count).toBe(1);
+
+    // Find each record by content_hash and check states.
+    const byCh = new Map(body.records.map((r) => [r.content_hash, r]));
+    const recA = byCh.get(a.content_hash);
+    const recB = byCh.get(b.content_hash);
+    const recC = byCh.get(c.content_hash);
+    expect(recA?.attestation_status).toBe("certified");
+    expect(recA?.attestation_cert_hash).toBe(certHashA);
+    expect(recA?.cardano_anchor_tx).toBe("0x" + txA);
+
+    expect(recB?.attestation_status).toBe("certified");
+    expect(recB?.attestation_cert_hash).toBe(certHashB);
+    expect(recB?.cardano_anchor_tx).toBeNull();
+
+    expect(recC?.attestation_status).toBe("pending");
+    expect(recC?.attestation_cert_hash).toBeNull();
+    expect(recC?.cardano_anchor_tx).toBeNull();
+  });
+
+  test("RPC unavailable → all records 'unknown' but query still 200", async () => {
+    const tenant = "tenant-rpcfail";
+    const baseEnd = Date.now() - 60_000;
+    await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-rpcfail",
+      uri: "//ComputeWorkerRpcFail",
+      period_start: baseEnd - 3_600_000,
+      period_end: baseEnd,
+    });
+    // Default mock already returns "unknown" for every hash.
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${baseEnd - 2 * 3_600_000}&end_ms=${baseEnd + 1000}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      aggregate: { certified_count: number; anchored_count: number };
+      records: Array<{ attestation_status: string; cardano_anchor_tx: string | null }>;
+    };
+    expect(body.aggregate.certified_count).toBe(0);
+    expect(body.aggregate.anchored_count).toBe(0);
+    expect(body.records[0].attestation_status).toBe("unknown");
+    expect(body.records[0].cardano_anchor_tx).toBeNull();
+  });
+});
+
+describe("GET /billing/usage — pagination + large result", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  async function fillN(n: number, tenant: string): Promise<void> {
+    const baseEnd = Date.now() - 60_000;
+    // Stagger period_start so they're naturally ordered.
+    for (let i = 0; i < n; i++) {
+      const periodStart = baseEnd - (n - i + 1) * 3_600_000;
+      const periodEnd = periodStart + 3_600_000;
+      const seed = randomBytes(8).toString("hex");
+      await submitOne(ctx, {
+        tenant_id: tenant,
+        worker_id: `wkr-page-${i}`,
+        uri: `//Worker${seed}`,
+        period_start: periodStart,
+        period_end: periodEnd,
+      });
+    }
+  }
+
+  test("page_size=2 with 5 records → 3 pages, all unique, no duplicates", async () => {
+    const tenant = "tenant-paged";
+    await fillN(5, tenant);
+    const seen = new Set<string>();
+    let cursor: string | null = null;
+    let pages = 0;
+    while (true) {
+      pages += 1;
+      if (pages > 10) throw new Error("pagination loop too long");
+      const cursorParam = cursor ? `&cursor=${cursor}` : "";
+      const start_ms = Date.now() - 60 * 24 * 3_600_000; // 60 days ago
+      const end_ms = Date.now() + 1000;
+      const res = await call(
+        ctx.app,
+        "GET",
+        `/billing/usage?tenant_id=${tenant}&start_ms=${start_ms}&end_ms=${end_ms}&include_records=true&page_size=2${cursorParam}`,
+        { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+      );
+      expect(res.status).toBe(200);
+      const b = res.body as {
+        records: Array<{ content_hash: string }>;
+        next_cursor: string | null;
+      };
+      for (const r of b.records) {
+        expect(seen.has(r.content_hash)).toBe(false);
+        seen.add(r.content_hash);
+      }
+      if (b.next_cursor === null) break;
+      cursor = b.next_cursor;
+    }
+    expect(seen.size).toBe(5);
+  });
+
+  test("default page_size=100, large set capped", async () => {
+    const tenant = "tenant-large";
+    // Submit 12 records — well under default 100. We just check the
+    // default works; large-set cap is enforced by page_size validation.
+    await fillN(12, tenant);
+    const start_ms = Date.now() - 60 * 24 * 3_600_000;
+    const end_ms = Date.now() + 1000;
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${start_ms}&end_ms=${end_ms}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const b = res.body as {
+      aggregate: { record_count: number };
+      records: Array<unknown>;
+      next_cursor: string | null;
+    };
+    expect(b.aggregate.record_count).toBe(12);
+    expect(b.records).toHaveLength(12);
+    expect(b.next_cursor).toBeNull();
+  });
+});
+
+describe("GET /billing/usage — partial certification + replay", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("partial certification: 5 records, 2 certified, 1 anchored", async () => {
+    const tenant = "tenant-partial";
+    const baseEnd = Date.now() - 60_000;
+    const submitted: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const r = await submitOne(ctx, {
+        tenant_id: tenant,
+        worker_id: `wkr-pc-${i}`,
+        uri: `//ComputeWorkerPC${i}`,
+        period_start: baseEnd - (i + 1) * 3_600_000,
+        period_end: baseEnd - i * 3_600_000,
+      });
+      submitted.push(r.content_hash);
+    }
+
+    const certified = new Set([submitted[0], submitted[2]]);
+    const anchorTxByCert = new Map<string, string>();
+    const certHash0 = "0x" + "10".repeat(32);
+    const certHash2 = "0x" + "20".repeat(32);
+    anchorTxByCert.set(certHash0, "ee".repeat(32));
+
+    queryReceiptStatusesMock.mockImplementation(async (hashes) =>
+      hashes.map((h) => {
+        if (h === submitted[0]) {
+          return {
+            content_hash: h,
+            receipt_id: "0x" + createHash("sha256").update(Buffer.from(h, "hex")).digest("hex"),
+            status: "certified",
+            cert_hash: certHash0,
+          };
+        }
+        if (h === submitted[2]) {
+          return {
+            content_hash: h,
+            receipt_id: "0x" + createHash("sha256").update(Buffer.from(h, "hex")).digest("hex"),
+            status: "certified",
+            cert_hash: certHash2,
+          };
+        }
+        return {
+          content_hash: h,
+          receipt_id: "0x" + createHash("sha256").update(Buffer.from(h, "hex")).digest("hex"),
+          status: "pending",
+          cert_hash: null,
+        };
+      }),
+    );
+    resolveAnchorTxsMock.mockImplementation(async (certs) =>
+      certs.map((c) => (c ? anchorTxByCert.get(c) ?? null : null)),
+    );
+
+    const start_ms = Date.now() - 60 * 24 * 3_600_000;
+    const end_ms = Date.now() + 1000;
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${start_ms}&end_ms=${end_ms}`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const b = res.body as {
+      aggregate: {
+        record_count: number;
+        certified_count: number;
+        anchored_count: number;
+      };
+    };
+    expect(b.aggregate.record_count).toBe(5);
+    expect(b.aggregate.certified_count).toBe(2);
+    expect(b.aggregate.anchored_count).toBe(1);
+    void certified;
+  });
+
+  test("replay tolerance: re-submit same record → same content_hash, no double-count", async () => {
+    const tenant = "tenant-replay";
+    const baseEnd = Date.now() - 60_000;
+    const r1 = buildSigned({
+      tenant_id: tenant,
+      worker_id: "wkr-replay-1",
+      uri: "//ComputeWorkerReplay",
+      period_start: baseEnd - 3_600_000,
+      period_end: baseEnd,
+    });
+    const a = await call(ctx.app, "POST", "/metering/submit", { body: r1 });
+    expect(a.status).toBe(200);
+    // Re-submit the EXACT SAME record → metering route returns "replay" but
+    // never appends a new metering_submissions row (PRIMARY KEY = content_hash
+    // means INSERT OR IGNORE drops the duplicate).
+    const b = await call(ctx.app, "POST", "/metering/submit", { body: r1 });
+    expect(b.status).toBe(200);
+    expect((b.body as { status: string }).status).toBe("replay");
+    const start_ms = Date.now() - 60 * 24 * 3_600_000;
+    const end_ms = Date.now() + 1000;
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${start_ms}&end_ms=${end_ms}`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { aggregate: { record_count: number } }).aggregate.record_count).toBe(1);
+  });
+});
+
+// Anti-injection: tenant_id is regex-validated server-side, but we also
+// confirm a SQL-injection attempt fails the regex check (so it never
+// reaches the prepared statement).
+describe("GET /billing/usage — tenant_id injection guard", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("' OR 1=1 -- → 400 BAD_PARAM (regex blocks it)", async () => {
+    const evil = encodeURIComponent("' OR 1=1 --");
+    const r = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${evil}&start_ms=1&end_ms=2`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(r.status).toBe(400);
+    expect((r.body as { field: string }).field).toBe("tenant_id");
+  });
+});
+
+

--- a/services/blob-gateway/src/__tests__/billing_tenant_binding.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_tenant_binding.test.ts
@@ -1,0 +1,624 @@
+/**
+ * Task #119 — cross-tenant data-leak fix on /billing/usage.
+ *
+ * Test plan (matches the PR brief):
+ *   1. issue token w/ tenant_id="ten-a" → query usage(tenant_id="ten-a") → 200
+ *   2. issue token w/ tenant_id="ten-a" → query usage(tenant_id="ten-b") → 403
+ *   3. issue token w/ NO tenant_id     → query usage(tenant_id="ten-Anything") → 200 (legacy)
+ *   4. issue token w/ tenant_id="ten-a" → query usage with NO tenant_id param → 400
+ *   5. migration against a fresh SQLite DB: a row inserted on the OLD schema
+ *      (no tenant_id column) survives the ALTER, ends up with tenant_id NULL,
+ *      and remains usable via /billing/usage as legacy/admin tier.
+ *
+ * Plus belt-and-suspenders coverage of:
+ *   - bindTokenToTenant() helper (post-issuance binding + clearing).
+ *   - migrate idempotency (running the migration twice on a fresh DB).
+ *   - 401 on missing/malformed/revoked Bearer.
+ *
+ * The chain query is mocked (these tests focus on auth, not aggregation).
+ * In-memory SQLite is used throughout — no /data/blobs file is touched.
+ */
+
+import { describe, test, expect, beforeEach, vi } from "vitest";
+
+// rpc-client + notify mocks mirror usage-tracking.test.ts so even the
+// indirect imports don't reach for a live websocket.
+vi.mock("../rpc-client.js", () => ({
+  checkFunded: vi.fn(async () => true),
+  checkReceiptStatus: vi.fn(async () => "not_found" as const),
+  disconnectRpc: vi.fn(async () => {}),
+}));
+vi.mock("../notify.js", () => ({
+  notifyDaemon: vi.fn(async () => {}),
+}));
+
+import express from "express";
+import Database from "better-sqlite3";
+import { createHash, randomBytes } from "crypto";
+
+import {
+  initApiTokensDb,
+  setApiTokensDb,
+  issueToken,
+  bindTokenToTenant,
+  verifyToken,
+  migrateTenantBindingColumn,
+  hashToken,
+  TOKEN_PREFIX,
+} from "../api-tokens.js";
+import {
+  setQuotaDbForTests,
+  migrateUsageColumns,
+  migrateBindingColumn,
+  recordUsage,
+} from "../quota.js";
+import { billingRouter } from "../routes/billing.js";
+import { registerTokenRoutes } from "../routes/tokens.js";
+import { initWorkerBoundsDb, setWorkerBoundsDbForTests } from "../worker_bounds.js";
+
+// Mock the chain-status + anchor-resolution modules so this suite stays
+// focused on auth/tenant binding (no live RPC, no SSH).
+vi.mock("../billing/chain_query.js", async () => {
+  const actual = await vi.importActual<typeof import("../billing/chain_query.js")>(
+    "../billing/chain_query.js",
+  );
+  return {
+    ...actual,
+    queryReceiptStatuses: vi.fn(async () => []),
+  };
+});
+vi.mock("../billing/anchor_resolver.js", async () => {
+  const actual = await vi.importActual<typeof import("../billing/anchor_resolver.js")>(
+    "../billing/anchor_resolver.js",
+  );
+  return {
+    ...actual,
+    resolveAnchorTxs: vi.fn(async () => []),
+  };
+});
+
+// --------------------------------------------------------------------------
+// DB fixtures + small HTTP helper
+// --------------------------------------------------------------------------
+
+/** Build the api_tokens DB shape we ship to prod (after task #119 migration). */
+function makeTokensDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = WAL");
+  initApiTokensDb(db);
+  setApiTokensDb(db);
+  return db;
+}
+
+/** Build a quota DB whose api_keys row carries the Phase 1 usage columns. */
+function makeQuotaDb(): Database.Database {
+  const quotaDb = new Database(":memory:");
+  quotaDb.pragma("journal_mode = WAL");
+  quotaDb.exec(`
+    CREATE TABLE api_keys (
+      key_hash TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+      max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+      max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+      validator_id TEXT DEFAULT NULL
+    );
+    CREATE TABLE quota_daily (
+      key_hash TEXT NOT NULL,
+      day TEXT NOT NULL,
+      receipts INTEGER NOT NULL DEFAULT 0,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (key_hash, day)
+    );
+  `);
+  migrateUsageColumns(quotaDb);
+  migrateBindingColumn(quotaDb);
+  setQuotaDbForTests(quotaDb);
+  return quotaDb;
+}
+
+/** Insert a single api_keys row tied to an SS58. */
+function seedApiKey(
+  quotaDb: Database.Database,
+  opts: { ss58: string; maxReceipts?: number; maxBytes?: number },
+): { keyHash: string } {
+  const plaintext = randomBytes(32).toString("hex");
+  const keyHash = createHash("sha256").update(plaintext).digest("hex");
+  quotaDb
+    .prepare(
+      `INSERT INTO api_keys
+       (key_hash, name, enabled, max_receipts_per_day, max_bytes_per_day, max_concurrent_uploads, validator_id)
+       VALUES (?, ?, 1, ?, ?, 5, ?)`,
+    )
+    .run(
+      keyHash,
+      "billing-test",
+      opts.maxReceipts ?? 100,
+      opts.maxBytes ?? 1073741824,
+      opts.ss58,
+    );
+  return { keyHash };
+}
+
+/**
+ * Stand up a fresh Express app with the billing routes mounted. Each call
+ * builds isolated in-memory DBs so tests run in parallel without crosstalk.
+ */
+type Mounted = {
+  app: express.Express;
+  tokensDb: Database.Database;
+  quotaDb: Database.Database;
+  adminToken: string;
+};
+
+function setupApp(): Mounted {
+  const tokensDb = makeTokensDb();
+  const quotaDb = makeQuotaDb();
+  const adminToken = `admin-${randomBytes(16).toString("hex")}`;
+
+  // Worker-bounds DB hosts the metering_submissions table queried by
+  // /billing/usage. Empty for this suite — we focus on auth, not aggregates.
+  const wbDb = new Database(":memory:");
+  wbDb.pragma("journal_mode = WAL");
+  initWorkerBoundsDb(wbDb);
+  setWorkerBoundsDbForTests(wbDb);
+
+  const app = express();
+  app.use(express.json());
+  registerTokenRoutes(app, { adminToken });
+  app.use(billingRouter);
+
+  return { app, tokensDb, quotaDb, adminToken };
+}
+
+/** Helper: build a fully-qualified /billing/usage URL with sensible defaults. */
+function billingUrl(tenantId?: string | null, extra?: Record<string, string>): string {
+  const params = new URLSearchParams();
+  if (tenantId !== null && tenantId !== undefined) {
+    params.set("tenant_id", tenantId);
+  }
+  // Wide window so the tenant-binding suite never fails on time-window edge.
+  params.set("start_ms", "0");
+  params.set("end_ms", String(90 * 24 * 60 * 60 * 1000));
+  for (const [k, v] of Object.entries(extra ?? {})) params.set(k, v);
+  return `/billing/usage?${params.toString()}`;
+}
+
+async function fetchJson(
+  app: express.Express,
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { "content-type": "application/json", ...(opts.headers || {}) },
+      };
+      if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let body: unknown;
+          try {
+            body = text ? JSON.parse(text) : null;
+          } catch {
+            body = text;
+          }
+          server.close();
+          resolve({ status: res.status, body });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+// --------------------------------------------------------------------------
+// Suite 1 — schema migration (runs ALTER against fresh sqlite, real ALTER)
+// --------------------------------------------------------------------------
+
+describe("api_tokens migration: tenant_id column", () => {
+  test("fresh DB has tenant_id after initApiTokensDb", () => {
+    const db = new Database(":memory:");
+    db.pragma("journal_mode = WAL");
+    initApiTokensDb(db);
+    const cols = db
+      .prepare("PRAGMA table_info(api_tokens)")
+      .all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === "tenant_id")).toBe(true);
+  });
+
+  test("existing pre-migration tokens survive the ALTER and read as NULL tenant_id", () => {
+    // Recreate the OLD schema (no tenant_id column) and seed a row.
+    const db = new Database(":memory:");
+    db.pragma("journal_mode = WAL");
+    db.exec(`
+      CREATE TABLE api_tokens (
+        token_hash TEXT PRIMARY KEY,
+        account_ss58 TEXT NOT NULL,
+        label TEXT,
+        created_at INTEGER NOT NULL,
+        last_used_at INTEGER,
+        revoked_at INTEGER,
+        revoked_reason TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_account ON api_tokens(account_ss58);
+    `);
+    const legacyHash = "a".repeat(64);
+    db.prepare(
+      "INSERT INTO api_tokens (token_hash, account_ss58, label, created_at) VALUES (?, ?, ?, ?)",
+    ).run(legacyHash, "5LegacyOperator11111111111111111111111111111", "pre-119", 1);
+
+    // Apply the migration (idempotent helper exposed for direct test access).
+    migrateTenantBindingColumn(db);
+
+    const cols = db
+      .prepare("PRAGMA table_info(api_tokens)")
+      .all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === "tenant_id")).toBe(true);
+
+    // The legacy row must still be there, with tenant_id = NULL.
+    const row = db
+      .prepare("SELECT account_ss58, tenant_id FROM api_tokens WHERE token_hash = ?")
+      .get(legacyHash) as { account_ss58: string; tenant_id: string | null };
+    expect(row.account_ss58).toBe("5LegacyOperator11111111111111111111111111111");
+    expect(row.tenant_id).toBeNull();
+  });
+
+  test("migration is idempotent (safe to call twice)", () => {
+    const db = new Database(":memory:");
+    db.pragma("journal_mode = WAL");
+    db.exec(`
+      CREATE TABLE api_tokens (
+        token_hash TEXT PRIMARY KEY,
+        account_ss58 TEXT NOT NULL,
+        label TEXT,
+        created_at INTEGER NOT NULL,
+        last_used_at INTEGER,
+        revoked_at INTEGER,
+        revoked_reason TEXT
+      );
+    `);
+    migrateTenantBindingColumn(db);
+    expect(() => migrateTenantBindingColumn(db)).not.toThrow();
+    const cols = db
+      .prepare("PRAGMA table_info(api_tokens)")
+      .all() as Array<{ name: string }>;
+    expect(cols.filter((c) => c.name === "tenant_id").length).toBe(1);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Suite 2 — issueToken / bindTokenToTenant / verifyToken surface tenantId
+// --------------------------------------------------------------------------
+
+describe("api-tokens: tenant_id round-trip", () => {
+  test("issueToken with tenantId persists and verifyToken returns it", () => {
+    const db = makeTokensDb();
+    const { token, tenantId } = issueToken(db, {
+      accountSs58: "5RoundTripaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      label: "rt",
+      tenantId: "ten-rt",
+    });
+    expect(tenantId).toBe("ten-rt");
+
+    const v = verifyToken(db, token);
+    expect(v.valid).toBe(true);
+    if (!v.valid) throw new Error("unreachable");
+    expect(v.tenantId).toBe("ten-rt");
+  });
+
+  test("issueToken without tenantId yields tenantId=null", () => {
+    const db = makeTokensDb();
+    const { token, tenantId } = issueToken(db, {
+      accountSs58: "5NoTenantxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      label: "nt",
+    });
+    expect(tenantId).toBeNull();
+
+    const v = verifyToken(db, token);
+    expect(v.valid).toBe(true);
+    if (!v.valid) throw new Error("unreachable");
+    expect(v.tenantId).toBeNull();
+  });
+
+  test("bindTokenToTenant updates an existing token", () => {
+    const db = makeTokensDb();
+    const { token, tokenHash } = issueToken(db, {
+      accountSs58: "5Bindzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+      label: "bind",
+    });
+    expect(verifyToken(db, token).valid).toBe(true);
+
+    const ok = bindTokenToTenant(db, tokenHash, "ten-late-bind");
+    expect(ok).toBe(true);
+
+    const v = verifyToken(db, token);
+    expect(v.valid).toBe(true);
+    if (!v.valid) throw new Error("unreachable");
+    expect(v.tenantId).toBe("ten-late-bind");
+  });
+
+  test("bindTokenToTenant(null) clears the binding", () => {
+    const db = makeTokensDb();
+    const { token, tokenHash } = issueToken(db, {
+      accountSs58: "5Clearccccccccccccccccccccccccccccccccccccccc",
+      label: "clear",
+      tenantId: "ten-to-be-cleared",
+    });
+    bindTokenToTenant(db, tokenHash, null);
+    const v = verifyToken(db, token);
+    expect(v.valid).toBe(true);
+    if (!v.valid) throw new Error("unreachable");
+    expect(v.tenantId).toBeNull();
+  });
+
+  test("bindTokenToTenant returns false for unknown hash", () => {
+    const db = makeTokensDb();
+    const ok = bindTokenToTenant(db, "deadbeef".repeat(8), "ten-x");
+    expect(ok).toBe(false);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Suite 3 — /billing/usage enforcement (the actual P0 fix)
+// --------------------------------------------------------------------------
+
+describe("GET /billing/usage — task #119 tenant binding enforcement", () => {
+  let ctx: Mounted;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    ctx = setupApp();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  test("token bound to ten-A querying ten-A → 200", async () => {
+    const ss58 = "5TenAhappypath11111111111111111111111111111111";
+    const { keyHash } = seedApiKey(ctx.quotaDb, { ss58, maxReceipts: 50, maxBytes: 1024 });
+    recordUsage(keyHash, 256, 1);
+
+    const { token } = issueToken(ctx.tokensDb, {
+      accountSs58: ss58,
+      label: "ten-a",
+      tenantId: "ten-a",
+    });
+
+    const res = await fetchJson(ctx.app, "GET", billingUrl("ten-a"), {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      tenant_id: string;
+      aggregate: { record_count: number };
+    };
+    expect(body.tenant_id).toBe("ten-a");
+    // Empty result is the expected shape — no metering rows in this suite.
+    expect(body.aggregate.record_count).toBe(0);
+    void keyHash; // quotaDb seeded for legacy parity; new endpoint reads worker_bounds.
+  });
+
+  test("token bound to ten-A querying ten-B → 403 TOKEN_TENANT_MISMATCH", async () => {
+    const ss58A = "5TenAleakerxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    const ss58B = "5TenBvictimyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+    seedApiKey(ctx.quotaDb, { ss58: ss58A });
+    seedApiKey(ctx.quotaDb, { ss58: ss58B, maxReceipts: 999 });
+
+    const { token: tokenA } = issueToken(ctx.tokensDb, {
+      accountSs58: ss58A,
+      tenantId: "ten-a",
+    });
+
+    const res = await fetchJson(ctx.app, "GET", billingUrl("ten-b"), {
+      headers: { authorization: `Bearer ${tokenA}` },
+    });
+    expect(res.status).toBe(403);
+    const body = res.body as { error: string; message?: string };
+    expect(body.error).toBe("TOKEN_TENANT_MISMATCH");
+
+    // Audit log fired (cross-tenant probe attempt).
+    const calls = (warnSpy.mock.calls as unknown[][]).map((c) => c.join(" "));
+    const auditLog = calls.find((m: string) => m.includes("billing-tenant-mismatch"));
+    expect(auditLog, `audit log missing: ${JSON.stringify(calls)}`).toBeTruthy();
+    expect(auditLog).toContain("boundTenant=ten-a");
+    expect(auditLog).toContain("requestedTenant=ten-b");
+    // Raw token NEVER in the log.
+    expect(auditLog).not.toContain(tokenA);
+  });
+
+  test("legacy token with NO tenant_id → query usage(any tenant) → 200", async () => {
+    const ss58 = "5LegacyAdminhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh";
+    seedApiKey(ctx.quotaDb, { ss58 });
+
+    // Token minted WITHOUT a tenant_id — represents pre-task-119 tokens
+    // and admin/legacy tier going forward.
+    const { token, tenantId } = issueToken(ctx.tokensDb, {
+      accountSs58: ss58,
+      label: "legacy-admin",
+    });
+    expect(tenantId).toBeNull();
+
+    // Querying ANY tenant_id is allowed (admin/legacy tier). Note: the
+    // /billing/usage tenant_id regex is `[a-z0-9-]{4,64}` so we use names
+    // that satisfy it.
+    for (const t of ["ten-anything", "ten-notmine", "ten-flawless"]) {
+      const res = await fetchJson(
+        ctx.app,
+        "GET",
+        billingUrl(t),
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(res.status, `query ${t} failed`).toBe(200);
+      const body = res.body as { tenant_id: string };
+      expect(body.tenant_id).toBe(t);
+    }
+    void ss58;
+  });
+
+  test("token with tenant_id but NO tenant_id query param → 400", async () => {
+    const ss58 = "5MissingParammmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm";
+    seedApiKey(ctx.quotaDb, { ss58 });
+    const { token } = issueToken(ctx.tokensDb, {
+      accountSs58: ss58,
+      tenantId: "ten-a",
+    });
+
+    // Build a URL that ONLY has start/end_ms but no tenant_id.
+    const res = await fetchJson(
+      ctx.app,
+      "GET",
+      `/billing/usage?start_ms=0&end_ms=${90 * 24 * 60 * 60 * 1000}`,
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(res.status).toBe(400);
+    const body = res.body as { field?: string; error: string };
+    // New endpoint surfaces the field name explicitly.
+    expect(body.field ?? body.error).toContain("tenant_id");
+  });
+
+  test("post-issuance bindTokenToTenant takes effect on subsequent requests", async () => {
+    const ss58 = "5PostBindeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    seedApiKey(ctx.quotaDb, { ss58 });
+    const { token, tokenHash } = issueToken(ctx.tokensDb, {
+      accountSs58: ss58,
+      label: "post-bind",
+    });
+
+    // Pre-bind: legacy tier — querying any tenant works.
+    const pre = await fetchJson(ctx.app, "GET", billingUrl("ten-z"), {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(pre.status).toBe(200);
+
+    // Bind to ten-A.
+    const bound = bindTokenToTenant(ctx.tokensDb, tokenHash, "ten-a");
+    expect(bound).toBe(true);
+
+    // Post-bind: tenant_id=ten-z must now 403.
+    const post = await fetchJson(ctx.app, "GET", billingUrl("ten-z"), {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(post.status).toBe(403);
+
+    // But ten-A succeeds.
+    const ok = await fetchJson(ctx.app, "GET", billingUrl("ten-a"), {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(ok.status).toBe(200);
+  });
+
+  test("missing Bearer header → 401", async () => {
+    const res = await fetchJson(ctx.app, "GET", billingUrl("ten-a"));
+    expect(res.status).toBe(401);
+  });
+
+  test("malformed Bearer (wrong prefix) → 401", async () => {
+    const res = await fetchJson(ctx.app, "GET", billingUrl("ten-a"), {
+      headers: { authorization: "Bearer notmatra_garbage" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("unknown Bearer hash → 401", async () => {
+    const bogus = `${TOKEN_PREFIX}aAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa`;
+    const res = await fetchJson(ctx.app, "GET", billingUrl("ten-a"), {
+      headers: { authorization: `Bearer ${bogus}` },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("revoked Bearer → 401 (not 403)", async () => {
+    const ss58 = "5RevokedBearerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr";
+    seedApiKey(ctx.quotaDb, { ss58 });
+    const { token, tokenHash } = issueToken(ctx.tokensDb, {
+      accountSs58: ss58,
+      tenantId: "ten-a",
+    });
+    ctx.tokensDb
+      .prepare(
+        "UPDATE api_tokens SET revoked_at = ?, revoked_reason = ? WHERE token_hash = ?",
+      )
+      .run(1, "test", tokenHash);
+
+    const res = await fetchJson(ctx.app, "GET", billingUrl("ten-a"), {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Suite 4 — POST /auth/token accepts tenant_id (snake + camel) — admin path
+// --------------------------------------------------------------------------
+
+describe("POST /auth/token — tenant_id mint flow", () => {
+  let ctx: Mounted;
+  beforeEach(() => {
+    ctx = setupApp();
+  });
+
+  test("snake-case tenant_id is persisted and verifyable", async () => {
+    const res = await fetchJson(ctx.app, "POST", "/auth/token", {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: {
+        account: "5MintTenantSnakeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        label: "snake",
+        tenant_id: "ten-snake",
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { token: string; tokenHash: string; tenantId: string };
+    expect(body.tenantId).toBe("ten-snake");
+
+    const v = verifyToken(ctx.tokensDb, body.token);
+    expect(v.valid).toBe(true);
+    if (!v.valid) throw new Error("unreachable");
+    expect(v.tenantId).toBe("ten-snake");
+    expect(hashToken(body.token)).toBe(body.tokenHash);
+  });
+
+  test("camelCase tenantId also accepted", async () => {
+    const res = await fetchJson(ctx.app, "POST", "/auth/token", {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: {
+        account: "5MintTenantCamellllllllllllllllllllllllllllllll",
+        label: "camel",
+        tenantId: "ten-camel",
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { tenantId: string };
+    expect(body.tenantId).toBe("ten-camel");
+  });
+
+  test("mint without tenant_id stays null (legacy/admin)", async () => {
+    const res = await fetchJson(ctx.app, "POST", "/auth/token", {
+      headers: { "x-admin-token": ctx.adminToken },
+      body: {
+        account: "5MintNoTenantqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+        label: "legacy",
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { tenantId: string | null };
+    expect(body.tenantId).toBeNull();
+  });
+
+  test("mint route stays 401 without admin token even with tenant_id supplied", async () => {
+    const res = await fetchJson(ctx.app, "POST", "/auth/token", {
+      body: { account: "5x", tenant_id: "ten-X" },
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/services/blob-gateway/src/__tests__/sponsored-receipts.test.ts
+++ b/services/blob-gateway/src/__tests__/sponsored-receipts.test.ts
@@ -225,6 +225,37 @@ describe("sponsored-receipts notify hook", () => {
     warnSpy.mockRestore();
   });
 
+  test("notify_propagates_schemaHash_when_set_omits_when_unset", async () => {
+    process.env.SPONSORED_RECEIPT_SUBMITTER_URL = `http://127.0.0.1:${fake.port}/submit`;
+    const { notifySponsoredReceiptSubmitter } = await import(
+      "../sponsored-receipts.js"
+    );
+
+    // schemaHash unset → field not present (legacy manifest flow shape).
+    await notifySponsoredReceiptSubmitter({
+      contentHash: "a".repeat(64),
+      operator: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      authTier: "bearer",
+    });
+    expect(fake.captured).toHaveLength(1);
+    const body0 = JSON.parse(fake.captured[0].body) as Record<string, unknown>;
+    expect("schemaHash" in body0).toBe(false);
+    expect(body0.source).toBe("blob-gateway");
+
+    // schemaHash set + custom source → both present in payload.
+    await notifySponsoredReceiptSubmitter({
+      contentHash: "a".repeat(64),
+      operator: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      authTier: "bearer",
+      schemaHash: "f".repeat(64),
+      source: "compute-metering-v1",
+    });
+    expect(fake.captured).toHaveLength(2);
+    const body1 = JSON.parse(fake.captured[1].body) as Record<string, unknown>;
+    expect(body1.schemaHash).toBe("f".repeat(64));
+    expect(body1.source).toBe("compute-metering-v1");
+  });
+
   test("isSponsoredTier_matches_bearer_and_api_key_tiers_only", async () => {
     const { isSponsoredTier } = await import("../sponsored-receipts.js");
     expect(isSponsoredTier("bearer")).toBe(true);

--- a/services/blob-gateway/src/api-tokens.ts
+++ b/services/blob-gateway/src/api-tokens.ts
@@ -39,6 +39,10 @@ export function getApiTokensDb(): Database.Database {
  * When called with no arg, opens (or creates) operators.db at the canonical
  * path and stores the handle as the module default. Tests pass an in-memory
  * handle instead.
+ *
+ * Task #119: also runs `migrateTenantBindingColumn()` to add the optional
+ * `tenant_id` column to existing rows. Pre-existing tokens stay NULL → behave
+ * as legacy/admin tier (no tenant restriction).
  */
 export function initApiTokensDb(database?: Database.Database): Database.Database {
   const handle = database ?? new Database(join(config.storagePath, "operators.db"));
@@ -56,8 +60,40 @@ export function initApiTokensDb(database?: Database.Database): Database.Database
     );
     CREATE INDEX IF NOT EXISTS idx_api_tokens_account ON api_tokens(account_ss58);
   `);
+  // Task #119 — additive tenant_id column. NULL = legacy/admin tier
+  // (no tenant restriction); a non-null value binds the token to exactly one
+  // tenant for cross-tenant isolation on /billing/usage.
+  migrateTenantBindingColumn(handle);
   if (!db) db = handle;
   return handle;
+}
+
+/**
+ * Task #119 — Idempotent migration: add `tenant_id` column to `api_tokens`.
+ *
+ * Behaviour:
+ *   - NULL = legacy/admin tier (no tenant restriction).
+ *   - Non-null = the token's owning tenant; /billing/usage compares this
+ *     against the URL `tenant_id` param and 403s on mismatch.
+ *
+ * Exported so tests + the index.ts startup path can both run it without
+ * re-creating the whole table. PRAGMA-checked first; the ALTER is wrapped in
+ * try/catch as belt-and-suspenders for parallel-startup races (SQLite's
+ * `ADD COLUMN` lacks `IF NOT EXISTS` on the versions we target).
+ */
+export function migrateTenantBindingColumn(database: Database.Database): void {
+  const cols = database
+    .prepare("PRAGMA table_info(api_tokens)")
+    .all() as Array<{ name: string }>;
+  if (cols.some((c) => c.name === "tenant_id")) return;
+  try {
+    database.exec("ALTER TABLE api_tokens ADD COLUMN tenant_id TEXT DEFAULT NULL");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!/duplicate column name/i.test(msg)) {
+      throw err;
+    }
+  }
 }
 
 /**
@@ -91,6 +127,13 @@ function toBase62(buf: Uint8Array): string {
 export interface IssueTokenInput {
   accountSs58: string;
   label?: string | undefined;
+  /**
+   * Task #119: Optional tenant binding. If supplied, the token can only be
+   * used to access this tenant's data on tenant-scoped routes
+   * (e.g. /billing/usage). Omit/null/undefined = legacy/admin tier with no
+   * tenant restriction.
+   */
+  tenantId?: string | null | undefined;
   /** Unix seconds override; used by tests for determinism. */
   now?: number;
 }
@@ -102,6 +145,8 @@ export interface IssuedToken {
   tokenHash: string;
   accountSs58: string;
   label: string | null;
+  /** Task #119 — null when not bound to any tenant. */
+  tenantId: string | null;
   createdAt: number;
 }
 
@@ -109,6 +154,9 @@ export interface IssuedToken {
  * Generate a new random token and insert the hashed row.
  * Returns the plaintext token to the caller — caller MUST forward it to
  * the operator immediately; we will never be able to reconstruct it.
+ *
+ * Task #119: when `input.tenantId` is supplied (non-empty string), the token
+ * row is persisted with that binding; otherwise tenant_id stays NULL.
  */
 export function issueToken(
   database: Database.Database,
@@ -118,15 +166,51 @@ export function issueToken(
   const token = `${TOKEN_PREFIX}${toBase62(raw)}`;
   const tokenHash = hashToken(token);
   const label = input.label ?? null;
+  const tenantId =
+    typeof input.tenantId === "string" && input.tenantId.length > 0
+      ? input.tenantId
+      : null;
   const createdAt = input.now ?? Math.floor(Date.now() / 1000);
 
   database
     .prepare(
-      `INSERT INTO api_tokens (token_hash, account_ss58, label, created_at) VALUES (?, ?, ?, ?)`,
+      `INSERT INTO api_tokens (token_hash, account_ss58, label, created_at, tenant_id) VALUES (?, ?, ?, ?, ?)`,
     )
-    .run(tokenHash, input.accountSs58, label, createdAt);
+    .run(tokenHash, input.accountSs58, label, createdAt, tenantId);
 
-  return { token, tokenHash, accountSs58: input.accountSs58, label, createdAt };
+  return {
+    token,
+    tokenHash,
+    accountSs58: input.accountSs58,
+    label,
+    tenantId,
+    createdAt,
+  };
+}
+
+/**
+ * Task #119 — Bind an existing token to a tenant_id (or clear by passing null).
+ *
+ * Used post-issuance for the "mint, then bind" admin flow (e.g. when the
+ * Compute Portal hands out a Bearer token and only later attaches it to a
+ * tenant). Safe to re-bind; the latest write wins.
+ *
+ * @param database  The api_tokens DB handle.
+ * @param tokenHash sha256-hex of the token (matches api_tokens.token_hash).
+ * @param tenantId  Non-empty string to set, null/empty to clear.
+ * @returns true iff a row was updated. false if no row exists for that hash.
+ */
+export function bindTokenToTenant(
+  database: Database.Database,
+  tokenHash: string,
+  tenantId: string | null,
+): boolean {
+  const normalized =
+    typeof tenantId === "string" && tenantId.length > 0 ? tenantId : null;
+  const result = database
+    .prepare(`UPDATE api_tokens SET tenant_id = ? WHERE token_hash = ?`)
+    .run(normalized, tokenHash);
+  return result.changes > 0;
 }
 
 export interface VerifyTokenOptions {
@@ -135,12 +219,24 @@ export interface VerifyTokenOptions {
 }
 
 export type VerifyResult =
-  | { valid: true; accountSs58: string; label: string | null; tokenHash: string }
+  | {
+      valid: true;
+      accountSs58: string;
+      label: string | null;
+      tokenHash: string;
+      /** Task #119 — null = legacy/admin tier, non-null = tenant-bound token. */
+      tenantId: string | null;
+    }
   | { valid: false; reason: "malformed" | "unknown" | "revoked" };
 
 /**
  * Verify a plaintext Bearer token against the DB.
  * On success, bumps last_used_at atomically.
+ *
+ * Task #119: surfaces `tenant_id` so route handlers can enforce that a
+ * tenant-bound token only reads its own tenant's data (see /billing/usage).
+ * Tokens issued before the column existed migrate as NULL → return null →
+ * preserve legacy behaviour.
  */
 export function verifyToken(
   database: Database.Database,
@@ -153,10 +249,15 @@ export function verifyToken(
   const tokenHash = hashToken(plaintext);
   const row = database
     .prepare(
-      `SELECT account_ss58, label, revoked_at FROM api_tokens WHERE token_hash = ?`,
+      `SELECT account_ss58, label, revoked_at, tenant_id FROM api_tokens WHERE token_hash = ?`,
     )
     .get(tokenHash) as
-    | { account_ss58: string; label: string | null; revoked_at: number | null }
+    | {
+        account_ss58: string;
+        label: string | null;
+        revoked_at: number | null;
+        tenant_id: string | null;
+      }
     | undefined;
 
   if (!row) return { valid: false, reason: "unknown" };
@@ -167,7 +268,13 @@ export function verifyToken(
     .prepare(`UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?`)
     .run(now, tokenHash);
 
-  return { valid: true, accountSs58: row.account_ss58, label: row.label, tokenHash };
+  return {
+    valid: true,
+    accountSs58: row.account_ss58,
+    label: row.label,
+    tokenHash,
+    tenantId: row.tenant_id ?? null,
+  };
 }
 
 export interface RevokeTokenInput {
@@ -203,6 +310,8 @@ export interface ListedToken {
   tokenHash: string;
   accountSs58: string;
   label: string | null;
+  /** Task #119 — null when not bound to a tenant (legacy/admin tier). */
+  tenantId: string | null;
   createdAt: number;
   lastUsedAt: number | null;
   revokedAt: number | null;
@@ -226,7 +335,7 @@ export function listTokens(
     where.push("revoked_at IS NULL");
   }
   const sql = `
-    SELECT token_hash, account_ss58, label, created_at, last_used_at, revoked_at, revoked_reason
+    SELECT token_hash, account_ss58, label, tenant_id, created_at, last_used_at, revoked_at, revoked_reason
     FROM api_tokens
     ${where.length ? "WHERE " + where.join(" AND ") : ""}
     ORDER BY created_at DESC
@@ -235,6 +344,7 @@ export function listTokens(
     token_hash: string;
     account_ss58: string;
     label: string | null;
+    tenant_id: string | null;
     created_at: number;
     last_used_at: number | null;
     revoked_at: number | null;
@@ -244,6 +354,7 @@ export function listTokens(
     tokenHash: r.token_hash,
     accountSs58: r.account_ss58,
     label: r.label,
+    tenantId: r.tenant_id ?? null,
     createdAt: r.created_at,
     lastUsedAt: r.last_used_at,
     revokedAt: r.revoked_at,

--- a/services/blob-gateway/src/billing/aggregate.ts
+++ b/services/blob-gateway/src/billing/aggregate.ts
@@ -1,0 +1,190 @@
+/**
+ * Aggregation logic for the billing-query endpoint (#112).
+ *
+ * Pure functions only — no IO, no globals. The route handler in
+ * `routes/billing.ts` reads rows from sqlite + chain-status from substrate +
+ * anchor-tx from the cert-daemon checkpoint history, then hands the
+ * compiled per-record list here.
+ *
+ * Design notes:
+ *   - Aggregates are computed in a single pass; we don't iterate per metric.
+ *   - record_count, certified_count, anchored_count are mutually-exclusive
+ *     UPSTREAM concepts but mutually-INCLUSIVE here:
+ *         certified_count <= record_count
+ *         anchored_count  <= certified_count
+ *     i.e. "anchored" implies "certified" implies "submitted". The route
+ *     enforces that constraint by ONLY setting `cardano_anchor_tx` when
+ *     `attestation_status === 'certified'`.
+ *   - Sums are done in number-space. JS doubles are exact for integers
+ *     <= 2^53; for floats (cpu_seconds etc.) we accept the standard FP
+ *     drift — billing reports already round to a sensible decimal, and
+ *     the schema validator caps cpu_seconds at periodSec*max_cpu_cores
+ *     which is well under the precision budget.
+ *   - first_record_ms / last_record_ms are computed over period_start_ms
+ *     (worker-claimed window start), matching the time semantics of
+ *     `getMeteringSubmissions()` (see `worker_bounds.ts`).
+ */
+
+/**
+ * One row from the gateway's `metering_submissions` table joined with
+ * its chain-status + anchor-resolution result. The aggregate function
+ * does not care WHERE these fields came from — it only cares about their
+ * values. Decoupling lets us exercise aggregation with synthetic fixtures
+ * in unit tests with zero IO.
+ */
+export interface AggregatableRecord {
+  worker_id: string;
+  tenant_id: string;
+  period_start_ms: number;
+  period_end_ms: number;
+  cpu_seconds: number;
+  ram_gb_hours: number;
+  disk_gb_hours: number;
+  net_bytes_in: number;
+  net_bytes_out: number;
+  gpu_seconds: number;
+  /** "certified" | "pending" | "unknown" — set by `chain_query.ts`. */
+  attestation_status: AttestationStatus;
+  /** Non-null cardano tx hash when anchor_resolver matched a checkpoint. */
+  cardano_anchor_tx: string | null;
+}
+
+export type AttestationStatus = "certified" | "pending" | "unknown";
+
+/** Aggregate counters returned in the billing response. */
+export interface BillingAggregate {
+  record_count: number;
+  certified_count: number;
+  anchored_count: number;
+  cpu_seconds_total: number;
+  ram_gb_hours_total: number;
+  disk_gb_hours_total: number;
+  net_bytes_in_total: number;
+  net_bytes_out_total: number;
+  gpu_seconds_total: number;
+  /** ms since epoch of the EARLIEST period_start in the result, or null. */
+  first_record_ms: number | null;
+  /** ms since epoch of the LATEST period_start in the result, or null. */
+  last_record_ms: number | null;
+  unique_workers: number;
+}
+
+/**
+ * Aggregate a list of records into the response shape. Returns the
+ * zero-aggregate (record_count=0, all sums=0, both *_record_ms=null) on an
+ * empty input — this is the explicit "no records found" path used by the
+ * route handler.
+ */
+export function aggregateRecords(
+  records: AggregatableRecord[],
+): BillingAggregate {
+  const result: BillingAggregate = {
+    record_count: 0,
+    certified_count: 0,
+    anchored_count: 0,
+    cpu_seconds_total: 0,
+    ram_gb_hours_total: 0,
+    disk_gb_hours_total: 0,
+    net_bytes_in_total: 0,
+    net_bytes_out_total: 0,
+    gpu_seconds_total: 0,
+    first_record_ms: null,
+    last_record_ms: null,
+    unique_workers: 0,
+  };
+
+  const workers = new Set<string>();
+  for (const r of records) {
+    result.record_count += 1;
+    if (r.attestation_status === "certified") result.certified_count += 1;
+    if (r.cardano_anchor_tx !== null) result.anchored_count += 1;
+    result.cpu_seconds_total += r.cpu_seconds;
+    result.ram_gb_hours_total += r.ram_gb_hours;
+    result.disk_gb_hours_total += r.disk_gb_hours;
+    // `net_bytes_*` are integer fields — keep them in integer space by
+    // adding through `+` (JS does the right thing as long as both sides
+    // are <= 2^53). The schema validator already caps each input at
+    // JS_SAFE_INT, so a single record can't push us over the edge in one
+    // step. Aggregate-level overflow is an open follow-up (BigInt).
+    result.net_bytes_in_total += r.net_bytes_in;
+    result.net_bytes_out_total += r.net_bytes_out;
+    result.gpu_seconds_total += r.gpu_seconds;
+    if (
+      result.first_record_ms === null ||
+      r.period_start_ms < result.first_record_ms
+    ) {
+      result.first_record_ms = r.period_start_ms;
+    }
+    if (
+      result.last_record_ms === null ||
+      r.period_start_ms > result.last_record_ms
+    ) {
+      result.last_record_ms = r.period_start_ms;
+    }
+    workers.add(r.worker_id);
+  }
+  result.unique_workers = workers.size;
+  return result;
+}
+
+/**
+ * Build the opaque `next_cursor` for pagination. Encodes the last row's
+ * (period_start_ms, content_hash) as base64url-encoded JSON. The format is
+ * intentionally opaque to the client — they pass it back unchanged.
+ *
+ * Returns null when the page is the LAST page (records.length < page_size).
+ * Callers that ALREADY know the page is final (e.g. count == 0) should
+ * pass `is_final: true` to short-circuit cursor generation.
+ */
+export function buildNextCursor(
+  records: Array<{ period_start_ms: number; content_hash: string }>,
+  pageSize: number,
+  is_final = false,
+): string | null {
+  if (is_final || records.length < pageSize) return null;
+  const last = records[records.length - 1];
+  if (!last) return null;
+  const payload = JSON.stringify({
+    p: last.period_start_ms,
+    h: last.content_hash,
+  });
+  // base64url, no padding. Same encoding the chain-side helpers use.
+  return Buffer.from(payload, "utf-8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Decode a `next_cursor` produced by `buildNextCursor()` into the typed
+ * (period_start_ms, content_hash) tuple `getMeteringSubmissions()` accepts
+ * as `after`.
+ *
+ * Returns null on any malformed input — the route should treat that as
+ * "no cursor" and start from the beginning. We do NOT throw on bad input
+ * because a stale-or-tampered cursor must NOT 500 the customer.
+ */
+export function decodeCursor(
+  cursor: string,
+): { period_start_ms: number; content_hash: string } | null {
+  try {
+    // Restore padding so atob/Buffer round-trips. Add up to 3 `=`s.
+    const pad = cursor.length % 4;
+    const restored = cursor + (pad ? "=".repeat(4 - pad) : "");
+    const standard = restored.replace(/-/g, "+").replace(/_/g, "/");
+    const json = Buffer.from(standard, "base64").toString("utf-8");
+    const obj = JSON.parse(json) as { p?: unknown; h?: unknown };
+    if (
+      typeof obj.p !== "number" ||
+      !Number.isInteger(obj.p) ||
+      typeof obj.h !== "string" ||
+      !/^[0-9a-f]{64}$/.test(obj.h)
+    ) {
+      return null;
+    }
+    return { period_start_ms: obj.p, content_hash: obj.h };
+  } catch {
+    return null;
+  }
+}

--- a/services/blob-gateway/src/billing/anchor_resolver.ts
+++ b/services/blob-gateway/src/billing/anchor_resolver.ts
@@ -1,0 +1,270 @@
+/**
+ * Cardano L1 anchor resolution for the billing-query endpoint (#112).
+ *
+ * Given a `cert_hash` (the on-chain availability_cert_hash from a
+ * Materios receipt), find the Cardano transaction that anchored it.
+ *
+ * Sources of truth:
+ *
+ *  1. **cert-daemon checkpoint-history.json** (default
+ *     `/data/checkpoint-history.json`, env `CERT_HISTORY_PATH`) — an
+ *     append-only JSON array of checkpoint records. Each record has:
+ *
+ *       { timestamp, root_hash, manifest_hash, manifest, leaves[] }
+ *
+ *     where leaves is `[{receipt_id, cert_hash, block_num, leaf_hash}, ...]`.
+ *     The Merkle ROOT of a checkpoint is what gets anchored on Cardano —
+ *     not the individual cert_hash. So this file alone tells us
+ *     `cert_hash → root_hash`, which is half the journey.
+ *
+ *  2. **anchor-worker log** (default
+ *     `/home/deci/materios-anchor-worker/anchor-worker.log`, env
+ *     `ANCHOR_WORKER_LOG_PATH`) — append-only line log; each anchor emits a
+ *     line of the form
+ *
+ *       `[anchor-worker] anchored root=<root20chars>... as tx <txhash> [...]`
+ *
+ *     The root is TRUNCATED to 20 hex chars in the log, which is enough
+ *     for unambiguous matching against the full root_hash we read in step 1.
+ *     We tolerate the truncation by indexing on the 20-char prefix; the
+ *     birthday-bound on collisions across a single chain's checkpoint
+ *     history is comfortably astronomical (2^80).
+ *
+ * Joining the two gives `cert_hash → root_hash → cardano_tx_hash`.
+ *
+ * Limitations & graceful fallback (this is HARD-CODED to NOT fail the
+ * billing query — see the matrix below):
+ *
+ *   | input               | result                                    |
+ *   | ------------------- | ----------------------------------------- |
+ *   | history file absent | every cert_hash → null (fallback "unknown") |
+ *   | log file absent     | cert_hash maps to root_hash but no tx → null |
+ *   | both present, hit   | cert_hash → tx_hash                        |
+ *   | both present, miss  | cert_hash → null (anchor not yet submitted) |
+ *
+ * The route surfaces null as `cardano_anchor_tx: null` and the audit_trail
+ * always includes `anchor_resolution_ms` so the customer sees the lookup
+ * happened.
+ *
+ * Caching: file mtime is checked at most once per `MTIME_CACHE_TTL_MS` ms
+ * (currently 30s). Within that window, a cached map (cert_hash → tx_hash
+ * | null) is reused — billing queries within the same window skip both
+ * file reads.
+ *
+ * Memory budget: a checkpoint with 10 leaves * 1000 checkpoints = 10k
+ * cert_hash entries * ~150 bytes ≈ 1.5 MB. We're nowhere near needing
+ * pagination of the resolution map.
+ */
+
+import { readFile, stat } from "fs/promises";
+
+/** Resolver configuration — both paths overridable from env for tests. */
+export interface AnchorResolverConfig {
+  cert_history_path: string;
+  anchor_worker_log_path: string;
+}
+
+/**
+ * Default config. The cert-daemon path is the standard preprod mount
+ * point; the anchor-worker log is the gemtek-local default. Both are
+ * env-overridable via `CERT_HISTORY_PATH` / `ANCHOR_WORKER_LOG_PATH`.
+ */
+export function defaultAnchorResolverConfig(): AnchorResolverConfig {
+  return {
+    cert_history_path:
+      process.env.CERT_HISTORY_PATH ?? "/data/checkpoint-history.json",
+    anchor_worker_log_path:
+      process.env.ANCHOR_WORKER_LOG_PATH ??
+      "/home/deci/materios-anchor-worker/anchor-worker.log",
+  };
+}
+
+/** One leaf parsed out of checkpoint-history.json. */
+interface HistoryLeaf {
+  cert_hash: string;
+  receipt_id?: string;
+  leaf_hash?: string;
+  block_num?: number;
+}
+
+/** One checkpoint parsed out of checkpoint-history.json. */
+interface HistoryCheckpoint {
+  root_hash: string;
+  leaves: HistoryLeaf[];
+}
+
+/**
+ * In-memory resolution map — cert_hash (no `0x` prefix, lowercase) →
+ * cardano_tx_hash (no `0x` prefix, lowercase) | null.
+ */
+type ResolveMap = Map<string, string | null>;
+
+interface CacheEntry {
+  map: ResolveMap;
+  history_mtime_ms: number;
+  log_mtime_ms: number;
+  built_at_ms: number;
+}
+
+const MTIME_CACHE_TTL_MS = 30_000;
+let cache: CacheEntry | null = null;
+
+/**
+ * Strip an optional 0x prefix and lowercase. Idempotent — safe to call
+ * repeatedly on already-clean input.
+ */
+function clean(hex: string): string {
+  const x = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+  return x.toLowerCase();
+}
+
+async function fileMtimeMs(path: string): Promise<number | null> {
+  try {
+    const s = await stat(path);
+    return s.mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse the anchor-worker log into a map `root20 → tx_hash`. Lines we
+ * don't recognise are silently skipped; this keeps the resolver tolerant
+ * of log-format drift (e.g. new tag suffixes added in the future).
+ *
+ * Exported for unit-test access; the route uses `buildResolveMap()`.
+ */
+export function parseAnchorWorkerLog(text: string): Map<string, string> {
+  // Pattern: "anchored root=<20-hex>... as tx <64-hex>"
+  // We don't anchor at line-start; a leading "[anchor-worker] " prefix
+  // is consumed by the .* before "anchored". Case-insensitive flag would
+  // hurt: hex output is always lowercase from the worker.
+  const re = /anchored\s+root=([0-9a-f]{20})\.{3}\s+as\s+tx\s+([0-9a-f]{64})/g;
+  const out = new Map<string, string>();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    out.set(match[1], match[2]);
+  }
+  return out;
+}
+
+/**
+ * Build the cert_hash → tx_hash | null map from both inputs.
+ *
+ * Returns an EMPTY map when cert-daemon's checkpoint-history.json is
+ * unreadable. Routes will still respond — they just resolve every record
+ * to `cardano_anchor_tx: null`.
+ */
+async function buildResolveMap(
+  cfg: AnchorResolverConfig,
+): Promise<{ map: ResolveMap; history_mtime_ms: number; log_mtime_ms: number }> {
+  const history_mtime_ms = (await fileMtimeMs(cfg.cert_history_path)) ?? 0;
+  const log_mtime_ms = (await fileMtimeMs(cfg.anchor_worker_log_path)) ?? 0;
+  const result: ResolveMap = new Map();
+
+  let history: HistoryCheckpoint[];
+  try {
+    const raw = await readFile(cfg.cert_history_path, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      // Malformed root: degrade gracefully (empty map).
+      return { map: result, history_mtime_ms, log_mtime_ms };
+    }
+    history = parsed as HistoryCheckpoint[];
+  } catch {
+    return { map: result, history_mtime_ms, log_mtime_ms };
+  }
+
+  // Optional: anchor-worker log. Even if absent, we still register the
+  // cert_hash entries (with null) so downstream consumers can distinguish
+  // "checkpointed but anchor unknown" from "not checkpointed at all".
+  let rootToTx = new Map<string, string>();
+  if (log_mtime_ms > 0) {
+    try {
+      const text = await readFile(cfg.anchor_worker_log_path, "utf-8");
+      rootToTx = parseAnchorWorkerLog(text);
+    } catch {
+      // Leave rootToTx empty.
+    }
+  }
+
+  for (const ck of history) {
+    if (!ck || typeof ck !== "object" || !Array.isArray(ck.leaves)) continue;
+    const root = clean(String(ck.root_hash ?? ""));
+    if (!/^[0-9a-f]{64}$/.test(root)) continue;
+    const root20 = root.slice(0, 20);
+    const tx = rootToTx.get(root20) ?? null;
+    for (const leaf of ck.leaves) {
+      if (!leaf || typeof leaf !== "object") continue;
+      const certHash = clean(String(leaf.cert_hash ?? ""));
+      if (!/^[0-9a-f]{64}$/.test(certHash)) continue;
+      // First write wins. checkpoint-history is append-only; if the same
+      // cert_hash appears in two checkpoints (e.g. a re-checkpoint), we
+      // anchor by the first entry to keep the result stable.
+      if (!result.has(certHash)) {
+        result.set(certHash, tx);
+      }
+    }
+  }
+
+  return { map: result, history_mtime_ms, log_mtime_ms };
+}
+
+/**
+ * Resolve a list of cert_hashes to Cardano tx hashes. Returns one entry
+ * per input — order-preserving, length-preserving. Null tx_hash means
+ * either "anchor not yet submitted" or "log unavailable" — the route
+ * surfaces both as `cardano_anchor_tx: null`.
+ *
+ * `cfgOverride` lets tests inject custom paths without touching env vars.
+ */
+export async function resolveAnchorTxs(
+  certHashes: ReadonlyArray<string | null>,
+  cfgOverride?: Partial<AnchorResolverConfig>,
+): Promise<Array<string | null>> {
+  if (certHashes.length === 0) return [];
+
+  const cfg: AnchorResolverConfig = {
+    ...defaultAnchorResolverConfig(),
+    ...(cfgOverride ?? {}),
+  };
+
+  // Cache invalidation: rebuild when EITHER file's mtime has changed
+  // since the last build OR the cache is older than the TTL. Cheap
+  // ${stat} calls bound the worst-case overhead.
+  const now = Date.now();
+  const need_rebuild =
+    cache === null ||
+    now - cache.built_at_ms > MTIME_CACHE_TTL_MS ||
+    cfgOverride !== undefined;
+
+  let entry: CacheEntry | null = cache;
+  if (need_rebuild) {
+    const built = await buildResolveMap(cfg);
+    entry = {
+      map: built.map,
+      history_mtime_ms: built.history_mtime_ms,
+      log_mtime_ms: built.log_mtime_ms,
+      built_at_ms: now,
+    };
+    // Don't pollute the global cache when a test passes cfgOverride.
+    if (cfgOverride === undefined) {
+      cache = entry;
+    }
+  }
+
+  const map = entry?.map ?? new Map<string, string | null>();
+  return certHashes.map((h) => {
+    if (!h) return null;
+    const c = clean(h);
+    if (!/^[0-9a-f]{64}$/.test(c)) return null;
+    const tx = map.get(c) ?? null;
+    if (!tx) return null;
+    return tx; // already lowercase, no 0x prefix — caller can prepend if it likes.
+  });
+}
+
+/** Test hook: drop the cached resolve-map so the next call re-reads files. */
+export function resetAnchorResolverForTests(): void {
+  cache = null;
+}

--- a/services/blob-gateway/src/billing/chain_query.ts
+++ b/services/blob-gateway/src/billing/chain_query.ts
@@ -1,0 +1,191 @@
+/**
+ * Materios chain RPC wrapper for the billing-query endpoint (#112).
+ *
+ * Given a list of `content_hash`es (the gateway-derived hash, hex), look up
+ * the on-chain receipt status for each one. The chain doesn't index by
+ * content_hash directly; the receipt-id IS deterministic from the
+ * content_hash (`receipt_id = sha256(content_hash_bytes)` per
+ * `storage.ts::computeReceiptId`), so we compute the receipt-id locally
+ * and storage-query `orinqReceipts.receipts(receipt_id)`.
+ *
+ * Status semantics (mirror `rpc-client.ts::checkReceiptStatus`):
+ *   - "certified": receipt exists AND availability_cert_hash != zero-hash
+ *   - "pending":   receipt exists AND availability_cert_hash == zero-hash
+ *   - "unknown":   receipt does not exist on chain (yet) OR RPC failed
+ *
+ * The "unknown" path is graceful — a billing query MUST not fail because a
+ * record's chain leg hasn't landed yet. The route surfaces "unknown" as
+ * `attestation_status="unknown"` + null `attestation_cert_hash`, and the
+ * audit_trail block records `chain_query_ms` so customers can see how long
+ * the lookups took.
+ *
+ * Caching: each ApiPromise is shared via `getOrConnectApi()` so the
+ * gateway only opens a single WS connection regardless of how many
+ * billing requests fly through. Reconnect cooldown matches `rpc-client.ts`.
+ *
+ * `@polkadot/api` is heavy — keep the dependency footprint here narrow,
+ * and don't pull in the SDK helpers (the SDK's `submitReceipt` etc. live
+ * in a different package).
+ */
+
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { createHash } from "crypto";
+import { config } from "../config.js";
+import type { AttestationStatus } from "./aggregate.js";
+
+const ZERO_HASH_NO_PREFIX = "00".repeat(32);
+const RECONNECT_COOLDOWN_MS = 30_000;
+
+/**
+ * Per-content-hash lookup result. `cert_hash` is null when status !=
+ * "certified" — we never fabricate a hash, callers must treat null as
+ * "no certification on chain yet".
+ */
+export interface ChainStatus {
+  content_hash: string;
+  receipt_id: string;
+  status: AttestationStatus;
+  cert_hash: string | null;
+}
+
+let apiPromise: Promise<ApiPromise> | null = null;
+let lastConnectAttempt = 0;
+
+/**
+ * Lazy-initialise (or reuse) the Materios @polkadot/api connection.
+ *
+ * Returns null when we've recently failed to connect — callers degrade to
+ * `status: "unknown"` rather than queueing waiters or blocking. A separate
+ * cooldown timer governs the next connect attempt.
+ */
+function getOrConnectApi(): Promise<ApiPromise> | null {
+  if (apiPromise) return apiPromise;
+  if (Date.now() - lastConnectAttempt < RECONNECT_COOLDOWN_MS) return null;
+  lastConnectAttempt = Date.now();
+
+  const provider = new WsProvider(config.materiosRpcUrl, /* autoConnectMs */ 5000);
+  apiPromise = ApiPromise.create({ provider, noInitWarn: true });
+  apiPromise
+    .then((api) => {
+      api.on("disconnected", () => {
+        apiPromise = null;
+      });
+      api.on("error", () => {
+        apiPromise = null;
+      });
+    })
+    .catch(() => {
+      apiPromise = null;
+    });
+  return apiPromise;
+}
+
+/**
+ * Compute the deterministic receipt_id from a content_hash hex string.
+ * Identical to `storage.ts::computeReceiptId` but kept here so callers
+ * don't pull in fs-touching modules.
+ */
+export function receiptIdFromContentHash(contentHashHex: string): string {
+  const clean = contentHashHex.startsWith("0x")
+    ? contentHashHex.slice(2)
+    : contentHashHex;
+  const digest = createHash("sha256").update(Buffer.from(clean, "hex")).digest("hex");
+  return "0x" + digest;
+}
+
+/**
+ * Bulk chain status lookup. Issues one `orinqReceipts.receipts(receipt_id)`
+ * storage query per content_hash; each is independent so we run them
+ * concurrently with `Promise.all`. Substrate's WS handles multiplexed
+ * requests fine.
+ *
+ * If the API connection is down, every record gets `status: "unknown"`
+ * with a null cert_hash. The route surfaces a `chain_query_ms = elapsed`
+ * regardless so the customer sees that the lookup happened.
+ *
+ * Test hook: `apiOverride` lets unit tests inject a stub that exposes
+ * just `query.orinqReceipts.receipts`. We deliberately accept `unknown`
+ * here so the test stub doesn't need to import the heavy ApiPromise type.
+ */
+export async function queryReceiptStatuses(
+  contentHashes: readonly string[],
+  apiOverride?: unknown,
+): Promise<ChainStatus[]> {
+  if (contentHashes.length === 0) return [];
+
+  // Deduplicate — multiple records can hash-collide in theory but in
+  // practice the same content_hash maps to one receipt. We over-fetch
+  // anyway; caller maps results back by content_hash.
+  const uniq = Array.from(new Set(contentHashes));
+  const ids: { content_hash: string; receipt_id: string }[] = uniq.map(
+    (contentHashHex) => ({
+      content_hash: contentHashHex,
+      receipt_id: receiptIdFromContentHash(contentHashHex),
+    }),
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let api: any = apiOverride;
+  if (api === undefined) {
+    const pending = getOrConnectApi();
+    if (!pending) {
+      return ids.map((x) => ({
+        content_hash: x.content_hash,
+        receipt_id: x.receipt_id,
+        status: "unknown",
+        cert_hash: null,
+      }));
+    }
+    try {
+      api = await pending;
+    } catch {
+      return ids.map((x) => ({
+        content_hash: x.content_hash,
+        receipt_id: x.receipt_id,
+        status: "unknown",
+        cert_hash: null,
+      }));
+    }
+  }
+
+  // Issue queries concurrently. A single failure (e.g. malformed receipt
+  // hex on a transient decoder fault) degrades only that record, not the
+  // whole batch.
+  const out = await Promise.all(
+    ids.map(async ({ content_hash, receipt_id }): Promise<ChainStatus> => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result: any = await api.query.orinqReceipts.receipts(receipt_id);
+        if (result.isEmpty) {
+          return { content_hash, receipt_id, status: "unknown", cert_hash: null };
+        }
+        const record = result.toJSON() as Record<string, unknown>;
+        const certHashRaw = String(
+          record.availability_cert_hash ?? record.availabilityCertHash ?? "",
+        );
+        const cert = certHashRaw.startsWith("0x")
+          ? certHashRaw.slice(2)
+          : certHashRaw;
+        if (!cert || cert === ZERO_HASH_NO_PREFIX) {
+          return { content_hash, receipt_id, status: "pending", cert_hash: null };
+        }
+        return {
+          content_hash,
+          receipt_id,
+          status: "certified",
+          cert_hash: "0x" + cert,
+        };
+      } catch {
+        return { content_hash, receipt_id, status: "unknown", cert_hash: null };
+      }
+    }),
+  );
+
+  return out;
+}
+
+/** Test hook: clear the cached ApiPromise so the next call re-connects. */
+export function resetChainQueryForTests(): void {
+  apiPromise = null;
+  lastConnectAttempt = 0;
+}

--- a/services/blob-gateway/src/index.ts
+++ b/services/blob-gateway/src/index.ts
@@ -23,6 +23,9 @@ import { registerTokenRoutes } from "./routes/tokens.js";
 import { chainInfoRouter, initChainInfoPoller } from "./routes/chain-info.js";
 import { faucetRouter } from "./routes/faucet.js";
 import { registerAdminKeysRoutes } from "./routes/admin-keys.js";
+import { meteringRouter } from "./routes/metering.js";
+import { billingRouter } from "./routes/billing.js";
+import { initWorkerBoundsDb } from "./worker_bounds.js";
 // initChainInfoPoller is re-exported for consumers that want to pre-warm the
 // cache at startup; we also call it in start() so the first /chain-info hit
 // after cold-start returns 200 instead of 503.
@@ -61,6 +64,8 @@ app.use(heartbeatsRouter);  // Handles own dual-mode auth (Phase 2)
 app.use(operatorsRouter);   // Invite-only operator registration
 app.use(chainInfoRouter);   // Public: /chain-info — used by flux1 explorer + cert-daemon auto-discovery
 app.use(faucetRouter);      // Public: /faucet/drip — operator onboarding (MATRA + MOTRA bootstrap). Volume-mounted overrides accepted; see ops compose templates.
+app.use(meteringRouter);    // Task #109: POST /metering/submit — compute_metering_v1 ingestion + sponsored-receipt forwarding.
+app.use(billingRouter);     // Task #112: GET /billing/usage — verifiable compute-metering billing query.
 registerTokenRoutes(app);   // Bearer-token lifecycle (admin-only)
 registerAdminKeysRoutes(app); // Task #94: api_keys.bound_validator_aura get/set/clear (admin-only)
 
@@ -79,6 +84,8 @@ async function start(): Promise<void> {
   // Bearer-token store (shares the SAME handle as operators.db so we never
   // have two competing connections to the same file).
   initApiTokensDb(getOperatorsDb());
+  // Compute metering v1 — per-worker hardware bounds + monotonic period_start.
+  initWorkerBoundsDb();
 
   // Start cleanup timers
   startCleanupTimer();

--- a/services/blob-gateway/src/routes/billing.ts
+++ b/services/blob-gateway/src/routes/billing.ts
@@ -1,0 +1,478 @@
+/**
+ * `GET /billing/usage` — verifiable compute-metering billing query.
+ *
+ * Customer query path. Computes the bill from cryptographically-attested
+ * usage records that landed at the gateway via `POST /metering/submit`,
+ * cross-checking each record's chain status (Materios `submit_receipt_v2`
+ * → optional cert-daemon attestation) and Cardano L1 anchor tx (cert-daemon
+ * checkpoint-history.json + anchor-worker log).
+ *
+ * Query parameters
+ * ----------------
+ *   tenant_id        REQUIRED   `[a-z0-9-]{4,64}` — same shape as the
+ *                                schema's `tenant_id` field.
+ *   start_ms         REQUIRED   integer; window start, INCLUSIVE.
+ *   end_ms           REQUIRED   integer; window end, EXCLUSIVE.
+ *                               Window: 0 < end_ms - start_ms <= 90 days.
+ *   include_records  optional   "true" | "false" (default false). When
+ *                                false, only the `aggregate` block is
+ *                                returned — no per-record fan-out.
+ *   page_size        optional   1 ≤ N ≤ 500, default 100.
+ *   cursor           optional   opaque pagination cursor returned as
+ *                                `next_cursor` from a previous response.
+ *
+ * Time-window semantics
+ * ---------------------
+ *   Records are filtered by `period_start_ms` (worker-claimed window
+ *   start), NOT `submitted_at_ms` (gateway ingest time). A record with
+ *   `period_start_ms === start_ms` IS included; one with
+ *   `period_start_ms === end_ms` is NOT. This matches what customers
+ *   expect: "show me usage for April" should include records that say
+ *   "I worked April 1 → April 1+1h" but not "I worked April 30 → May 1".
+ *
+ * Empty-result contract
+ * ---------------------
+ *   "No records in the window" returns 200 with a zero-aggregate, NOT
+ *   404. We can't distinguish "tenant doesn't exist" from "tenant exists
+ *   but has zero usage", and reserving 404 for a state we can't detect
+ *   would break the contract. Always 200, always a usable shape.
+ *
+ * Auth
+ * ----
+ *   Authorization: Bearer matra_<token>. We inline-verify the token here
+ *   (instead of using the shared `bearerAuth` middleware) so we can pull
+ *   the optional `tenantId` binding off the verify result and enforce
+ *   cross-tenant isolation per task #119. x-api-key auth is intentionally
+ *   NOT supported on this route — tenant binding lives on api_tokens, and
+ *   the legacy x-api-key path uses a different table without a tenant_id
+ *   column.
+ *
+ *   Task #119 — cross-tenant isolation:
+ *     - Token has NO tenant_id (legacy/admin) → allow any tenant_id query.
+ *     - Token tenant_id === query.tenant_id → 200.
+ *     - Token tenant_id !== query.tenant_id → 403 TOKEN_TENANT_MISMATCH.
+ *
+ * Errors (uniform JSON `{ ok: false, error, ... }`):
+ *   400 `MISSING_PARAM` — tenant_id / start_ms / end_ms missing or wrong type
+ *   400 `BAD_PARAM`     — value out of range / fails validation
+ *   400 `BAD_WINDOW`    — end_ms <= start_ms or window > 90 days
+ *   401 `UNAUTHENTICATED` — no Bearer / malformed Bearer / token revoked
+ *   403 `TOKEN_TENANT_MISMATCH` — token bound to a different tenant (#119)
+ *   500 `INTERNAL`      — uncaught error path
+ */
+
+import { Router, type Request, type Response } from "express";
+import { verifyToken, getApiTokensDb, TOKEN_PREFIX } from "../api-tokens.js";
+import {
+  getMeteringSubmissions,
+  type MeteringSubmissionRow,
+} from "../worker_bounds.js";
+import {
+  aggregateRecords,
+  buildNextCursor,
+  decodeCursor,
+  type AggregatableRecord,
+  type AttestationStatus,
+} from "../billing/aggregate.js";
+import {
+  queryReceiptStatuses,
+  receiptIdFromContentHash,
+  type ChainStatus,
+} from "../billing/chain_query.js";
+import { resolveAnchorTxs } from "../billing/anchor_resolver.js";
+import { SCHEMA_HASH_HEX } from "../schemas/compute_metering_v1.js";
+
+export const billingRouter = Router();
+
+/** Same regex as the schema validator's `tenant_id` check. */
+const ID_REGEX = /^[a-z0-9-]{4,64}$/;
+/** 90 days in milliseconds — window-size cap. */
+const MAX_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
+const DEFAULT_PAGE_SIZE = 100;
+const MAX_PAGE_SIZE = 500;
+
+/**
+ * Parse a string into a positive integer or return null if it can't be
+ * coerced cleanly. We reject NaN, floats, and negative values so the
+ * client sees a 400 instead of an off-by-1e6 silent bug.
+ */
+function parseIntStrict(s: unknown): number | null {
+  if (typeof s !== "string") return null;
+  if (!/^-?\d+$/.test(s)) return null;
+  const n = Number(s);
+  if (!Number.isInteger(n)) return null;
+  return n;
+}
+
+/**
+ * Return a typed `{ ok: false, error, field?, message }` body. The status
+ * code is the caller's responsibility — keeps the helper composable.
+ */
+function badRequest(
+  res: Response,
+  error: string,
+  field: string,
+  message: string,
+): void {
+  res.status(400).json({
+    ok: false,
+    error,
+    field,
+    message,
+  });
+}
+
+/**
+ * Convert a stored row + chain status + anchor tx into the per-record
+ * response shape. Pure — no IO. Exported for tests.
+ */
+export function rowToRecordResponse(
+  row: MeteringSubmissionRow,
+  chain: ChainStatus,
+  anchorTx: string | null,
+): {
+  worker_id: string;
+  period_start_ms: number;
+  period_end_ms: number;
+  content_hash: string;
+  receipt_id: string | null;
+  schema_hash: string;
+  attestation_cert_hash: string | null;
+  attestation_status: AttestationStatus;
+  cardano_anchor_tx: string | null;
+  metrics: {
+    cpu_seconds: number;
+    ram_gb_hours: number;
+    disk_gb_hours: number;
+    net_bytes_in: number;
+    net_bytes_out: number;
+    gpu_seconds: number;
+  };
+} {
+  return {
+    worker_id: row.worker_id,
+    period_start_ms: row.period_start_ms,
+    period_end_ms: row.period_end_ms,
+    content_hash: row.content_hash,
+    // receipt_id is deterministic from content_hash, so we surface it even
+    // when the chain leg hasn't landed (status="unknown") — handy for
+    // customers who want to look up the receipt later via SDK without
+    // re-deriving the id themselves. When status is "unknown" we still
+    // return the LOCALLY-derived id (truthful: this is what it WILL be).
+    receipt_id: chain.receipt_id,
+    schema_hash: SCHEMA_HASH_HEX,
+    attestation_cert_hash: chain.cert_hash,
+    attestation_status: chain.status,
+    // Anchor tx hash is null unless EVERY leg succeeded:
+    //   1. record certified on Materios (chain.status === "certified")
+    //   2. cert_hash present (chain.cert_hash !== null)
+    //   3. resolver matched a Cardano tx
+    // Items (1) and (2) imply each other — keep the explicit AND so the
+    // intent reads cleanly.
+    cardano_anchor_tx:
+      chain.status === "certified" && chain.cert_hash !== null && anchorTx
+        ? anchorTx.startsWith("0x")
+          ? anchorTx
+          : "0x" + anchorTx
+        : null,
+    metrics: {
+      cpu_seconds: row.cpu_seconds,
+      ram_gb_hours: row.ram_gb_hours,
+      disk_gb_hours: row.disk_gb_hours,
+      net_bytes_in: row.net_bytes_in,
+      net_bytes_out: row.net_bytes_out,
+      gpu_seconds: row.gpu_seconds,
+    },
+  };
+}
+
+/**
+ * Wire-up note: bearerAuth is applied per-route (not at router level) so
+ * other downstream handlers under `/billing` can have different auth in
+ * the future without an `unless()`-style escape hatch.
+ */
+billingRouter.get(
+  "/billing/usage",
+  async (req: Request, res: Response) => {
+    try {
+      const t0 = Date.now();
+
+      // ---------- inline bearer auth (#119: tenant binding is checked
+      // post-auth, pre-aggregation; the shared `bearerAuth` middleware
+      // doesn't surface verify.tenantId, so we verify here directly).
+      const authHeader = (req.headers.authorization ||
+        (req.headers as Record<string, unknown>)["Authorization"]) as
+        | string
+        | undefined;
+      if (typeof authHeader !== "string" || !authHeader.startsWith("Bearer ")) {
+        res
+          .status(401)
+          .json({ error: "authentication required (Bearer token)" });
+        return;
+      }
+      const token = authHeader.slice("Bearer ".length).trim();
+      if (!token.startsWith(TOKEN_PREFIX)) {
+        res.status(401).json({ error: "invalid bearer token: malformed" });
+        return;
+      }
+      const verify = verifyToken(getApiTokensDb(), token);
+      if (!verify.valid) {
+        res
+          .status(401)
+          .json({ error: `invalid bearer token: ${verify.reason}` });
+        return;
+      }
+
+      // ---------- query param parsing ----------
+      const tenant_id_raw = req.query.tenant_id;
+      const start_raw = req.query.start_ms;
+      const end_raw = req.query.end_ms;
+
+      if (typeof tenant_id_raw !== "string" || tenant_id_raw === "") {
+        badRequest(
+          res,
+          "MISSING_PARAM",
+          "tenant_id",
+          "tenant_id is required",
+        );
+        return;
+      }
+      if (!ID_REGEX.test(tenant_id_raw)) {
+        badRequest(
+          res,
+          "BAD_PARAM",
+          "tenant_id",
+          `tenant_id must match [a-z0-9-]{4,64}, got "${tenant_id_raw}"`,
+        );
+        return;
+      }
+
+      // ---------- task #119: cross-tenant isolation ----------
+      // Token has NO tenant_id (legacy/admin) → allow any tenant_id query.
+      // Token tenant_id === query.tenant_id → fall through to aggregation.
+      // Token tenant_id !== query.tenant_id → 403.
+      const boundTenant = verify.tenantId ?? null;
+      if (boundTenant !== null && boundTenant !== tenant_id_raw) {
+        console.warn(
+          `[blob-gateway] billing-tenant-mismatch tokenHash=${verify.tokenHash.slice(0, 16)}... boundTenant=${boundTenant} requestedTenant=${tenant_id_raw}`,
+        );
+        res.status(403).json({
+          error: "TOKEN_TENANT_MISMATCH",
+          message:
+            "Bearer token is bound to a different tenant than the requested tenant_id",
+        });
+        return;
+      }
+
+      if (typeof start_raw !== "string") {
+        badRequest(res, "MISSING_PARAM", "start_ms", "start_ms is required");
+        return;
+      }
+      if (typeof end_raw !== "string") {
+        badRequest(res, "MISSING_PARAM", "end_ms", "end_ms is required");
+        return;
+      }
+      const start_ms = parseIntStrict(start_raw);
+      if (start_ms === null || start_ms < 0) {
+        badRequest(
+          res,
+          "BAD_PARAM",
+          "start_ms",
+          "start_ms must be a non-negative integer",
+        );
+        return;
+      }
+      const end_ms = parseIntStrict(end_raw);
+      if (end_ms === null || end_ms < 0) {
+        badRequest(
+          res,
+          "BAD_PARAM",
+          "end_ms",
+          "end_ms must be a non-negative integer",
+        );
+        return;
+      }
+      if (end_ms <= start_ms) {
+        res.status(400).json({
+          ok: false,
+          error: "BAD_WINDOW",
+          field: "end_ms",
+          message: "end_ms must be > start_ms",
+        });
+        return;
+      }
+      if (end_ms - start_ms > MAX_WINDOW_MS) {
+        res.status(400).json({
+          ok: false,
+          error: "BAD_WINDOW",
+          field: "end_ms",
+          message: `window must be <= ${MAX_WINDOW_MS} ms (90 days)`,
+        });
+        return;
+      }
+
+      const include_records_raw = req.query.include_records;
+      const include_records =
+        include_records_raw === "true" || include_records_raw === "1";
+
+      let page_size = DEFAULT_PAGE_SIZE;
+      if (typeof req.query.page_size === "string") {
+        const n = parseIntStrict(req.query.page_size);
+        if (n === null || n < 1 || n > MAX_PAGE_SIZE) {
+          badRequest(
+            res,
+            "BAD_PARAM",
+            "page_size",
+            `page_size must be an integer in [1, ${MAX_PAGE_SIZE}]`,
+          );
+          return;
+        }
+        page_size = n;
+      }
+
+      let after: { period_start_ms: number; content_hash: string } | undefined;
+      if (typeof req.query.cursor === "string" && req.query.cursor !== "") {
+        const decoded = decodeCursor(req.query.cursor);
+        if (decoded === null) {
+          badRequest(
+            res,
+            "BAD_PARAM",
+            "cursor",
+            "cursor is malformed or stale",
+          );
+          return;
+        }
+        after = decoded;
+      }
+
+      // ---------- gateway-db read ----------
+      const dbStart = Date.now();
+      const rows = getMeteringSubmissions({
+        tenant_id: tenant_id_raw,
+        start_ms,
+        end_ms,
+        // page_size+1 is a common pagination idiom but we keep it simple:
+        // ask for exactly page_size; if the result equals page_size we
+        // assume "could be more" and emit a cursor. False positives (a
+        // page exactly at the boundary returns an extra round-trip with
+        // 0 rows) are acceptable; better than mis-counting.
+        limit: page_size,
+        after,
+      });
+      const gateway_db_query_ms = Date.now() - dbStart;
+
+      // ---------- chain status ----------
+      const chainStart = Date.now();
+      const chainStatuses = await queryReceiptStatuses(
+        rows.map((r) => r.content_hash),
+      );
+      const chain_query_ms = Date.now() - chainStart;
+      // Build a content_hash → status map for O(1) merge below.
+      const chainByContent = new Map<string, ChainStatus>();
+      for (const cs of chainStatuses) chainByContent.set(cs.content_hash, cs);
+
+      // ---------- anchor resolution ----------
+      const anchorStart = Date.now();
+      const certHashes = chainStatuses.map((s) => s.cert_hash);
+      const anchorTxs = await resolveAnchorTxs(certHashes);
+      const anchor_resolution_ms = Date.now() - anchorStart;
+      const anchorByCert = new Map<string, string | null>();
+      for (let i = 0; i < chainStatuses.length; i++) {
+        const cs = chainStatuses[i];
+        if (cs.cert_hash) {
+          anchorByCert.set(cs.cert_hash, anchorTxs[i] ?? null);
+        }
+      }
+
+      // ---------- merge into AggregatableRecord[] ----------
+      const aggRecords: AggregatableRecord[] = rows.map((r) => {
+        const chain =
+          chainByContent.get(r.content_hash) ??
+          ({
+            content_hash: r.content_hash,
+            receipt_id: receiptIdFromContentHash(r.content_hash),
+            status: "unknown" as AttestationStatus,
+            cert_hash: null,
+          } satisfies ChainStatus);
+        const anchor =
+          chain.status === "certified" && chain.cert_hash
+            ? anchorByCert.get(chain.cert_hash) ?? null
+            : null;
+        return {
+          worker_id: r.worker_id,
+          tenant_id: r.tenant_id,
+          period_start_ms: r.period_start_ms,
+          period_end_ms: r.period_end_ms,
+          cpu_seconds: r.cpu_seconds,
+          ram_gb_hours: r.ram_gb_hours,
+          disk_gb_hours: r.disk_gb_hours,
+          net_bytes_in: r.net_bytes_in,
+          net_bytes_out: r.net_bytes_out,
+          gpu_seconds: r.gpu_seconds,
+          attestation_status: chain.status,
+          cardano_anchor_tx: anchor,
+        };
+      });
+
+      const aggregate = aggregateRecords(aggRecords);
+
+      const responseRecords = include_records
+        ? rows.map((r) => {
+            const chain =
+              chainByContent.get(r.content_hash) ??
+              ({
+                content_hash: r.content_hash,
+                receipt_id: receiptIdFromContentHash(r.content_hash),
+                status: "unknown" as AttestationStatus,
+                cert_hash: null,
+              } satisfies ChainStatus);
+            const anchor =
+              chain.status === "certified" && chain.cert_hash
+                ? anchorByCert.get(chain.cert_hash) ?? null
+                : null;
+            return rowToRecordResponse(r, chain, anchor);
+          })
+        : undefined;
+
+      const next_cursor = buildNextCursor(
+        rows.map((r) => ({
+          period_start_ms: r.period_start_ms,
+          content_hash: r.content_hash,
+        })),
+        page_size,
+      );
+
+      // Audit-trail tail — keeps the timing breakdown visible to clients
+      // verifying the response. SCHEMA_HASH_HEX is constant but echoed so
+      // client tooling doesn't need to import it from the schema package.
+      const responseBody: Record<string, unknown> = {
+        tenant_id: tenant_id_raw,
+        period: {
+          start_ms,
+          end_ms,
+          now_ms: t0,
+        },
+        aggregate,
+        next_cursor,
+        audit_trail: {
+          schema_hash: SCHEMA_HASH_HEX,
+          gateway_db_query_ms,
+          chain_query_ms,
+          anchor_resolution_ms,
+        },
+      };
+      if (responseRecords) {
+        responseBody.records = responseRecords;
+      }
+      res.status(200).json(responseBody);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[blob-gateway] /billing/usage unexpected error: ${msg}`);
+      res.status(500).json({
+        ok: false,
+        error: "INTERNAL",
+        message: "internal error",
+      });
+    }
+  },
+);

--- a/services/blob-gateway/src/routes/metering.ts
+++ b/services/blob-gateway/src/routes/metering.ts
@@ -1,0 +1,236 @@
+/**
+ * `POST /metering/submit` — accept and validate a `compute_metering_v1`
+ * record from a compute worker.
+ *
+ * Pipeline:
+ *   1. Parse JSON body; reject 400 on malformed input.
+ *   2. Validate against the schema (shape, bounds, sig, time, monotonic).
+ *   3. Persist receipt manifest at the canonical `receipts/{contentHash}` path
+ *      so the existing cleanup/index machinery picks it up.
+ *   4. Update worker_state (last_period_start, last_content_hash).
+ *   5. Fire-and-forget `notifySponsoredReceiptSubmitter()` with
+ *      `schemaHash = SCHEMA_HASH_HEX` and `source = "compute-metering-v1"`.
+ *      The submitter is the only party with the operator signing keys; it
+ *      produces the on-chain `submit_receipt_v2` extrinsic.
+ *
+ * Auth model:
+ *   The `worker_signature` field IS the auth — sr25519 over the canonical
+ *   body. We do NOT also require Bearer/x-api-key on the HTTP request because
+ *   the workers run in customer environments without operator credentials.
+ *   That's fine: a forged record cannot pass `signatureVerify()` against the
+ *   declared `worker_pubkey`, and the SS58 we derive from the pubkey is what
+ *   the upstream receipt is attributed to. Replay is bounded by:
+ *     - monotonic `period_start` (per-worker_id, persisted in worker_state)
+ *     - `content_hash` uniqueness on chain (chain-side anti-replay)
+ *     - same-content shortcut at the gateway (`isReplayedContent()`)
+ *
+ * Idempotency:
+ *   A retry of the EXACT same record (same canonical_body → same
+ *   content_hash) returns 200 without re-firing the submitter. A retry with
+ *   ANY differing field (e.g. cpu_seconds bumped) is a different record and
+ *   passes through, but the monotonic check still allows it as long as
+ *   period_start is non-decreasing.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { config } from "../config.js";
+import {
+  validateComputeMeteringV1,
+  workerPubkeyToSs58,
+  SCHEMA_VERSION,
+} from "../schemas/compute_metering_v1.js";
+import {
+  getWorkerBounds,
+  getLastPeriodStart,
+  recordWorkerSubmission,
+  recordMeteringSubmission,
+  isReplayedContent,
+} from "../worker_bounds.js";
+import { notifySponsoredReceiptSubmitter } from "../sponsored-receipts.js";
+import { saveManifest, updateReceiptMeta } from "../storage.js";
+
+export const meteringRouter = Router();
+
+/**
+ * Source tag used in the outbound sponsored-receipt-submitter payload.
+ * Stable string — exposed here so the submitter side can pin a constant.
+ */
+export const METERING_SOURCE = "compute-metering-v1" as const;
+
+/**
+ * Map a validator error code to an HTTP status code.
+ *
+ *   400 — input is malformed in a way the worker should fix client-side.
+ *   401 — signature didn't verify (the only "auth" failure on this route).
+ *   409 — monotonic violation (period_start would rewind history).
+ *   422 — input is well-formed JSON but violates a constraint
+ *         (over-bound, schema-version mismatch).
+ */
+function statusForCode(code: string): number {
+  switch (code) {
+    case "INVALID_JSON":
+    case "MISSING_FIELD":
+    case "WRONG_TYPE":
+    case "ID_FORMAT":
+    case "PERIOD_INVALID":
+    case "NEGATIVE_VALUE":
+    case "INT_OVERFLOW":
+    case "HEX_FORMAT":
+      return 400;
+    case "WRONG_SCHEMA_VERSION":
+    case "BOUND_EXCEEDED":
+      return 422;
+    case "SIGNATURE_INVALID":
+      return 401;
+    case "MONOTONIC_VIOLATION":
+      return 409;
+    default:
+      return 400;
+  }
+}
+
+meteringRouter.post(
+  "/metering/submit",
+  async (req: Request, res: Response) => {
+    try {
+      const raw = req.body;
+      if (raw === undefined || raw === null) {
+        res.status(400).json({
+          ok: false,
+          code: "INVALID_JSON",
+          message: "request body must be a JSON object",
+        });
+        return;
+      }
+
+      // Look up workerId BEFORE full validation so we can pin per-worker
+      // bounds and last_period_start. We DEFENSIVELY guard against the case
+      // where worker_id is itself malformed — fall back to the same defaults
+      // as `getWorkerBounds()` (DEFAULT_BOUNDS) and let the validator emit
+      // the proper ID_FORMAT error.
+      const workerIdGuess =
+        typeof raw === "object" && raw !== null && "worker_id" in raw
+          ? (raw as { worker_id: unknown }).worker_id
+          : undefined;
+      const workerIdStr =
+        typeof workerIdGuess === "string" ? workerIdGuess : "";
+
+      const bounds = workerIdStr ? getWorkerBounds(workerIdStr) : undefined;
+      const lastPeriodStart = workerIdStr
+        ? getLastPeriodStart(workerIdStr)
+        : 0;
+
+      const result = validateComputeMeteringV1(raw, {
+        bounds,
+        last_period_start: lastPeriodStart,
+        // Use real wall-clock time. Tests inject `now_ms` directly via the
+        // pure validator unit tests; this route uses live time, so any record
+        // with `period_end > now+60s` is rejected.
+      });
+      if (!result.ok) {
+        res
+          .status(statusForCode(result.code))
+          .json({
+            ok: false,
+            code: result.code,
+            message: result.message,
+            ...(result.field ? { field: result.field } : {}),
+          });
+        return;
+      }
+
+      const { record, content_hash, schema_hash } = result;
+
+      // Replay short-circuit: if this is the EXACT same content the worker
+      // last submitted, return 200 without re-firing the submitter. This is
+      // a friendly retry path — the canonical anti-replay is on-chain
+      // (content_hash uniqueness in pallet-orinq-receipts).
+      const replayed = isReplayedContent(record.worker_id, content_hash);
+      if (replayed) {
+        res.status(200).json({
+          ok: true,
+          status: "replay",
+          content_hash,
+          schema_hash,
+          worker_id: record.worker_id,
+        });
+        return;
+      }
+
+      // Derive the operator SS58 from the worker pubkey. The upstream
+      // sponsored-receipt-submitter uses this as the receipt's `operator`.
+      const operatorSs58 = workerPubkeyToSs58(record.worker_pubkey);
+
+      // Persist a "manifest" so the existing cleanup/TTL/index machinery
+      // sees this receipt the same way it sees blob receipts. The manifest
+      // body is the validated record + a synthetic `chunks: []` (no blob
+      // data — the receipt itself IS the data here). We tag it with the
+      // schema marker so a future operator inspecting receipts/{hash}/manifest.json
+      // can tell at a glance what kind of payload it is.
+      const manifest = {
+        schema: SCHEMA_VERSION,
+        record,
+        chunks: [],
+        rootHash: content_hash,
+      };
+      await saveManifest(content_hash, manifest);
+      await updateReceiptMeta(content_hash, { uploaderAddress: operatorSs58 });
+
+      // Mark this submission in worker_state. Order matters: do this BEFORE
+      // firing notify so a same-second retry hits the replay shortcut.
+      recordWorkerSubmission(record.worker_id, record.period_start, content_hash);
+
+      // Append the per-record billing snapshot used by GET /billing/usage
+      // (#112). INSERT OR IGNORE absorbs any duplicate content_hash race —
+      // the replay shortcut above is the primary defense, this is a backstop.
+      recordMeteringSubmission({
+        content_hash,
+        tenant_id: record.tenant_id,
+        worker_id: record.worker_id,
+        period_start_ms: record.period_start,
+        period_end_ms: record.period_end,
+        cpu_seconds: record.cpu_seconds,
+        ram_gb_hours: record.ram_gb_hours,
+        disk_gb_hours: record.disk_gb_hours,
+        net_bytes_in: record.net_bytes_in,
+        net_bytes_out: record.net_bytes_out,
+        gpu_seconds: record.gpu_seconds,
+        submitted_at_ms: Date.now(),
+      });
+
+      // Fire-and-forget upstream notification. Schema_hash is set so the
+      // submitter can pass it through to `submit_receipt_v2(schema_hash=...)`.
+      // `authTier: "bearer"` is a placeholder in the existing submitter
+      // contract — the real attribution comes from `operator + schemaHash`.
+      void notifySponsoredReceiptSubmitter({
+        contentHash: content_hash,
+        operator: operatorSs58,
+        authTier: "bearer",
+        schemaHash: schema_hash,
+        source: METERING_SOURCE,
+        // No rootHash/manifestHash — those are blob-flow concepts. Worker
+        // SDK can compute the manifest hash itself if the submitter ever
+        // needs it; for now we omit.
+      });
+
+      res.status(200).json({
+        ok: true,
+        status: "accepted",
+        content_hash,
+        schema_hash,
+        worker_id: record.worker_id,
+        operator: operatorSs58,
+        sponsored_receipt_submitter_configured:
+          Boolean(config.sponsoredReceiptSubmitterUrl),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[blob-gateway] /metering/submit unexpected error: ${msg}`);
+      res.status(500).json({
+        ok: false,
+        code: "INTERNAL",
+        message: "internal error",
+      });
+    }
+  },
+);

--- a/services/blob-gateway/src/routes/tokens.ts
+++ b/services/blob-gateway/src/routes/tokens.ts
@@ -72,6 +72,8 @@ export function registerTokenRoutes(app: Express, opts: RegisterTokenRoutesOpts 
       const body = (req.body ?? {}) as {
         account?: string;
         label?: string;
+        tenant_id?: string;
+        tenantId?: string;
       };
       if (typeof body.account !== "string" || !SS58_SHAPE.test(body.account)) {
         res.status(400).json({ error: "missing or invalid account (expected SS58 address)" });
@@ -82,14 +84,26 @@ export function registerTokenRoutes(app: Express, opts: RegisterTokenRoutesOpts 
           ? body.label.trim().slice(0, 128)
           : null;
 
+      // Task #119: optional tenant_id binding. Accept either snake_case
+      // (matches the URL param convention used on /billing/usage) or
+      // camelCase. Trim + bound to 128 chars for the same reason as label.
+      const tenantRaw =
+        typeof body.tenant_id === "string" && body.tenant_id.trim()
+          ? body.tenant_id.trim()
+          : typeof body.tenantId === "string" && body.tenantId.trim()
+            ? body.tenantId.trim()
+            : null;
+      const tenantId = tenantRaw ? tenantRaw.slice(0, 128) : null;
+
       const issued = issueToken(getApiTokensDb(), {
         accountSs58: body.account,
         label: label ?? undefined,
+        tenantId: tenantId ?? undefined,
       });
 
-      // Structured audit log — account + label, never the raw token.
+      // Structured audit log — account + label + tenant, never the raw token.
       console.log(
-        `[blob-gateway] api-token minted account=${issued.accountSs58} label=${label ?? "-"} hash=${issued.tokenHash.slice(0, 16)}...`,
+        `[blob-gateway] api-token minted account=${issued.accountSs58} label=${label ?? "-"} tenant=${tenantId ?? "-"} hash=${issued.tokenHash.slice(0, 16)}...`,
       );
 
       res.status(200).json({
@@ -98,6 +112,7 @@ export function registerTokenRoutes(app: Express, opts: RegisterTokenRoutesOpts 
         tokenHash: issued.tokenHash,
         account: issued.accountSs58,
         label: issued.label,
+        tenantId: issued.tenantId,
         createdAt: issued.createdAt,
         message: "Store this token now. It will never be shown again.",
       });

--- a/services/blob-gateway/src/schemas/__tests__/compute_metering_v1.test.ts
+++ b/services/blob-gateway/src/schemas/__tests__/compute_metering_v1.test.ts
@@ -1,0 +1,816 @@
+/**
+ * Unit tests for `compute_metering_v1` schema validator.
+ *
+ * Exhaustive cell-by-cell coverage of every constraint in the schema spec:
+ *   - field present / missing
+ *   - type confusion (string-where-int, array-where-object, NaN, Infinity)
+ *   - shape (regex on ids / hex)
+ *   - bounds (negative, zero, hardware-cap, JS-safe-int, period > 24 h)
+ *   - clock skew (period_end > now+60s)
+ *   - monotonic per-worker (period_start < last)
+ *   - signature verify (valid / corrupt sig / corrupt body / replay)
+ *   - canonical CBOR determinism (key-order independence)
+ *
+ * No mocks for crypto. We use real sr25519 keypairs from @polkadot/keyring.
+ */
+import { describe, test, expect, beforeAll } from "vitest";
+import { Keyring } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+import { createHash } from "crypto";
+
+import {
+  validateComputeMeteringV1,
+  canonicalBody,
+  canonicalContentHash,
+  workerPubkeyToSs58,
+  SCHEMA_VERSION,
+  SCHEMA_HASH_HEX,
+  DEFAULT_BOUNDS,
+  MAX_PERIOD_MS,
+  FUTURE_SKEW_MS,
+  JS_SAFE_INT,
+  type ComputeMeteringV1,
+  type WorkerBounds,
+} from "../compute_metering_v1.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let keyring: Keyring;
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+  keyring = new Keyring({ type: "sr25519" });
+});
+
+interface BuildOpts {
+  worker_id?: string;
+  tenant_id?: string;
+  period_start?: number;
+  period_end?: number;
+  cpu_seconds?: number;
+  ram_gb_hours?: number;
+  disk_gb_hours?: number;
+  net_bytes_in?: number;
+  net_bytes_out?: number;
+  gpu_seconds?: number;
+  /** sr25519 URI seed for the keypair. Default `//ComputeWorker0`. */
+  uri?: string;
+  /** When set, overrides `worker_pubkey` in the output (for tampering tests). */
+  override_pubkey?: string;
+  /** When set, overrides `worker_signature` (for tampering tests). */
+  override_signature?: string;
+}
+
+/**
+ * Build a fully-signed valid record. Override any field via `opts`.
+ * Returns the JSON object suitable for `validateComputeMeteringV1(rec)`.
+ */
+function buildSigned(opts: BuildOpts = {}): ComputeMeteringV1 {
+  const pair = keyring.addFromUri(opts.uri ?? "//ComputeWorker0");
+  // Fixed deterministic period for reproducibility (2025-01-01..+1h):
+  const period_start = opts.period_start ?? 1_735_689_600_000;
+  const period_end = opts.period_end ?? period_start + 3_600_000;
+  const body = {
+    schema_version: SCHEMA_VERSION,
+    worker_id: opts.worker_id ?? "worker-001",
+    tenant_id: opts.tenant_id ?? "tenant-acme",
+    period_start,
+    period_end,
+    cpu_seconds: opts.cpu_seconds ?? 60.5,
+    ram_gb_hours: opts.ram_gb_hours ?? 0.5,
+    disk_gb_hours: opts.disk_gb_hours ?? 1.25,
+    net_bytes_in: opts.net_bytes_in ?? 1_048_576,
+    net_bytes_out: opts.net_bytes_out ?? 524_288,
+    gpu_seconds: opts.gpu_seconds ?? 0,
+    worker_pubkey:
+      opts.override_pubkey ?? u8aToHex(pair.publicKey, undefined, false),
+  } as const;
+  const cb = canonicalBody(body);
+  const sig =
+    opts.override_signature ?? u8aToHex(pair.sign(cb), undefined, false);
+  return { ...body, worker_signature: sig };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Canonical encoder unit tests
+// ---------------------------------------------------------------------------
+
+describe("canonical CBOR encoder — determinism", () => {
+  test("key-order independence: input order doesn't change output bytes", () => {
+    const body1 = canonicalBody({
+      schema_version: SCHEMA_VERSION,
+      worker_id: "abcd",
+      tenant_id: "efgh",
+      period_start: 1_735_689_600_000,
+      period_end: 1_735_689_600_000 + 1000,
+      cpu_seconds: 1.5,
+      ram_gb_hours: 0.0,
+      disk_gb_hours: 0.0,
+      net_bytes_in: 0,
+      net_bytes_out: 0,
+      gpu_seconds: 0.0,
+      worker_pubkey: "ab".repeat(32),
+    });
+    // Same logical record, different field-mention order via spread:
+    const body2 = canonicalBody({
+      worker_pubkey: "ab".repeat(32),
+      gpu_seconds: 0.0,
+      net_bytes_out: 0,
+      net_bytes_in: 0,
+      disk_gb_hours: 0.0,
+      ram_gb_hours: 0.0,
+      cpu_seconds: 1.5,
+      period_end: 1_735_689_600_000 + 1000,
+      period_start: 1_735_689_600_000,
+      tenant_id: "efgh",
+      worker_id: "abcd",
+      schema_version: SCHEMA_VERSION,
+    });
+    expect(u8aToHex(body1)).toBe(u8aToHex(body2));
+  });
+
+  test("content_hash is sha256 of canonical body", () => {
+    const body = canonicalBody({
+      schema_version: SCHEMA_VERSION,
+      worker_id: "abcd",
+      tenant_id: "efgh",
+      period_start: 1_735_689_600_000,
+      period_end: 1_735_689_600_000 + 1000,
+      cpu_seconds: 1.5,
+      ram_gb_hours: 0.0,
+      disk_gb_hours: 0.0,
+      net_bytes_in: 0,
+      net_bytes_out: 0,
+      gpu_seconds: 0.0,
+      worker_pubkey: "ab".repeat(32),
+    });
+    const hash = createHash("sha256").update(body).digest("hex");
+    const helperHash = canonicalContentHash({
+      schema_version: SCHEMA_VERSION,
+      worker_id: "abcd",
+      tenant_id: "efgh",
+      period_start: 1_735_689_600_000,
+      period_end: 1_735_689_600_000 + 1000,
+      cpu_seconds: 1.5,
+      ram_gb_hours: 0.0,
+      disk_gb_hours: 0.0,
+      net_bytes_in: 0,
+      net_bytes_out: 0,
+      gpu_seconds: 0.0,
+      worker_pubkey: "ab".repeat(32),
+    });
+    expect(helperHash).toBe(hash);
+  });
+
+  test("SCHEMA_HASH_HEX is sha256 of the version string", () => {
+    const expected = createHash("sha256")
+      .update("compute_metering_v1", "utf-8")
+      .digest("hex");
+    expect(SCHEMA_HASH_HEX).toBe(expected);
+  });
+
+  test("workerPubkeyToSs58 round-trips through Keyring address", () => {
+    const pair = keyring.addFromUri("//ComputeWorker0");
+    const hex = u8aToHex(pair.publicKey, undefined, false);
+    const ss58 = workerPubkeyToSs58(hex);
+    expect(ss58).toBe(pair.address);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Happy path
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — happy path", () => {
+  test("valid record → ok with content_hash and schema_hash", () => {
+    const rec = buildSigned();
+    const res = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1000,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.content_hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(res.schema_hash).toBe(SCHEMA_HASH_HEX);
+      expect(res.canonical_body).toBeInstanceOf(Uint8Array);
+      expect(res.canonical_body.length).toBeGreaterThan(0);
+      // Content-hash is reproducible from the canonical body in the result.
+      expect(
+        createHash("sha256").update(res.canonical_body).digest("hex"),
+      ).toBe(res.content_hash);
+    }
+  });
+
+  test("zero-valued resource fields are allowed", () => {
+    const rec = buildSigned({
+      cpu_seconds: 0,
+      ram_gb_hours: 0,
+      disk_gb_hours: 0,
+      net_bytes_in: 0,
+      net_bytes_out: 0,
+      gpu_seconds: 0,
+    });
+    const res = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1000,
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  test("max-allowed bounds (exact cap) is allowed", () => {
+    const period_start = 1_735_689_600_000;
+    const period_end = period_start + 3_600_000;
+    const periodSec = (period_end - period_start) / 1000;
+    const periodHr = (period_end - period_start) / 3_600_000;
+    const rec = buildSigned({
+      period_start,
+      period_end,
+      cpu_seconds: periodSec * DEFAULT_BOUNDS.max_cpu_cores,
+      ram_gb_hours: periodHr * DEFAULT_BOUNDS.max_ram_gb,
+      disk_gb_hours: periodHr * DEFAULT_BOUNDS.max_disk_gb,
+      gpu_seconds: periodSec * DEFAULT_BOUNDS.max_gpu_count,
+      net_bytes_in: JS_SAFE_INT,
+      net_bytes_out: JS_SAFE_INT,
+    });
+    const res = validateComputeMeteringV1(rec, {
+      now_ms: period_end + 1000,
+    });
+    expect(res.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Missing / wrong type
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — missing fields", () => {
+  test("null root → WRONG_TYPE", () => {
+    const r = validateComputeMeteringV1(null);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_TYPE");
+  });
+
+  test("array root → WRONG_TYPE", () => {
+    const r = validateComputeMeteringV1([1, 2, 3]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_TYPE");
+  });
+
+  test("string root → WRONG_TYPE", () => {
+    const r = validateComputeMeteringV1("not an object");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_TYPE");
+  });
+
+  // Each required field, omitted in turn, must produce MISSING_FIELD with the
+  // correct field name. Drives one assertion per field — exhaustive coverage.
+  const fields: Array<keyof ComputeMeteringV1> = [
+    "schema_version",
+    "worker_id",
+    "tenant_id",
+    "period_start",
+    "period_end",
+    "cpu_seconds",
+    "ram_gb_hours",
+    "disk_gb_hours",
+    "net_bytes_in",
+    "net_bytes_out",
+    "gpu_seconds",
+    "worker_pubkey",
+    "worker_signature",
+  ];
+
+  for (const f of fields) {
+    test(`missing ${f} → MISSING_FIELD with field=${f}`, () => {
+      const rec = buildSigned() as Record<string, unknown>;
+      delete rec[f];
+      const res = validateComputeMeteringV1(rec, {
+        now_ms: 1_735_693_200_000 + 1000,
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.code).toBe("MISSING_FIELD");
+        expect(res.field).toBe(f);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. Wrong type per field
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — wrong type per field", () => {
+  test("schema_version not string → WRONG_TYPE", () => {
+    const rec = { ...buildSigned(), schema_version: 42 };
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("WRONG_TYPE");
+      expect(r.field).toBe("schema_version");
+    }
+  });
+
+  test("worker_id not string → WRONG_TYPE", () => {
+    const rec = { ...buildSigned(), worker_id: 1 };
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("WRONG_TYPE");
+      expect(r.field).toBe("worker_id");
+    }
+  });
+
+  test("period_start not integer (float) → WRONG_TYPE", () => {
+    const rec = { ...buildSigned(), period_start: 1.5 };
+    const r = validateComputeMeteringV1(rec, { now_ms: 1_735_693_200_000 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("WRONG_TYPE");
+      expect(r.field).toBe("period_start");
+    }
+  });
+
+  test("net_bytes_in non-integer → WRONG_TYPE", () => {
+    const rec = { ...buildSigned(), net_bytes_in: 1.7 };
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("WRONG_TYPE");
+      expect(r.field).toBe("net_bytes_in");
+    }
+  });
+
+  test("cpu_seconds NaN → WRONG_TYPE", () => {
+    const rec = { ...buildSigned(), cpu_seconds: NaN };
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("WRONG_TYPE");
+      expect(r.field).toBe("cpu_seconds");
+    }
+  });
+
+  test("cpu_seconds Infinity → WRONG_TYPE", () => {
+    const rec = { ...buildSigned(), cpu_seconds: Infinity };
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_TYPE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Schema version
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — schema_version", () => {
+  test("rejects mismatched version", () => {
+    const rec = { ...buildSigned(), schema_version: "compute_metering_v2" };
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("WRONG_SCHEMA_VERSION");
+      expect(r.field).toBe("schema_version");
+    }
+  });
+
+  test("rejects close-but-different version (case sensitive)", () => {
+    const rec = { ...buildSigned(), schema_version: "Compute_Metering_V1" };
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_SCHEMA_VERSION");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. ID format
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — id format", () => {
+  test("worker_id too short (< 4) rejected", () => {
+    const r = validateComputeMeteringV1(buildSigned({ worker_id: "abc" }), {
+      now_ms: 1_735_700_000_000,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("ID_FORMAT");
+      expect(r.field).toBe("worker_id");
+    }
+  });
+
+  test("worker_id too long (> 64) rejected", () => {
+    const r = validateComputeMeteringV1(buildSigned({ worker_id: "a".repeat(65) }), {
+      now_ms: 1_735_700_000_000,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("ID_FORMAT");
+  });
+
+  test("worker_id with uppercase rejected", () => {
+    const r = validateComputeMeteringV1(buildSigned({ worker_id: "WORKER" }), {
+      now_ms: 1_735_700_000_000,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("ID_FORMAT");
+  });
+
+  test("worker_id with disallowed chars rejected", () => {
+    const r = validateComputeMeteringV1(buildSigned({ worker_id: "worker_001" }), {
+      now_ms: 1_735_700_000_000,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("ID_FORMAT");
+  });
+
+  test("tenant_id with leading dash and digits accepted", () => {
+    const rec = buildSigned({ tenant_id: "tenant-007" });
+    const r = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1,
+    });
+    expect(r.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Period validation
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — period", () => {
+  test("period_start <= 0 rejected", () => {
+    const rec = buildSigned({
+      period_start: 0,
+      period_end: 1000,
+    });
+    const r = validateComputeMeteringV1(rec, { now_ms: 1_735_700_000_000 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("PERIOD_INVALID");
+      expect(r.field).toBe("period_start");
+    }
+  });
+
+  test("period_start negative rejected", () => {
+    const rec = buildSigned({
+      period_start: -1,
+      period_end: 1000,
+    });
+    const r = validateComputeMeteringV1(rec, { now_ms: 1_735_700_000_000 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("PERIOD_INVALID");
+  });
+
+  test("period_end == period_start rejected", () => {
+    const rec = buildSigned({
+      period_start: 1_735_689_600_000,
+      period_end: 1_735_689_600_000,
+    });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("PERIOD_INVALID");
+      expect(r.field).toBe("period_end");
+    }
+  });
+
+  test("period_end < period_start rejected", () => {
+    const rec = buildSigned({
+      period_start: 1_735_689_600_000,
+      period_end: 1_735_689_500_000,
+    });
+    const r = validateComputeMeteringV1(rec, { now_ms: 1_735_700_000_000 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("PERIOD_INVALID");
+  });
+
+  test("period > 24 h rejected", () => {
+    const start = 1_735_689_600_000;
+    const rec = buildSigned({
+      period_start: start,
+      period_end: start + MAX_PERIOD_MS + 1,
+      // Keep resource fields zero so we don't trip a bound first.
+      cpu_seconds: 0,
+      ram_gb_hours: 0,
+      disk_gb_hours: 0,
+      gpu_seconds: 0,
+    });
+    const r = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("PERIOD_INVALID");
+  });
+
+  test("period == exactly 24 h accepted", () => {
+    const start = 1_735_689_600_000;
+    const rec = buildSigned({
+      period_start: start,
+      period_end: start + MAX_PERIOD_MS,
+      cpu_seconds: 0,
+      ram_gb_hours: 0,
+      disk_gb_hours: 0,
+      gpu_seconds: 0,
+    });
+    const r = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  test("period_end > now + 60s rejected (clock skew)", () => {
+    const now = 1_735_700_000_000;
+    const rec = buildSigned({
+      period_start: now - 3_600_000,
+      period_end: now + FUTURE_SKEW_MS + 1,
+    });
+    const r = validateComputeMeteringV1(rec, { now_ms: now });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("PERIOD_INVALID");
+      expect(r.field).toBe("period_end");
+    }
+  });
+
+  test("period_end == now + 60s accepted (skew exact)", () => {
+    const now = 1_735_700_000_000;
+    const rec = buildSigned({
+      period_start: now - 3_600_000,
+      period_end: now + FUTURE_SKEW_MS,
+    });
+    const r = validateComputeMeteringV1(rec, { now_ms: now });
+    expect(r.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Bounds
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — resource bounds", () => {
+  test("negative cpu_seconds rejected", () => {
+    const rec = buildSigned({ cpu_seconds: -0.001 });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("NEGATIVE_VALUE");
+      expect(r.field).toBe("cpu_seconds");
+    }
+  });
+
+  test("negative net_bytes_in rejected", () => {
+    const rec = buildSigned({ net_bytes_in: -1 });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("NEGATIVE_VALUE");
+  });
+
+  test("cpu_seconds exceeds hardware-implausible cap (default bounds)", () => {
+    // 1-hour period × 128 cores = 460800 max cpu_seconds. Push above.
+    const rec = buildSigned({ cpu_seconds: 460_801 });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("BOUND_EXCEEDED");
+      expect(r.field).toBe("cpu_seconds");
+    }
+  });
+
+  test("ram_gb_hours exceeds bound", () => {
+    // 1-hour period × 2048 GB = 2048 max ram_gb_hours.
+    const rec = buildSigned({ ram_gb_hours: 2049 });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("BOUND_EXCEEDED");
+  });
+
+  test("disk_gb_hours exceeds bound", () => {
+    const rec = buildSigned({ disk_gb_hours: 16_385 });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("BOUND_EXCEEDED");
+  });
+
+  test("gpu_seconds exceeds bound", () => {
+    // 1-hour × 8 = 28800
+    const rec = buildSigned({ gpu_seconds: 28_801 });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("BOUND_EXCEEDED");
+  });
+
+  test("net_bytes_in == JS_SAFE_INT accepted; +1 over rejected", () => {
+    const rec = buildSigned({ net_bytes_in: JS_SAFE_INT });
+    const okRes = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(okRes.ok).toBe(true);
+
+    // For values > 2^53, JS rounds to even — Number.isInteger may still be
+    // true (e.g. 2^53 + 2 round-trips). The schema explicitly rejects
+    // anything > JS_SAFE_INT regardless. Build the over-cap record by hand
+    // (skip buildSigned, which sign-encodes via canonicalBody and would itself
+    // refuse the oversized value — that defence-in-depth is desired and
+    // separately tested below).
+    const oversized = Number.MAX_SAFE_INTEGER + 2; // === 2^53 + 2
+    expect(Number.isInteger(oversized)).toBe(true);
+    const ok = buildSigned();
+    const recBig: ComputeMeteringV1 = {
+      ...ok,
+      net_bytes_in: oversized,
+      // Signature is now invalid for the tampered body — but the validator
+      // checks bounds BEFORE signature, so it will fail on INT_OVERFLOW first.
+    };
+    const overRes = validateComputeMeteringV1(recBig, {
+      now_ms: recBig.period_end + 1,
+    });
+    expect(overRes.ok).toBe(false);
+    if (!overRes.ok) expect(overRes.code).toBe("INT_OVERFLOW");
+  });
+
+  test("canonicalBody itself refuses to encode > JS_SAFE_INT (defence-in-depth)", () => {
+    expect(() =>
+      canonicalBody({
+        schema_version: SCHEMA_VERSION,
+        worker_id: "wkr-001",
+        tenant_id: "ten-001",
+        period_start: 1,
+        period_end: 2,
+        cpu_seconds: 0,
+        ram_gb_hours: 0,
+        disk_gb_hours: 0,
+        net_bytes_in: Number.MAX_SAFE_INTEGER + 2,
+        net_bytes_out: 0,
+        gpu_seconds: 0,
+        worker_pubkey: "ab".repeat(32),
+      }),
+    ).toThrow(/exceeds JS-safe int/);
+  });
+
+  test("custom bounds: smaller cap applied", () => {
+    const small: WorkerBounds = {
+      max_cpu_cores: 1,
+      max_ram_gb: 1,
+      max_disk_gb: 1,
+      max_gpu_count: 1,
+    };
+    // 1h × 1 core = 3600 cpu_seconds. Default would allow ~460k.
+    const rec = buildSigned({ cpu_seconds: 3601 });
+    const r = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1,
+      bounds: small,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("BOUND_EXCEEDED");
+      expect(r.field).toBe("cpu_seconds");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Hex format
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — hex format", () => {
+  test("worker_pubkey wrong length (62) rejected", () => {
+    const rec = buildSigned({ override_pubkey: "ab".repeat(31) });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("HEX_FORMAT");
+      expect(r.field).toBe("worker_pubkey");
+    }
+  });
+
+  test("worker_pubkey uppercase hex rejected (canonicalisation)", () => {
+    const rec = buildSigned({ override_pubkey: "AB".repeat(32) });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("HEX_FORMAT");
+  });
+
+  test("worker_pubkey 0x-prefixed rejected (we want raw 64-hex)", () => {
+    const rec = buildSigned({ override_pubkey: "0x" + "ab".repeat(32) });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("HEX_FORMAT");
+  });
+
+  test("worker_signature wrong length rejected", () => {
+    const rec = buildSigned({ override_signature: "cd".repeat(63) });
+    const r = validateComputeMeteringV1(rec, { now_ms: rec.period_end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("HEX_FORMAT");
+      expect(r.field).toBe("worker_signature");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Signature verify
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — signature verification", () => {
+  test("corrupt signature (one bit flipped) → SIGNATURE_INVALID", () => {
+    const rec = buildSigned();
+    // Flip one nibble in the signature.
+    const flipped =
+      rec.worker_signature.slice(0, 2) === "00"
+        ? "01" + rec.worker_signature.slice(2)
+        : "00" + rec.worker_signature.slice(2);
+    const tampered = { ...rec, worker_signature: flipped };
+    const r = validateComputeMeteringV1(tampered, {
+      now_ms: tampered.period_end + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("SIGNATURE_INVALID");
+      expect(r.field).toBe("worker_signature");
+    }
+  });
+
+  test("body tampered after sign (cpu_seconds) → SIGNATURE_INVALID", () => {
+    const rec = buildSigned();
+    const tampered = { ...rec, cpu_seconds: rec.cpu_seconds + 1 };
+    const r = validateComputeMeteringV1(tampered, {
+      now_ms: tampered.period_end + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("SIGNATURE_INVALID");
+  });
+
+  test("pubkey swapped to a different worker → SIGNATURE_INVALID", () => {
+    const rec = buildSigned({ uri: "//ComputeWorker0" });
+    const otherPair = keyring.addFromUri("//ComputeWorker1");
+    const tampered = {
+      ...rec,
+      worker_pubkey: u8aToHex(otherPair.publicKey, undefined, false),
+    };
+    const r = validateComputeMeteringV1(tampered, {
+      now_ms: tampered.period_end + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("SIGNATURE_INVALID");
+  });
+
+  test("replay: same record verifies twice (no statefulness in validator)", () => {
+    // Validator itself is stateless re: replay — replay protection is the
+    // caller's job (chain-level dedup via content_hash + monotonic
+    // period_start). This test pins that behaviour so a future refactor
+    // doesn't accidentally introduce statefulness here.
+    const rec = buildSigned();
+    const r1 = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1,
+    });
+    const r2 = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1,
+    });
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    if (r1.ok && r2.ok) {
+      expect(r1.content_hash).toBe(r2.content_hash);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. Monotonic period_start
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV1 — monotonic period_start", () => {
+  test("period_start < last_period_start rejected", () => {
+    const rec = buildSigned({
+      period_start: 1_735_689_600_000,
+      period_end: 1_735_689_600_000 + 1000,
+    });
+    const r = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1,
+      last_period_start: rec.period_start + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("MONOTONIC_VIOLATION");
+      expect(r.field).toBe("period_start");
+    }
+  });
+
+  test("period_start == last_period_start accepted (non-decreasing)", () => {
+    const rec = buildSigned({
+      period_start: 1_735_689_600_000,
+      period_end: 1_735_689_600_000 + 1000,
+    });
+    const r = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1,
+      last_period_start: rec.period_start,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  test("first record (last_period_start = 0) accepted", () => {
+    const rec = buildSigned();
+    const r = validateComputeMeteringV1(rec, {
+      now_ms: rec.period_end + 1,
+      last_period_start: 0,
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/services/blob-gateway/src/schemas/__tests__/metering_live_preprod.test.ts
+++ b/services/blob-gateway/src/schemas/__tests__/metering_live_preprod.test.ts
@@ -1,0 +1,430 @@
+/**
+ * LIVE PREPROD integration test for `POST /metering/submit`.
+ *
+ * Per the convention captured in
+ * `feedback_intent_settlement_chain_tdd.md` — chain-side validation tests
+ * hit the live preprod chain with NO mocks. Wire here:
+ *
+ *   1. Spin up a local blob-gateway-only Express app in this process,
+ *      pointed at the production preprod RPC (wss://materios.fluxpointstudios.com/preprod-rpc).
+ *      Only the metering route is mounted (we don't need the full gateway
+ *      surface, just the validator + sponsored-receipt forwarding glue).
+ *
+ *   2. Generate a fresh sr25519 keypair, build a valid `compute_metering_v1`
+ *      record, sign the canonical body, POST it to /metering/submit. Confirm
+ *      the route returned 200 and a content_hash.
+ *
+ *   3. Submit a receipt to the on-chain pallet directly using the SDK's
+ *      `submitReceipt()` with //Alice as signer. The metering route's
+ *      sponsored-receipt-submitter is fired via the fake submitter (so we
+ *      can assert on its payload), but the on-chain leg uses the SDK
+ *      because there is no live submitter pointed at preprod that we can
+ *      reuse from this test process. Schema_hash = SCHEMA_HASH_HEX is
+ *      passed through verbatim so the on-chain receipt records the
+ *      compute-metering-v1 schema.
+ *
+ *   4. Poll `orinq_getReceipt` until the receipt appears (deadline-bounded,
+ *      no sleep loops). Assert the receipt's content_hash matches what the
+ *      route returned.
+ *
+ *   5. Poll `orinq_getReceiptStatus` (via SDK helper) for non-zero cert
+ *      hash → asserts "Certified" eventually. We give cert-daemon up to
+ *      90s; if it doesn't certify in that window we record "Submitted but
+ *      not yet certified" and DO NOT fail the test (cert-daemon health is
+ *      not what this test is exercising — it's a separate component).
+ *
+ * Gating: this test runs ONLY when `LIVE_PREPROD=1` is set in the
+ * environment. CI configurations that don't have outbound preprod access
+ * skip it. To run locally:
+ *
+ *   LIVE_PREPROD=1 npx vitest run services/blob-gateway/src/schemas/__tests__/metering_live_preprod.test.ts
+ */
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { ApiPromise, Keyring, WsProvider } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+import { createHash } from "crypto";
+
+import { config } from "../../config.js";
+import { meteringRouter } from "../../routes/metering.js";
+import {
+  initWorkerBoundsDb,
+  setWorkerBoundsDbForTests,
+} from "../../worker_bounds.js";
+import {
+  canonicalBody,
+  SCHEMA_HASH_HEX,
+  SCHEMA_VERSION,
+  type ComputeMeteringV1,
+} from "../compute_metering_v1.js";
+
+const PREPROD_WSS = "wss://materios.fluxpointstudios.com/preprod-rpc";
+const LIVE = process.env.LIVE_PREPROD === "1";
+
+// Cert-daemon timing on preprod typically certifies inside 30-60s; allow 90s
+// before degrading to "submitted but not yet certified".
+const CERT_DEADLINE_MS = 90_000;
+// Receipt should appear within a few blocks; preprod block time is ~6s.
+const RECEIPT_APPEAR_DEADLINE_MS = 60_000;
+
+interface FakeSubmitter {
+  server: Server;
+  port: number;
+  captured: Array<{ body: string }>;
+  stop(): Promise<void>;
+}
+
+async function startFakeSubmitter(): Promise<FakeSubmitter> {
+  const captured: FakeSubmitter["captured"] = [];
+  const server = createServer((req: IncomingMessage, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      captured.push({ body: Buffer.concat(chunks).toString("utf-8") });
+      res.statusCode = 202;
+      res.setHeader("content-type", "application/json");
+      res.end('{"accepted":true}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    server,
+    port,
+    captured,
+    async stop() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+interface AppCtx {
+  app: express.Express;
+  storage: string;
+  prevStorage: string;
+  prevSubmitterUrl: string;
+  fake: FakeSubmitter;
+  db: Database.Database;
+}
+
+async function setupApp(): Promise<AppCtx> {
+  const storage = mkdtempSync(join(tmpdir(), "metering-live-test-"));
+  const prevStorage = config.storagePath;
+  config.storagePath = storage;
+
+  const db = new Database(":memory:");
+  initWorkerBoundsDb(db);
+  setWorkerBoundsDbForTests(db);
+
+  const fake = await startFakeSubmitter();
+  const prevSubmitterUrl = config.sponsoredReceiptSubmitterUrl;
+  config.sponsoredReceiptSubmitterUrl = `http://127.0.0.1:${fake.port}/submit`;
+
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.use(meteringRouter);
+
+  return { app, storage, prevStorage, prevSubmitterUrl, fake, db };
+}
+
+async function teardown(ctx: AppCtx): Promise<void> {
+  config.storagePath = ctx.prevStorage;
+  config.sponsoredReceiptSubmitterUrl = ctx.prevSubmitterUrl;
+  await ctx.fake.stop();
+  rmSync(ctx.storage, { recursive: true, force: true });
+  ctx.db.close();
+}
+
+async function postJson(
+  app: express.Express,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${(addr as AddressInfo).port}${path}`;
+      fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+/**
+ * Deadline-bounded polling helper. Returns the value when the predicate
+ * resolves to non-undefined; throws on timeout.
+ */
+async function pollUntil<T>(
+  fn: () => Promise<T | undefined>,
+  opts: { deadlineMs: number; intervalMs?: number; what: string },
+): Promise<T> {
+  const deadline = Date.now() + opts.deadlineMs;
+  const interval = opts.intervalMs ?? 2000;
+  while (Date.now() < deadline) {
+    const v = await fn();
+    if (v !== undefined && v !== null) return v;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`pollUntil timeout after ${opts.deadlineMs}ms: ${opts.what}`);
+}
+
+function computeReceiptId(contentHashHex: string): string {
+  return (
+    "0x" +
+    createHash("sha256")
+      .update(Buffer.from(contentHashHex, "hex"))
+      .digest("hex")
+  );
+}
+
+const describeMaybe = LIVE ? describe : describe.skip;
+
+describeMaybe("POST /metering/submit — LIVE preprod end-to-end", () => {
+  let appCtx: AppCtx;
+  let api: ApiPromise;
+
+  beforeAll(async () => {
+    await cryptoWaitReady();
+    appCtx = await setupApp();
+    const provider = new WsProvider(PREPROD_WSS, 5000);
+    api = await ApiPromise.create({ provider, noInitWarn: true });
+    const chain = (await api.rpc.system.chain()).toString();
+    // Sanity: confirm we connected to the right chain. If this is a wrong
+    // chain (e.g. mainnet), abort early so we don't accidentally write to it.
+    if (!/preprod/i.test(chain)) {
+      throw new Error(
+        `LIVE_PREPROD pointed at unexpected chain "${chain}" — refusing to run`,
+      );
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      `[live-preprod] connected to "${chain}" via ${PREPROD_WSS}`,
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    if (api) await api.disconnect();
+    if (appCtx) await teardown(appCtx);
+  });
+
+  test(
+    "valid record → 200 → on-chain receipt appears → eventually certified",
+    async () => {
+      const keyring = new Keyring({ type: "sr25519" });
+      // Fresh worker key per test run. Period: a 5-minute window ending
+      // 30s ago so we're well inside the 60s skew tolerance.
+      const workerPair = keyring.addFromUri(
+        "//ComputeWorkerLive" + Date.now(),
+      );
+      const period_end = Date.now() - 30_000;
+      const period_start = period_end - 5 * 60_000;
+      const baseBody = {
+        schema_version: SCHEMA_VERSION,
+        worker_id: "wkr-live-" + Date.now().toString(36),
+        tenant_id: "ten-live-" + Date.now().toString(36),
+        period_start,
+        period_end,
+        cpu_seconds: 12.5,
+        ram_gb_hours: 0.1,
+        disk_gb_hours: 0.05,
+        net_bytes_in: 4096,
+        net_bytes_out: 2048,
+        gpu_seconds: 0,
+        worker_pubkey: u8aToHex(workerPair.publicKey, undefined, false),
+      };
+      const cb = canonicalBody(baseBody);
+      const sig = u8aToHex(workerPair.sign(cb), undefined, false);
+      const record: ComputeMeteringV1 = { ...baseBody, worker_signature: sig };
+
+      // 1. POST to local /metering/submit
+      const res = await postJson(appCtx.app, "/metering/submit", record);
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        ok: true;
+        status: string;
+        content_hash: string;
+        schema_hash: string;
+        operator: string;
+      };
+      expect(body.ok).toBe(true);
+      expect(body.status).toBe("accepted");
+      expect(body.content_hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(body.schema_hash).toBe(SCHEMA_HASH_HEX);
+
+      // 2. Submit on-chain via SDK using //Alice (the only funded preprod
+      //    test signer accessible to this test process). schema_hash is
+      //    passed exactly as the validator returned it, proving end-to-end
+      //    that the gateway-derived hash and the on-chain hash match.
+      const alice = keyring.addFromUri("//Alice");
+      const contentHashHex = body.content_hash;
+      const receiptId = computeReceiptId(contentHashHex);
+
+      // Build the extrinsic by hand to expose schema_hash explicitly. The
+      // SDK's `submitReceipt()` zeroes schema_hash (it predates the
+      // compute-metering schema), so we don't use it here.
+      // Live arg order on preprod: receiptId, contentHash, baseRootSha256,
+      // zkRootPoseidon (Option), poseidonParamsHash (Option), baseManifestHash,
+      // safetyManifestHash, monitorConfigHash, attestationEvidenceHash,
+      // storageLocatorHash, schemaHash.
+      const tx = (
+        api.tx as unknown as Record<
+          string,
+          Record<string, (...args: unknown[]) => unknown>
+        >
+      ).orinqReceipts.submitReceipt(
+        receiptId,
+        "0x" + contentHashHex,
+        "0x" + contentHashHex,         // baseRootSha256
+        null,                          // zkRootPoseidon (Option)
+        null,                          // poseidonParamsHash (Option)
+        "0x" + contentHashHex,         // baseManifestHash
+        "0x" + "00".repeat(32),        // safetyManifestHash
+        "0x" + "00".repeat(32),        // monitorConfigHash
+        "0x" + "00".repeat(32),        // attestationEvidenceHash
+        "0x" + "00".repeat(32),        // storageLocatorHash
+        "0x" + body.schema_hash,       // schemaHash — THE point of this test
+      );
+
+      const txHash = await new Promise<string>((resolve, reject) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (tx as any).signAndSend(
+          alice,
+          { nonce: -1 },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ({ status, dispatchError, txHash: hash }: any) => {
+            if (dispatchError) {
+              if (dispatchError.isModule) {
+                const decoded = api.registry.findMetaError(
+                  dispatchError.asModule,
+                );
+                reject(
+                  new Error(
+                    `dispatch ${decoded.section}.${decoded.name}: ${decoded.docs.join(" ")}`,
+                  ),
+                );
+              } else {
+                reject(new Error(`dispatch ${String(dispatchError)}`));
+              }
+              return;
+            }
+            if (status.isInBlock) {
+              resolve(hash ? hash.toHex() : "0x");
+            }
+          },
+        );
+      });
+      // eslint-disable-next-line no-console
+      console.log(
+        `[live-preprod] submitted receipt receiptId=${receiptId} content_hash=${contentHashHex} txHash=${txHash}`,
+      );
+
+      // 3. Poll `orinq_getReceipt` until the record exists.
+      const onChainRecord = await pollUntil(
+        async () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const result: any = await (api.query as any).orinqReceipts.receipts(
+            receiptId,
+          );
+          if (result.isEmpty) return undefined;
+          return result.toJSON() as Record<string, unknown>;
+        },
+        {
+          deadlineMs: RECEIPT_APPEAR_DEADLINE_MS,
+          intervalMs: 3000,
+          what: "receipt to appear in storage",
+        },
+      );
+      const onChainContentHash = String(
+        onChainRecord.content_hash ?? onChainRecord.contentHash ?? "",
+      ).replace(/^0x/, "");
+      expect(onChainContentHash.toLowerCase()).toBe(contentHashHex);
+
+      // schema_hash must round-trip — proves the validator-derived hash is
+      // what lands on chain. (The pallet treats it as opaque [u8; 32], so a
+      // round-trip is sufficient.)
+      const onChainSchemaHash = String(
+        onChainRecord.schema_hash ?? onChainRecord.schemaHash ?? "",
+      ).replace(/^0x/, "");
+      expect(onChainSchemaHash.toLowerCase()).toBe(SCHEMA_HASH_HEX);
+
+      // 4. Poll for certification — but DO NOT fail the test if cert-daemon
+      //    is slow. The point of THIS test is the metering→content_hash→
+      //    on-chain leg; cert-daemon is exercised elsewhere.
+      let certified = false;
+      try {
+        await pollUntil(
+          async () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const result: any = await (api.query as any).orinqReceipts.receipts(
+              receiptId,
+            );
+            if (result.isEmpty) return undefined;
+            const record = result.toJSON() as Record<string, unknown>;
+            const certHash = String(
+              record.availability_cert_hash ??
+                record.availabilityCertHash ??
+                "",
+            ).replace(/^0x/, "");
+            // Zero hash → still pending; non-zero → certified.
+            return certHash && certHash !== "00".repeat(32) ? true : undefined;
+          },
+          {
+            deadlineMs: CERT_DEADLINE_MS,
+            intervalMs: 3000,
+            what: "receipt to be certified",
+          },
+        );
+        certified = true;
+        // eslint-disable-next-line no-console
+        console.log(
+          `[live-preprod] receipt CERTIFIED receiptId=${receiptId}`,
+        );
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[live-preprod] receipt submitted but NOT certified within ${CERT_DEADLINE_MS}ms — cert-daemon health check not part of this test. err=${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      // Either certified or in-storage-pending counts as success for this
+      // test's contract — the metering route delivered a content_hash that
+      // round-trips through the on-chain pallet, AND the schema_hash matches.
+      expect(onChainContentHash).toBeTruthy();
+      // Surface the certification outcome for the test report.
+      // eslint-disable-next-line no-console
+      console.log(
+        `[live-preprod] terminal status: certified=${certified} content_hash=${contentHashHex}`,
+      );
+    },
+    /* timeout: */ CERT_DEADLINE_MS + RECEIPT_APPEAR_DEADLINE_MS + 60_000,
+  );
+});

--- a/services/blob-gateway/src/schemas/__tests__/metering_route.test.ts
+++ b/services/blob-gateway/src/schemas/__tests__/metering_route.test.ts
@@ -1,0 +1,439 @@
+/**
+ * Integration tests for `POST /metering/submit`.
+ *
+ * In-process Express server, real schema validator, real worker_bounds db
+ * (in-memory), real Polkadot crypto. The sponsored-receipt-submitter is a
+ * fake HTTP server (mirrors the existing pattern in
+ * `__tests__/sponsored-receipts.test.ts`) so we can assert the outbound
+ * payload shape without hitting a real submitter.
+ */
+import { describe, test, expect, beforeEach, afterEach, beforeAll } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { Keyring } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+
+import { config } from "../../config.js";
+import { meteringRouter } from "../../routes/metering.js";
+import {
+  initWorkerBoundsDb,
+  setWorkerBoundsDbForTests,
+  upsertWorkerBounds,
+} from "../../worker_bounds.js";
+import {
+  canonicalBody,
+  SCHEMA_VERSION,
+  SCHEMA_HASH_HEX,
+  workerPubkeyToSs58,
+  type ComputeMeteringV1,
+} from "../compute_metering_v1.js";
+
+let keyring: Keyring;
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+  keyring = new Keyring({ type: "sr25519" });
+});
+
+interface FakeSubmitter {
+  server: Server;
+  port: number;
+  captured: Array<{
+    method: string;
+    url: string;
+    body: string;
+    headers: Record<string, string | string[] | undefined>;
+  }>;
+  stop(): Promise<void>;
+}
+
+async function startFakeSubmitter(): Promise<FakeSubmitter> {
+  const captured: FakeSubmitter["captured"] = [];
+  const server = createServer((req: IncomingMessage, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      captured.push({
+        method: req.method || "",
+        url: req.url || "",
+        body: Buffer.concat(chunks).toString("utf-8"),
+        headers: { ...req.headers },
+      });
+      res.statusCode = 202;
+      res.setHeader("content-type", "application/json");
+      res.end('{"accepted":true}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    server,
+    port,
+    captured,
+    async stop() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+interface BuildOpts {
+  worker_id?: string;
+  tenant_id?: string;
+  period_start?: number;
+  period_end?: number;
+  cpu_seconds?: number;
+  ram_gb_hours?: number;
+  disk_gb_hours?: number;
+  net_bytes_in?: number;
+  net_bytes_out?: number;
+  gpu_seconds?: number;
+  uri?: string;
+}
+
+function buildSigned(opts: BuildOpts = {}): ComputeMeteringV1 {
+  const pair = keyring.addFromUri(opts.uri ?? "//ComputeWorker0");
+  const now = Date.now();
+  // Default period: 1h ending 5s ago — comfortably inside the skew tolerance.
+  const period_end = opts.period_end ?? now - 5000;
+  const period_start = opts.period_start ?? period_end - 3_600_000;
+  const body = {
+    schema_version: SCHEMA_VERSION,
+    worker_id: opts.worker_id ?? "worker-int-001",
+    tenant_id: opts.tenant_id ?? "tenant-acme-1",
+    period_start,
+    period_end,
+    cpu_seconds: opts.cpu_seconds ?? 30,
+    ram_gb_hours: opts.ram_gb_hours ?? 0.5,
+    disk_gb_hours: opts.disk_gb_hours ?? 1,
+    net_bytes_in: opts.net_bytes_in ?? 1024,
+    net_bytes_out: opts.net_bytes_out ?? 512,
+    gpu_seconds: opts.gpu_seconds ?? 0,
+    worker_pubkey: u8aToHex(pair.publicKey, undefined, false),
+  } as const;
+  const cb = canonicalBody(body);
+  const sig = u8aToHex(pair.sign(cb), undefined, false);
+  return { ...body, worker_signature: sig };
+}
+
+interface Ctx {
+  app: express.Express;
+  storage: string;
+  prevStorage: string;
+  prevSubmitterUrl: string;
+  prevSubmitterTimeout: number;
+  fake: FakeSubmitter;
+  db: Database.Database;
+}
+
+async function setupApp(): Promise<Ctx> {
+  const storage = mkdtempSync(join(tmpdir(), "metering-test-"));
+  const prevStorage = config.storagePath;
+  config.storagePath = storage;
+
+  // Worker-bounds DB in-memory; mirror the production schema.
+  const db = new Database(":memory:");
+  initWorkerBoundsDb(db);
+  setWorkerBoundsDbForTests(db);
+
+  // Fake submitter
+  const fake = await startFakeSubmitter();
+  const prevSubmitterUrl = config.sponsoredReceiptSubmitterUrl;
+  const prevSubmitterTimeout = config.sponsoredReceiptNotifyTimeoutMs;
+  config.sponsoredReceiptSubmitterUrl = `http://127.0.0.1:${fake.port}/submit`;
+  config.sponsoredReceiptNotifyTimeoutMs = 5000;
+
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.use(meteringRouter);
+
+  return {
+    app,
+    storage,
+    prevStorage,
+    prevSubmitterUrl,
+    prevSubmitterTimeout,
+    fake,
+    db,
+  };
+}
+
+async function teardown(ctx: Ctx): Promise<void> {
+  config.storagePath = ctx.prevStorage;
+  config.sponsoredReceiptSubmitterUrl = ctx.prevSubmitterUrl;
+  config.sponsoredReceiptNotifyTimeoutMs = ctx.prevSubmitterTimeout;
+  await ctx.fake.stop();
+  rmSync(ctx.storage, { recursive: true, force: true });
+  ctx.db.close();
+}
+
+async function fetchJson(
+  app: express.Express,
+  method: string,
+  path: string,
+  body?: unknown,
+  rawText?: string,
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { "content-type": "application/json" },
+      };
+      if (rawText !== undefined) {
+        init.body = rawText;
+      } else if (body !== undefined) {
+        init.body = JSON.stringify(body);
+      }
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+/**
+ * Wait until a predicate returns true or the deadline expires. NO sleep loop —
+ * exits immediately on success, and the deadline guarantees no test hang.
+ */
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  opts: { deadlineMs: number; intervalMs?: number; what: string },
+): Promise<void> {
+  const deadline = Date.now() + opts.deadlineMs;
+  const interval = opts.intervalMs ?? 50;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`waitFor timeout after ${opts.deadlineMs}ms: ${opts.what}`);
+}
+
+describe("POST /metering/submit — happy path", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("valid record → 200 accepted with content_hash and schema_hash", async () => {
+    const rec = buildSigned();
+    const res = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      status: "accepted",
+      worker_id: rec.worker_id,
+      schema_hash: SCHEMA_HASH_HEX,
+    });
+    const body = res.body as Record<string, unknown>;
+    expect(body.content_hash).toMatch(/^[0-9a-f]{64}$/);
+    // Operator SS58 should be derivable from worker_pubkey.
+    expect(body.operator).toBe(workerPubkeyToSs58(rec.worker_pubkey));
+  });
+
+  test("manifest persisted at receipts/{contentHash}/manifest.json", async () => {
+    const rec = buildSigned();
+    const res = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(res.status).toBe(200);
+    const ch = (res.body as { content_hash: string }).content_hash;
+    const manifestPath = join(
+      ctx.storage,
+      "receipts",
+      ch,
+      "manifest.json",
+    );
+    expect(existsSync(manifestPath)).toBe(true);
+    const stored = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+      schema: string;
+      record: ComputeMeteringV1;
+      chunks: unknown[];
+      rootHash: string;
+    };
+    expect(stored.schema).toBe(SCHEMA_VERSION);
+    expect(stored.record.worker_id).toBe(rec.worker_id);
+    expect(stored.rootHash).toBe(ch);
+    expect(stored.chunks).toEqual([]);
+  });
+
+  test("submitter notified with schemaHash + source=compute-metering-v1", async () => {
+    const rec = buildSigned();
+    const res = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(res.status).toBe(200);
+    // Notify is fire-and-forget; poll captured array with a deadline.
+    await waitFor(() => ctx.fake.captured.length === 1, {
+      deadlineMs: 2000,
+      what: "submitter received notify",
+    });
+    const captured = ctx.fake.captured[0];
+    expect(captured.method).toBe("POST");
+    const body = JSON.parse(captured.body) as Record<string, unknown>;
+    expect(body.contentHash).toBe((res.body as { content_hash: string }).content_hash);
+    expect(body.schemaHash).toBe(SCHEMA_HASH_HEX);
+    expect(body.source).toBe("compute-metering-v1");
+    expect(body.operator).toBe(workerPubkeyToSs58(rec.worker_pubkey));
+  });
+});
+
+describe("POST /metering/submit — failure modes", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("malformed JSON → 400", async () => {
+    const res = await fetchJson(
+      ctx.app,
+      "POST",
+      "/metering/submit",
+      undefined,
+      "{not_json",
+    );
+    expect(res.status).toBe(400);
+    // Express's default JSON-parse failure handler returns its own shape;
+    // either way, body is non-empty and no submitter notify was made.
+    expect(ctx.fake.captured).toHaveLength(0);
+  });
+
+  test("missing schema_version → 400 with field=schema_version", async () => {
+    const rec = buildSigned() as Record<string, unknown>;
+    delete rec.schema_version;
+    const res = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(res.status).toBe(400);
+    const body = res.body as Record<string, unknown>;
+    expect(body.code).toBe("MISSING_FIELD");
+    expect(body.field).toBe("schema_version");
+  });
+
+  test("wrong schema_version → 422", async () => {
+    const rec = { ...buildSigned(), schema_version: "compute_metering_v2" };
+    const res = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(res.status).toBe(422);
+  });
+
+  test("over-bound cpu_seconds → 422", async () => {
+    const rec = buildSigned({ cpu_seconds: 460_801 });
+    const res = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(res.status).toBe(422);
+    expect((res.body as { code: string }).code).toBe("BOUND_EXCEEDED");
+  });
+
+  test("invalid signature → 401", async () => {
+    const rec = buildSigned();
+    const tampered = {
+      ...rec,
+      // Flip one bit in the signature.
+      worker_signature: rec.worker_signature.slice(0, -2) +
+        (rec.worker_signature.endsWith("ff") ? "00" : "ff"),
+    };
+    const res = await fetchJson(ctx.app, "POST", "/metering/submit", tampered);
+    expect(res.status).toBe(401);
+    expect((res.body as { code: string }).code).toBe("SIGNATURE_INVALID");
+  });
+
+  test("monotonic violation → 409", async () => {
+    const baseEnd = Date.now() - 5000;
+    const baseStart = baseEnd - 3_600_000;
+    const first = buildSigned({
+      worker_id: "worker-mono-001",
+      period_start: baseStart,
+      period_end: baseEnd,
+    });
+    const r1 = await fetchJson(ctx.app, "POST", "/metering/submit", first);
+    expect(r1.status).toBe(200);
+
+    // Submit a record with EARLIER period_start for same worker — must reject.
+    const earlier = buildSigned({
+      worker_id: "worker-mono-001",
+      period_start: baseStart - 60_000,
+      period_end: baseStart - 1000,
+    });
+    const r2 = await fetchJson(ctx.app, "POST", "/metering/submit", earlier);
+    expect(r2.status).toBe(409);
+    expect((r2.body as { code: string }).code).toBe("MONOTONIC_VIOLATION");
+  });
+
+  test("idempotent retry → 200 status:replay; submitter NOT notified twice", async () => {
+    const rec = buildSigned({ worker_id: "worker-idem-001" });
+    const r1 = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(r1.status).toBe(200);
+    expect((r1.body as { status: string }).status).toBe("accepted");
+    await waitFor(() => ctx.fake.captured.length === 1, {
+      deadlineMs: 2000,
+      what: "first notify",
+    });
+
+    const r2 = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(r2.status).toBe(200);
+    expect((r2.body as { status: string }).status).toBe("replay");
+    // Give a beat for any async fire-and-forget; submitter must still be 1.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(ctx.fake.captured).toHaveLength(1);
+  });
+});
+
+describe("POST /metering/submit — registry-driven bounds", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("registered tighter bounds reject otherwise-valid record", async () => {
+    upsertWorkerBounds("worker-tight-001", {
+      max_cpu_cores: 1,
+      max_ram_gb: 1,
+      max_disk_gb: 1,
+      max_gpu_count: 1,
+    });
+    // 1h × 1 core = 3600 max cpu_seconds; this requests 3601.
+    const rec = buildSigned({
+      worker_id: "worker-tight-001",
+      cpu_seconds: 3601,
+    });
+    const res = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(res.status).toBe(422);
+    expect((res.body as { code: string }).code).toBe("BOUND_EXCEEDED");
+  });
+
+  test("default bounds accept moderate values for unregistered worker", async () => {
+    const rec = buildSigned({
+      worker_id: "worker-newbie-001",
+      cpu_seconds: 1000, // well under default max.
+    });
+    const res = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
+    expect(res.status).toBe(200);
+  });
+});

--- a/services/blob-gateway/src/schemas/compute_metering_v1.ts
+++ b/services/blob-gateway/src/schemas/compute_metering_v1.ts
@@ -1,0 +1,651 @@
+/**
+ * `compute_metering_v1` — schema definition + gateway-side validator.
+ *
+ * Compute workers report resource usage (CPU/RAM/disk/net/GPU over a time
+ * window) to the Materios blob gateway via a signed JSON record. The gateway
+ * validates the record (shape, bounds, signature, time-skew), derives a
+ * canonical content hash, and (on success) routes it through the existing
+ * sponsored-receipt pipeline as if it were a regular receipt with
+ * `schema_hash = sha256("compute_metering_v1")`.
+ *
+ * Why CBOR for the canonical body?
+ *   The signature MUST be verifiable byte-for-byte across languages (worker
+ *   SDKs in TS/Python/Rust). Plain JSON is non-canonical: spacing, key order,
+ *   number formatting all vary. Canonical CBOR (RFC 8949 §4.2.1) gives one
+ *   deterministic byte string for one logical record.
+ *
+ *   We implement a TINY canonical CBOR encoder inline rather than pulling in
+ *   `cbor`, `cbor-x`, or similar — the input shape is closed, the encoding is
+ *   exhaustively unit-tested, and a third-party canonical mode often differs
+ *   in subtle ways (negative-zero floats, non-shortest ints, BigInt fallback).
+ *   Keep it minimal and audited.
+ *
+ * Canonical encoding rules (RFC 8949 §4.2.1, distilled to what we need):
+ *   - Definite-length encoding (no indefinite-length items).
+ *   - Shortest possible integer form (uint major type 0/1).
+ *   - Floats: IEEE-754 binary64 (major type 7, additional info 27, 8-byte BE).
+ *     We do NOT shorten floats to f32/f16 — the cross-language verifier ports
+ *     would need to match shortening exactly, which is a footgun. Always 8-byte.
+ *   - Map keys sorted by encoded-byte lexicographic order (for our all-ASCII
+ *     short keys this is identical to UTF-8 string lex order).
+ *   - Strings: UTF-8 bytes, major type 3.
+ *
+ * The signature is sr25519 over the canonical CBOR of the body MINUS the
+ * `worker_signature` field itself (canonical map of all other fields). The
+ * `content_hash` returned by the validator is SHA-256 of that same canonical
+ * CBOR — this lets the on-chain receipt's `content_hash` be reproduced by any
+ * verifier independently of the gateway.
+ */
+
+import { createHash } from "crypto";
+import { signatureVerify, encodeAddress } from "@polkadot/util-crypto";
+import { hexToU8a, u8aToHex } from "@polkadot/util";
+
+/** Exact schema version string. Anything else = reject. */
+export const SCHEMA_VERSION = "compute_metering_v1";
+
+/** sha256 of the schema-version string — used as `schema_hash` upstream. */
+export const SCHEMA_HASH_HEX = createHash("sha256")
+  .update(SCHEMA_VERSION, "utf-8")
+  .digest("hex");
+
+/** Field-name regex for `worker_id` and `tenant_id`. */
+const ID_REGEX = /^[a-z0-9-]{4,64}$/;
+
+/** Period upper bound: 24 h. */
+export const MAX_PERIOD_MS = 86_400_000;
+
+/** Future-dated `period_end` tolerance: 60 s of clock skew. */
+export const FUTURE_SKEW_MS = 60_000;
+
+/** JS-safe int max (`Number.MAX_SAFE_INTEGER` = 2^53 - 1). */
+export const JS_SAFE_INT = Number.MAX_SAFE_INTEGER;
+
+/** Default per-worker hardware bounds. Used when the registry has no row. */
+export const DEFAULT_BOUNDS: WorkerBounds = Object.freeze({
+  max_cpu_cores: 128,
+  max_ram_gb: 2048,
+  max_disk_gb: 16384,
+  max_gpu_count: 8,
+});
+
+/** Hex regex for `worker_pubkey` (64 chars) and `worker_signature` (128 chars). */
+const HEX64 = /^[0-9a-f]{64}$/;
+const HEX128 = /^[0-9a-f]{128}$/;
+
+/** Per-worker hardware bounds. */
+export interface WorkerBounds {
+  max_cpu_cores: number;
+  max_ram_gb: number;
+  max_disk_gb: number;
+  max_gpu_count: number;
+}
+
+/** Decoded compute_metering_v1 record (post-validation). */
+export interface ComputeMeteringV1 {
+  schema_version: typeof SCHEMA_VERSION;
+  worker_id: string;
+  tenant_id: string;
+  period_start: number;
+  period_end: number;
+  cpu_seconds: number;
+  ram_gb_hours: number;
+  disk_gb_hours: number;
+  net_bytes_in: number;
+  net_bytes_out: number;
+  gpu_seconds: number;
+  worker_pubkey: string;
+  worker_signature: string;
+}
+
+/** Successful validation result. */
+export interface ValidateOk {
+  ok: true;
+  /** The fully-typed, normalised record. */
+  record: ComputeMeteringV1;
+  /**
+   * SHA-256 of the canonical CBOR (everything except `worker_signature`).
+   * Hex-encoded, no `0x` prefix. This is what the upstream sponsored-receipt
+   * pipeline uses as `content_hash`.
+   */
+  content_hash: string;
+  /**
+   * SHA-256 of the schema-version string. Hex, no prefix. Stable across
+   * records — provided here for convenience so callers don't have to import
+   * `SCHEMA_HASH_HEX` separately.
+   */
+  schema_hash: string;
+  /** Canonical body bytes (CBOR-encoded, signature field stripped). */
+  canonical_body: Uint8Array;
+}
+
+/** Failed validation result. `field` names the offending key when applicable. */
+export interface ValidateErr {
+  ok: false;
+  /** Stable error code suitable for client-side handling. */
+  code: ValidateErrorCode;
+  /** Human-readable message including the offending field name. */
+  message: string;
+  /** Optional field name (snake_case) of the failing constraint. */
+  field?: string;
+}
+
+export type ValidateErrorCode =
+  | "INVALID_JSON"
+  | "MISSING_FIELD"
+  | "WRONG_TYPE"
+  | "WRONG_SCHEMA_VERSION"
+  | "ID_FORMAT"
+  | "PERIOD_INVALID"
+  | "NEGATIVE_VALUE"
+  | "BOUND_EXCEEDED"
+  | "INT_OVERFLOW"
+  | "HEX_FORMAT"
+  | "SIGNATURE_INVALID"
+  | "MONOTONIC_VIOLATION";
+
+export type ValidateResult = ValidateOk | ValidateErr;
+
+/** Optional per-worker context passed into the validator. */
+export interface ValidateOptions {
+  /**
+   * Hardware bounds for this `worker_id`. Pass the result of
+   * `getWorkerBounds(worker_id)` from `worker_bounds.ts`. When omitted,
+   * `DEFAULT_BOUNDS` are used — useful for unit tests and the first time a
+   * worker is seen.
+   */
+  bounds?: WorkerBounds;
+  /**
+   * Greatest `period_start` previously observed for this `worker_id`. The
+   * incoming record's `period_start` MUST be `>=` this value (monotonic
+   * non-decreasing). Pass `0` (or omit) for first-ever record.
+   */
+  last_period_start?: number;
+  /**
+   * Override `Date.now()` in tests. Production callers omit this.
+   */
+  now_ms?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical CBOR encoder — RFC 8949 §4.2.1, restricted to the types we use:
+//   - Unsigned ints (major type 0)
+//   - Signed ints (major type 1)
+//   - Byte strings (major type 2) — currently unused in this schema
+//   - Text strings (major type 3)
+//   - Arrays (major type 4) — unused in this schema
+//   - Maps (major type 5)
+//   - Floats (major type 7, additional 27 → IEEE-754 binary64, 8 bytes BE)
+// All other CBOR features (tags, bignums, simple values beyond float64) are
+// intentionally NOT supported — pass an unsupported value and you get a
+// `TypeError`, by design. Keeps the cross-language verifier surface tiny.
+// ---------------------------------------------------------------------------
+
+function encodeUint(major: number, n: number): Uint8Array {
+  // Shortest encoding per RFC 8949 §3.1.
+  if (n < 0 || !Number.isFinite(n)) {
+    throw new TypeError(`encodeUint: out of range: ${n}`);
+  }
+  if (n <= 23) {
+    return Uint8Array.of((major << 5) | n);
+  }
+  if (n <= 0xff) {
+    return Uint8Array.of((major << 5) | 24, n);
+  }
+  if (n <= 0xffff) {
+    return Uint8Array.of((major << 5) | 25, (n >> 8) & 0xff, n & 0xff);
+  }
+  if (n <= 0xffffffff) {
+    return Uint8Array.of(
+      (major << 5) | 26,
+      (n >>> 24) & 0xff,
+      (n >>> 16) & 0xff,
+      (n >>> 8) & 0xff,
+      n & 0xff,
+    );
+  }
+  // 64-bit unsigned. JS numbers are safe up to 2^53; we explicitly cap at
+  // JS_SAFE_INT in the validator before encoding, so this branch is reachable
+  // ONLY for values ≤ 2^53 - 1. Use BigInt to do the byte split safely.
+  if (n > JS_SAFE_INT) {
+    throw new TypeError(`encodeUint: exceeds JS-safe int: ${n}`);
+  }
+  const bn = BigInt(n);
+  const out = new Uint8Array(9);
+  out[0] = (major << 5) | 27;
+  for (let i = 0; i < 8; i++) {
+    out[8 - i] = Number((bn >> BigInt(i * 8)) & 0xffn);
+  }
+  return out;
+}
+
+function encodeInt(n: number): Uint8Array {
+  if (!Number.isInteger(n)) {
+    throw new TypeError(`encodeInt: not an integer: ${n}`);
+  }
+  if (n >= 0) return encodeUint(0, n);
+  // Negative: major type 1, value -1 - n.
+  return encodeUint(1, -1 - n);
+}
+
+function encodeFloat64(n: number): Uint8Array {
+  // RFC 8949 §3.3: float64 is major type 7, additional info 27, 8-byte BE.
+  // We always use float64; never shorten to f32/f16. NaN is canonicalised to
+  // a single bit pattern (0x7ff8...) by Node's DataView — but we explicitly
+  // refuse NaN/Infinity in the validator before reaching here, so this is
+  // belt-and-suspenders.
+  if (!Number.isFinite(n)) {
+    throw new TypeError(`encodeFloat64: not finite: ${n}`);
+  }
+  const buf = new ArrayBuffer(9);
+  const view = new DataView(buf);
+  view.setUint8(0, (7 << 5) | 27);
+  view.setFloat64(1, n, /* littleEndian = */ false);
+  return new Uint8Array(buf);
+}
+
+function encodeText(s: string): Uint8Array {
+  const bytes = new TextEncoder().encode(s);
+  const head = encodeUint(3, bytes.length);
+  const out = new Uint8Array(head.length + bytes.length);
+  out.set(head, 0);
+  out.set(bytes, head.length);
+  return out;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+/**
+ * Canonical CBOR map encoder. Keys are encoded first, then sorted by the
+ * lexicographic order of their encoded bytes (RFC 8949 §4.2.1). Since our
+ * keys are all short ASCII, this is identical to JS string-comparison sort.
+ *
+ * Value type dispatch is closed: int → encodeInt, finite float → encodeFloat64,
+ * string → encodeText. Anything else throws — we never silently coerce.
+ */
+function encodeMap(
+  entries: Array<[string, number | string]>,
+): Uint8Array {
+  const encoded = entries.map(([k, v]) => {
+    const keyBytes = encodeText(k);
+    let valueBytes: Uint8Array;
+    if (typeof v === "string") {
+      valueBytes = encodeText(v);
+    } else if (Number.isInteger(v)) {
+      valueBytes = encodeInt(v);
+    } else if (typeof v === "number" && Number.isFinite(v)) {
+      valueBytes = encodeFloat64(v);
+    } else {
+      throw new TypeError(
+        `encodeMap: unsupported value for key '${k}': ${String(v)}`,
+      );
+    }
+    return { keyBytes, valueBytes };
+  });
+  // Sort by encoded key bytes — lex over Uint8Array.
+  encoded.sort((a, b) => cmpBytes(a.keyBytes, b.keyBytes));
+  const head = encodeUint(5, encoded.length);
+  const parts: Uint8Array[] = [head];
+  for (const { keyBytes, valueBytes } of encoded) {
+    parts.push(keyBytes, valueBytes);
+  }
+  return concat(parts);
+}
+
+function cmpBytes(a: Uint8Array, b: Uint8Array): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return a.length - b.length;
+}
+
+/**
+ * Build the canonical body bytes for a record. The `worker_signature` field
+ * is excluded — that's the input to sr25519.verify, NOT a self-reference.
+ *
+ * Exported so worker SDKs (and the worker_signature pre-image side) can use
+ * the SAME function. Reuse beats reimplementation across languages.
+ */
+export function canonicalBody(
+  rec: Omit<ComputeMeteringV1, "worker_signature">,
+): Uint8Array {
+  const entries: Array<[string, number | string]> = [
+    ["schema_version", rec.schema_version],
+    ["worker_id", rec.worker_id],
+    ["tenant_id", rec.tenant_id],
+    ["period_start", rec.period_start],
+    ["period_end", rec.period_end],
+    ["cpu_seconds", rec.cpu_seconds],
+    ["ram_gb_hours", rec.ram_gb_hours],
+    ["disk_gb_hours", rec.disk_gb_hours],
+    ["net_bytes_in", rec.net_bytes_in],
+    ["net_bytes_out", rec.net_bytes_out],
+    ["gpu_seconds", rec.gpu_seconds],
+    ["worker_pubkey", rec.worker_pubkey],
+  ];
+  return encodeMap(entries);
+}
+
+/**
+ * SHA-256 hex-digest of the canonical body (sans signature).
+ * This is the upstream `content_hash` and the message that the sr25519
+ * signature MUST be verified against.
+ */
+export function canonicalContentHash(
+  rec: Omit<ComputeMeteringV1, "worker_signature">,
+): string {
+  return createHash("sha256").update(canonicalBody(rec)).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+function err(
+  code: ValidateErrorCode,
+  message: string,
+  field?: string,
+): ValidateErr {
+  return field !== undefined
+    ? { ok: false, code, message, field }
+    : { ok: false, code, message };
+}
+
+/**
+ * Validate a parsed JSON object against the `compute_metering_v1` schema.
+ *
+ * Returns either `{ ok: true, record, content_hash, schema_hash, canonical_body }`
+ * on success or `{ ok: false, code, message, field? }` on failure.
+ *
+ * The validator NEVER throws on input shape — every failure mode is captured
+ * as a `ValidateErr`. (It WILL throw on a programming error like passing
+ * `null` for `opts`, but that's a usage bug.)
+ */
+export function validateComputeMeteringV1(
+  raw: unknown,
+  opts: ValidateOptions = {},
+): ValidateResult {
+  const bounds = opts.bounds ?? DEFAULT_BOUNDS;
+  const nowMs = opts.now_ms ?? Date.now();
+  const lastPeriodStart = opts.last_period_start ?? 0;
+
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return err("WRONG_TYPE", "expected JSON object at root");
+  }
+  const r = raw as Record<string, unknown>;
+
+  // --- schema_version ---
+  if (!("schema_version" in r)) {
+    return err("MISSING_FIELD", "schema_version is required", "schema_version");
+  }
+  if (typeof r.schema_version !== "string") {
+    return err(
+      "WRONG_TYPE",
+      "schema_version must be a string",
+      "schema_version",
+    );
+  }
+  if (r.schema_version !== SCHEMA_VERSION) {
+    return err(
+      "WRONG_SCHEMA_VERSION",
+      `schema_version must be exactly "${SCHEMA_VERSION}", got "${r.schema_version}"`,
+      "schema_version",
+    );
+  }
+
+  // --- worker_id / tenant_id ---
+  for (const key of ["worker_id", "tenant_id"] as const) {
+    if (!(key in r)) {
+      return err("MISSING_FIELD", `${key} is required`, key);
+    }
+    const v = r[key];
+    if (typeof v !== "string") {
+      return err("WRONG_TYPE", `${key} must be a string`, key);
+    }
+    if (!ID_REGEX.test(v)) {
+      return err(
+        "ID_FORMAT",
+        `${key} must match [a-z0-9-]{4,64}, got "${v}"`,
+        key,
+      );
+    }
+  }
+  const workerId = r.worker_id as string;
+  const tenantId = r.tenant_id as string;
+
+  // --- period_start ---
+  if (!("period_start" in r)) {
+    return err("MISSING_FIELD", "period_start is required", "period_start");
+  }
+  if (typeof r.period_start !== "number" || !Number.isInteger(r.period_start)) {
+    return err(
+      "WRONG_TYPE",
+      "period_start must be an integer (unix millis)",
+      "period_start",
+    );
+  }
+  if (r.period_start <= 0) {
+    return err(
+      "PERIOD_INVALID",
+      "period_start must be > 0",
+      "period_start",
+    );
+  }
+  const periodStart = r.period_start;
+
+  // --- period_end ---
+  if (!("period_end" in r)) {
+    return err("MISSING_FIELD", "period_end is required", "period_end");
+  }
+  if (typeof r.period_end !== "number" || !Number.isInteger(r.period_end)) {
+    return err(
+      "WRONG_TYPE",
+      "period_end must be an integer (unix millis)",
+      "period_end",
+    );
+  }
+  const periodEnd = r.period_end;
+  if (periodEnd <= periodStart) {
+    return err(
+      "PERIOD_INVALID",
+      "period_end must be > period_start",
+      "period_end",
+    );
+  }
+  if (periodEnd - periodStart > MAX_PERIOD_MS) {
+    return err(
+      "PERIOD_INVALID",
+      `period (period_end - period_start) must be <= ${MAX_PERIOD_MS} ms (24 h)`,
+      "period_end",
+    );
+  }
+  if (periodEnd > nowMs + FUTURE_SKEW_MS) {
+    return err(
+      "PERIOD_INVALID",
+      `period_end is too far in the future (skew > ${FUTURE_SKEW_MS} ms)`,
+      "period_end",
+    );
+  }
+
+  // --- monotonic non-decreasing per worker_id ---
+  if (periodStart < lastPeriodStart) {
+    return err(
+      "MONOTONIC_VIOLATION",
+      `period_start ${periodStart} < last observed ${lastPeriodStart} for ${workerId}`,
+      "period_start",
+    );
+  }
+
+  // --- numeric fields with bounds ---
+  // Pre-compute the period in seconds and hours so each bound check uses the
+  // SAME arithmetic — no float drift between fields.
+  const periodSec = (periodEnd - periodStart) / 1000;
+  const periodHr = (periodEnd - periodStart) / 3_600_000;
+
+  type Numeric = {
+    key: keyof ComputeMeteringV1;
+    kind: "float" | "int";
+    cap: number;
+  };
+
+  const numericFields: Numeric[] = [
+    { key: "cpu_seconds", kind: "float", cap: periodSec * bounds.max_cpu_cores },
+    { key: "ram_gb_hours", kind: "float", cap: periodHr * bounds.max_ram_gb },
+    { key: "disk_gb_hours", kind: "float", cap: periodHr * bounds.max_disk_gb },
+    { key: "net_bytes_in", kind: "int", cap: JS_SAFE_INT },
+    { key: "net_bytes_out", kind: "int", cap: JS_SAFE_INT },
+    { key: "gpu_seconds", kind: "float", cap: periodSec * bounds.max_gpu_count },
+  ];
+
+  for (const f of numericFields) {
+    const k = f.key;
+    if (!(k in r)) {
+      return err("MISSING_FIELD", `${k} is required`, k);
+    }
+    const v = r[k];
+    if (typeof v !== "number" || !Number.isFinite(v)) {
+      return err(
+        "WRONG_TYPE",
+        `${k} must be a finite number`,
+        k,
+      );
+    }
+    if (f.kind === "int" && !Number.isInteger(v)) {
+      return err("WRONG_TYPE", `${k} must be an integer`, k);
+    }
+    if (v < 0) {
+      return err("NEGATIVE_VALUE", `${k} must be >= 0, got ${v}`, k);
+    }
+    if (f.kind === "int" && v > JS_SAFE_INT) {
+      return err(
+        "INT_OVERFLOW",
+        `${k} must be <= 2^53-1, got ${v}`,
+        k,
+      );
+    }
+    // Bound check for *_per_period derived caps (cpu/ram/disk/gpu).
+    // For net_bytes_*, the cap IS JS_SAFE_INT (already enforced above).
+    if (f.kind === "float" && v > f.cap) {
+      return err(
+        "BOUND_EXCEEDED",
+        `${k} ${v} exceeds hardware-implausible cap ${f.cap}`,
+        k,
+      );
+    }
+  }
+
+  // --- worker_pubkey / worker_signature (hex, fixed length) ---
+  for (const [k, re, expected] of [
+    ["worker_pubkey", HEX64, 64],
+    ["worker_signature", HEX128, 128],
+  ] as const) {
+    if (!(k in r)) {
+      return err("MISSING_FIELD", `${k} is required`, k);
+    }
+    const v = r[k];
+    if (typeof v !== "string") {
+      return err("WRONG_TYPE", `${k} must be a string`, k);
+    }
+    if (!re.test(v)) {
+      return err(
+        "HEX_FORMAT",
+        `${k} must be exactly ${expected} lowercase hex chars, got length ${v.length}`,
+        k,
+      );
+    }
+  }
+  const workerPubkey = r.worker_pubkey as string;
+  const workerSignature = r.worker_signature as string;
+
+  // --- assemble the typed record ---
+  const record: ComputeMeteringV1 = {
+    schema_version: SCHEMA_VERSION,
+    worker_id: workerId,
+    tenant_id: tenantId,
+    period_start: periodStart,
+    period_end: periodEnd,
+    cpu_seconds: r.cpu_seconds as number,
+    ram_gb_hours: r.ram_gb_hours as number,
+    disk_gb_hours: r.disk_gb_hours as number,
+    net_bytes_in: r.net_bytes_in as number,
+    net_bytes_out: r.net_bytes_out as number,
+    gpu_seconds: r.gpu_seconds as number,
+    worker_pubkey: workerPubkey,
+    worker_signature: workerSignature,
+  };
+
+  // --- canonical body + signature verify ---
+  const body = canonicalBody({
+    schema_version: record.schema_version,
+    worker_id: record.worker_id,
+    tenant_id: record.tenant_id,
+    period_start: record.period_start,
+    period_end: record.period_end,
+    cpu_seconds: record.cpu_seconds,
+    ram_gb_hours: record.ram_gb_hours,
+    disk_gb_hours: record.disk_gb_hours,
+    net_bytes_in: record.net_bytes_in,
+    net_bytes_out: record.net_bytes_out,
+    gpu_seconds: record.gpu_seconds,
+    worker_pubkey: record.worker_pubkey,
+  });
+
+  // sr25519 verify. We pass the pubkey as a 0x-prefixed hex string — the
+  // util-crypto helper accepts that as an "address-like" public key.
+  const pubkeyU8 = hexToU8a("0x" + workerPubkey);
+  const sigU8 = hexToU8a("0x" + workerSignature);
+  let isValid = false;
+  try {
+    const result = signatureVerify(body, sigU8, u8aToHex(pubkeyU8));
+    isValid = result.isValid;
+  } catch (e) {
+    // Malformed pubkey/sig caught here. Treat as signature-invalid; the hex
+    // shape was already format-checked above so this is a deeper crypto fail.
+    return err(
+      "SIGNATURE_INVALID",
+      `signature verify error: ${e instanceof Error ? e.message : String(e)}`,
+      "worker_signature",
+    );
+  }
+  if (!isValid) {
+    return err(
+      "SIGNATURE_INVALID",
+      "sr25519 signature does not verify against worker_pubkey",
+      "worker_signature",
+    );
+  }
+
+  const contentHash = createHash("sha256").update(body).digest("hex");
+  return {
+    ok: true,
+    record,
+    content_hash: contentHash,
+    schema_hash: SCHEMA_HASH_HEX,
+    canonical_body: body,
+  };
+}
+
+/**
+ * Convenience: derive the SS58 address (Substrate generic, prefix 42) from a
+ * 32-byte sr25519 hex pubkey. Used by the gateway route to attribute the
+ * upstream sponsored-receipt to the worker's account.
+ */
+export function workerPubkeyToSs58(workerPubkey: string, prefix = 42): string {
+  if (!HEX64.test(workerPubkey)) {
+    throw new TypeError(
+      `workerPubkeyToSs58: expected 64 lowercase hex, got "${workerPubkey}"`,
+    );
+  }
+  return encodeAddress(hexToU8a("0x" + workerPubkey), prefix);
+}

--- a/services/blob-gateway/src/sponsored-receipts.ts
+++ b/services/blob-gateway/src/sponsored-receipts.ts
@@ -39,6 +39,24 @@ export interface SponsoredReceiptPayload {
   authTier: "bearer" | "api-key" | "api-key-legacy-ss58";
   rootHash?: string;
   manifestHash?: string;
+  /**
+   * Optional schema hash override. When set (e.g. by the
+   * `compute_metering_v1` route via `schemas/compute_metering_v1.ts`'s
+   * `SCHEMA_HASH_HEX`), the submitter is expected to pass it as
+   * `submit_receipt_v2(schema_hash = ...)`. When unset (existing manifest
+   * flow), the submitter uses its own default (sha256 of "manifest_v1") so
+   * existing callers don't change behaviour.
+   *
+   * Hex, 64 chars, no `0x` prefix.
+   */
+  schemaHash?: string;
+  /**
+   * Optional override for the `source` field in the outbound payload.
+   * Defaults to `"blob-gateway"`. Set to `"compute-metering-v1"` (or another
+   * stable string) when the submitter needs to route the request through a
+   * non-default code path (e.g. compute-portal billing).
+   */
+  source?: string;
 }
 
 /**
@@ -59,14 +77,19 @@ export async function notifySponsoredReceiptSubmitter(
     headers["authorization"] = "Bearer " + config.sponsoredReceiptSubmitterToken;
   }
 
-  const body = JSON.stringify({
+  // Include `schemaHash` only when caller supplied it — keeps the wire shape
+  // identical for the legacy manifest flow so existing submitter
+  // implementations don't see new fields they may reject as unknown.
+  const bodyShape: Record<string, unknown> = {
     contentHash: payload.contentHash,
     operator: payload.operator,
     authTier: payload.authTier,
     rootHash: payload.rootHash,
     manifestHash: payload.manifestHash,
-    source: "blob-gateway",
-  });
+    source: payload.source ?? "blob-gateway",
+  };
+  if (payload.schemaHash) bodyShape.schemaHash = payload.schemaHash;
+  const body = JSON.stringify(bodyShape);
 
   const controller = new AbortController();
   const timeoutId = setTimeout(

--- a/services/blob-gateway/src/worker_bounds.ts
+++ b/services/blob-gateway/src/worker_bounds.ts
@@ -1,0 +1,388 @@
+/**
+ * SQLite-backed registry of per-worker hardware bounds for
+ * `compute_metering_v1`. Used by the gateway-side validator to check that
+ * reported resource usage doesn't exceed the worker's known capacity.
+ *
+ * Why a separate db handle and not quota.db?
+ *   - Compute metering is its own product line (#108 — Compute Portal).
+ *     Keeping the schema independent means we don't entangle billing-pipeline
+ *     migrations with the upload-quota schema, which is already busy.
+ *   - Tests can swap in an in-memory handle via `setWorkerBoundsDbForTests()`
+ *     without touching the real /data/blobs/quota.db file.
+ *
+ * Also tracks `last_period_start` per worker so the validator can enforce
+ * monotonic non-decreasing `period_start` across submissions for the same
+ * worker_id (replay/rewind protection).
+ *
+ * The registry CONSUMES no secrets; bounds are operator-declared and apply
+ * the same way as docker `--cpus` / `--memory` flags do. Sensible defaults
+ * mean a worker that hasn't been registered still gets validated against
+ * `DEFAULT_BOUNDS` (128 cores / 2 TB RAM / 16 TB disk / 8 GPUs) — generous
+ * enough to admit any production hardware while still rejecting absurd
+ * fabrications.
+ */
+
+import Database from "better-sqlite3";
+import { join } from "path";
+import { config } from "./config.js";
+import { DEFAULT_BOUNDS, type WorkerBounds } from "./schemas/compute_metering_v1.js";
+
+let db: Database.Database | null = null;
+
+/**
+ * Test hook: inject an in-memory handle. Must be called after the schema
+ * has been initialised on that handle (use `initWorkerBoundsDb(handle)` for
+ * that). Production code path uses initWorkerBoundsDb() with no arg.
+ */
+export function setWorkerBoundsDbForTests(injected: Database.Database): void {
+  db = injected;
+}
+
+/**
+ * Initialise the worker_bounds + worker_state tables on a SQLite handle.
+ * If `database` is omitted, opens (or creates) `worker_bounds.db` at the
+ * canonical storage path.
+ *
+ * Safe to call repeatedly (idempotent CREATE IF NOT EXISTS). Returns the
+ * handle so callers may share it.
+ */
+export function initWorkerBoundsDb(
+  database?: Database.Database,
+): Database.Database {
+  const handle =
+    database ?? new Database(join(config.storagePath, "worker_bounds.db"));
+  handle.pragma("journal_mode = WAL");
+  handle.pragma("busy_timeout = 5000");
+  handle.exec(`
+    CREATE TABLE IF NOT EXISTS worker_bounds (
+      worker_id TEXT PRIMARY KEY,
+      max_cpu_cores INTEGER NOT NULL,
+      max_ram_gb INTEGER NOT NULL,
+      max_disk_gb INTEGER NOT NULL,
+      max_gpu_count INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS worker_state (
+      worker_id TEXT PRIMARY KEY,
+      last_period_start INTEGER NOT NULL DEFAULT 0,
+      last_content_hash TEXT,
+      last_seen_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_worker_state_last_period
+      ON worker_state(worker_id, last_period_start);
+
+    -- Per-record submission log used by the billing-query endpoint
+    -- (#112). Each row is the per-period snapshot produced by a worker's
+    -- compute_metering_v1 submission. content_hash is PRIMARY KEY so
+    -- replays/idempotent retries are silently absorbed (an INSERT OR IGNORE
+    -- is a no-op when the same record is re-submitted byte-for-byte).
+    --
+    -- We persist all six metric fields verbatim — billing queries aggregate
+    -- across these directly without re-reading manifest.json off disk.
+    -- submitted_at_ms is wall-clock ingest time at the gateway (not the
+    -- worker's claimed period_*); useful for "fresh-vs-stale" accounting.
+    CREATE TABLE IF NOT EXISTS metering_submissions (
+      content_hash TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      worker_id TEXT NOT NULL,
+      period_start_ms INTEGER NOT NULL,
+      period_end_ms INTEGER NOT NULL,
+      cpu_seconds REAL NOT NULL,
+      ram_gb_hours REAL NOT NULL,
+      disk_gb_hours REAL NOT NULL,
+      net_bytes_in INTEGER NOT NULL,
+      net_bytes_out INTEGER NOT NULL,
+      gpu_seconds REAL NOT NULL,
+      submitted_at_ms INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_metering_tenant_period
+      ON metering_submissions(tenant_id, period_start_ms);
+    CREATE INDEX IF NOT EXISTS idx_metering_worker
+      ON metering_submissions(worker_id);
+  `);
+  if (!db) db = handle;
+  return handle;
+}
+
+/**
+ * Look up bounds for a worker_id. Returns `DEFAULT_BOUNDS` if the worker is
+ * not registered (registration is operator-driven; missing entry means
+ * "first time we've seen this worker" and we fall back to defaults).
+ */
+export function getWorkerBounds(workerId: string): WorkerBounds {
+  if (!db) {
+    // Defensive: not initialised. This shouldn't happen in production
+    // because index.ts calls initWorkerBoundsDb() at boot, but tests that
+    // forgot to call setWorkerBoundsDbForTests() also hit this. Default to
+    // bounds (don't throw) so the schema validator is still callable in
+    // contexts that haven't wired the db (e.g. pure unit tests of the
+    // validator below the route layer).
+    return DEFAULT_BOUNDS;
+  }
+  const row = db
+    .prepare(
+      `SELECT max_cpu_cores, max_ram_gb, max_disk_gb, max_gpu_count
+       FROM worker_bounds WHERE worker_id = ?`,
+    )
+    .get(workerId) as
+    | {
+        max_cpu_cores: number;
+        max_ram_gb: number;
+        max_disk_gb: number;
+        max_gpu_count: number;
+      }
+    | undefined;
+  if (!row) return DEFAULT_BOUNDS;
+  return {
+    max_cpu_cores: row.max_cpu_cores,
+    max_ram_gb: row.max_ram_gb,
+    max_disk_gb: row.max_disk_gb,
+    max_gpu_count: row.max_gpu_count,
+  };
+}
+
+/**
+ * Upsert a worker's bounds. Used by ops tooling (and tests) to register
+ * realistic hardware caps for a specific worker. Validates that values
+ * are positive integers — silent acceptance of zero/negative would defeat
+ * the bound check.
+ */
+export function upsertWorkerBounds(
+  workerId: string,
+  bounds: WorkerBounds,
+): void {
+  if (!db) throw new Error("worker_bounds db not initialised");
+  for (const [k, v] of Object.entries(bounds)) {
+    if (!Number.isInteger(v) || v <= 0) {
+      throw new TypeError(`upsertWorkerBounds: ${k} must be a positive integer, got ${v}`);
+    }
+  }
+  const now = Math.floor(Date.now() / 1000);
+  db.prepare(
+    `INSERT INTO worker_bounds (worker_id, max_cpu_cores, max_ram_gb, max_disk_gb, max_gpu_count, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(worker_id) DO UPDATE SET
+       max_cpu_cores = excluded.max_cpu_cores,
+       max_ram_gb = excluded.max_ram_gb,
+       max_disk_gb = excluded.max_disk_gb,
+       max_gpu_count = excluded.max_gpu_count,
+       updated_at = excluded.updated_at`,
+  ).run(
+    workerId,
+    bounds.max_cpu_cores,
+    bounds.max_ram_gb,
+    bounds.max_disk_gb,
+    bounds.max_gpu_count,
+    now,
+    now,
+  );
+}
+
+/**
+ * Read the last-observed period_start for a worker. Returns 0 if no record
+ * has ever been admitted (first-time worker — any positive period_start
+ * passes the monotonic check).
+ */
+export function getLastPeriodStart(workerId: string): number {
+  if (!db) return 0;
+  const row = db
+    .prepare(
+      `SELECT last_period_start FROM worker_state WHERE worker_id = ?`,
+    )
+    .get(workerId) as { last_period_start: number } | undefined;
+  return row?.last_period_start ?? 0;
+}
+
+/**
+ * Update the worker_state row for a worker after a successful submission.
+ * Called by the route handler ONLY after every other check has passed
+ * (signature, bounds, monotonic). Sets `last_period_start` to the new
+ * period_start (guaranteed >= old), records the content_hash for idempotency
+ * checks, and stamps last_seen_at.
+ *
+ * Idempotent on `last_content_hash`: callers should check this BEFORE
+ * forwarding to the upstream sponsored-receipt pipeline so a retry of the
+ * same record doesn't double-debit the customer. See `isReplayedContent()`.
+ */
+export function recordWorkerSubmission(
+  workerId: string,
+  periodStart: number,
+  contentHash: string,
+): void {
+  if (!db) throw new Error("worker_bounds db not initialised");
+  const now = Math.floor(Date.now() / 1000);
+  db.prepare(
+    `INSERT INTO worker_state (worker_id, last_period_start, last_content_hash, last_seen_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(worker_id) DO UPDATE SET
+       last_period_start = excluded.last_period_start,
+       last_content_hash = excluded.last_content_hash,
+       last_seen_at = excluded.last_seen_at`,
+  ).run(workerId, periodStart, contentHash, now);
+}
+
+/**
+ * Returns true iff the supplied content_hash matches the LAST recorded
+ * content_hash for this worker — used as a cheap dedup against immediate
+ * retries of the exact same record. NOT a full replay-protection store
+ * (the chain is the canonical anti-replay via content_hash uniqueness),
+ * but it short-circuits a common retry pattern at the gateway edge.
+ */
+export function isReplayedContent(
+  workerId: string,
+  contentHash: string,
+): boolean {
+  if (!db) return false;
+  const row = db
+    .prepare(
+      `SELECT last_content_hash FROM worker_state WHERE worker_id = ?`,
+    )
+    .get(workerId) as { last_content_hash: string | null } | undefined;
+  return row?.last_content_hash === contentHash;
+}
+
+/**
+ * Per-record billing snapshot. Mirrors the columns of
+ * `metering_submissions`. Returned by `getMeteringSubmissions()` for the
+ * billing-query endpoint (#112).
+ */
+export interface MeteringSubmissionRow {
+  content_hash: string;
+  tenant_id: string;
+  worker_id: string;
+  period_start_ms: number;
+  period_end_ms: number;
+  cpu_seconds: number;
+  ram_gb_hours: number;
+  disk_gb_hours: number;
+  net_bytes_in: number;
+  net_bytes_out: number;
+  gpu_seconds: number;
+  submitted_at_ms: number;
+}
+
+/**
+ * Append a billing-purpose row for a successful metering submission.
+ *
+ * Uses INSERT OR IGNORE so an idempotent retry (same content_hash) is a
+ * silent no-op — we never double-count usage. The route already
+ * short-circuits replays before reaching here via `isReplayedContent()`,
+ * but the OR IGNORE is belt-and-suspenders against a race where two
+ * threads both pass the replay check and both call recordSubmission().
+ */
+export function recordMeteringSubmission(
+  row: MeteringSubmissionRow,
+): void {
+  if (!db) throw new Error("worker_bounds db not initialised");
+  db.prepare(
+    `INSERT OR IGNORE INTO metering_submissions (
+       content_hash, tenant_id, worker_id,
+       period_start_ms, period_end_ms,
+       cpu_seconds, ram_gb_hours, disk_gb_hours,
+       net_bytes_in, net_bytes_out, gpu_seconds,
+       submitted_at_ms
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    row.content_hash,
+    row.tenant_id,
+    row.worker_id,
+    row.period_start_ms,
+    row.period_end_ms,
+    row.cpu_seconds,
+    row.ram_gb_hours,
+    row.disk_gb_hours,
+    row.net_bytes_in,
+    row.net_bytes_out,
+    row.gpu_seconds,
+    row.submitted_at_ms,
+  );
+}
+
+/**
+ * Filter for `getMeteringSubmissions()`.
+ *
+ * Time-window semantics: `[start_ms, end_ms)` — INCLUSIVE start, EXCLUSIVE
+ * end. A record with `period_start_ms === start_ms` IS included; a record
+ * with `period_start_ms === end_ms` is NOT. We filter by `period_start_ms`
+ * (worker-claimed window start) — NOT by `submitted_at_ms` (gateway ingest
+ * time) — because customers care about the period the work was done, not
+ * when it landed at the gateway.
+ *
+ * Pagination: order by (period_start_ms ASC, content_hash ASC) — stable
+ * across calls. The caller passes the last (period_start_ms, content_hash)
+ * tuple as `cursor` to fetch the next page.
+ */
+export interface MeteringQuery {
+  tenant_id: string;
+  start_ms: number;
+  end_ms: number;
+  /** Maximum rows to return. */
+  limit: number;
+  /**
+   * Opaque pagination cursor. When provided, the query continues strictly
+   * after the (period_start_ms, content_hash) encoded here.
+   */
+  after?: { period_start_ms: number; content_hash: string };
+}
+
+/**
+ * Read metering rows for a tenant in a time window. Pure read — no side
+ * effects, no order-by-magic. Always returns at most `limit` rows.
+ */
+export function getMeteringSubmissions(
+  q: MeteringQuery,
+): MeteringSubmissionRow[] {
+  if (!db) return [];
+  // Two SQL paths so we don't bind unused parameters; SQLite handles each
+  // form fine but the prepared-statement cache is keyed on the SQL string
+  // and we'd rather not churn it on every page.
+  if (q.after) {
+    const stmt = db.prepare(
+      `SELECT content_hash, tenant_id, worker_id,
+              period_start_ms, period_end_ms,
+              cpu_seconds, ram_gb_hours, disk_gb_hours,
+              net_bytes_in, net_bytes_out, gpu_seconds,
+              submitted_at_ms
+         FROM metering_submissions
+        WHERE tenant_id = ?
+          AND period_start_ms >= ?
+          AND period_start_ms < ?
+          AND (period_start_ms > ?
+                OR (period_start_ms = ? AND content_hash > ?))
+        ORDER BY period_start_ms ASC, content_hash ASC
+        LIMIT ?`,
+    );
+    return stmt.all(
+      q.tenant_id,
+      q.start_ms,
+      q.end_ms,
+      q.after.period_start_ms,
+      q.after.period_start_ms,
+      q.after.content_hash,
+      q.limit,
+    ) as MeteringSubmissionRow[];
+  }
+  const stmt = db.prepare(
+    `SELECT content_hash, tenant_id, worker_id,
+            period_start_ms, period_end_ms,
+            cpu_seconds, ram_gb_hours, disk_gb_hours,
+            net_bytes_in, net_bytes_out, gpu_seconds,
+            submitted_at_ms
+       FROM metering_submissions
+      WHERE tenant_id = ?
+        AND period_start_ms >= ?
+        AND period_start_ms < ?
+      ORDER BY period_start_ms ASC, content_hash ASC
+      LIMIT ?`,
+  );
+  return stmt.all(
+    q.tenant_id,
+    q.start_ms,
+    q.end_ms,
+    q.limit,
+  ) as MeteringSubmissionRow[];
+}


### PR DESCRIPTION
## Summary

- Recovers task #112's compute-metering billing query API (orphaned when its agent's worktree was cleaned up before push). Reconstructed from the agent's transcript at `/home/deci/.claude/projects/-home-deci/93582ed9-742f-45d3-9e79-74b6bf1ef9fa/subagents/agent-a39adf40b60b7f6cc.jsonl`.
- Integrates task #119's cross-tenant isolation directly into the recovered #112 billing route. The sibling branch `fix/billing-tenant-binding-task-119` (149-LoC standalone billing.ts) is now superseded and can be closed unmerged.
- Includes the upstream wave-1 deps (#109 schema + #110 worker hooks) so the test pyramid above the billing route compiles cleanly on `main` without depending on those branches landing first.

## What's new

### Task #112 — `/billing/usage` (compute aggregation)
- `schemas/compute_metering_v1.ts` — validator + `SCHEMA_HASH_HEX = a297e9fa…`
- `worker_bounds.ts` — adds `metering_submissions` table + `recordMeteringSubmission()` + `getMeteringSubmissions()` (paged, tenant-scoped)
- `routes/metering.ts` — `POST /metering/submit` (compute_metering_v1 ingestion + sponsored-receipt forwarding now passes `schemaHash` + `source`)
- `billing/aggregate.ts` — pure-function aggregation + opaque cursor encoding
- `billing/chain_query.ts` — `orinq_getReceiptStatus` wrapper, graceful-degraded
- `billing/anchor_resolver.ts` — cert-daemon `checkpoint-history.json` + `anchor-worker.log` → `cert_hash` → Cardano tx, with SSH-unavailable fallback to "anchor unknown"
- `routes/billing.ts` — `GET /billing/usage?tenant_id=&start_ms=&end_ms=&include_records=&page_size=&cursor=` with full aggregation, pagination, audit trail (timing breakdown, schema_hash echo)
- 13 + 11 + 28 + 1 (LIVE_PREPROD-gated) new tests on the billing layer
- 64 + 12 + 1 (LIVE_PREPROD-gated) new tests on the #109 schema/route layer

### Task #119 — cross-tenant isolation
- `api-tokens.ts` — additive `tenant_id` column migration (idempotent ALTER), `bindTokenToTenant()` post-issuance helper, `verifyToken()` surfaces `tenantId`
- `routes/tokens.ts` — `POST /auth/token` accepts `tenant_id` (snake) or `tenantId` (camel), persists, echoes in response
- `routes/billing.ts` — post-auth pre-aggregation `TOKEN_TENANT_MISMATCH` check. Tokens with NULL `tenant_id` (legacy/admin tier) retain unrestricted access; tokens bound to tenant X get 403 if they query tenant Y. Audit log on every mismatch (token hash prefix only, never raw token).
- 21 new tests — happy path, mismatch, legacy-allow, missing-param, post-issuance bind, missing/malformed/unknown/revoked Bearer, migration round-trip, snake+camel mint flows

## Test plan

- [x] `pnpm vitest run services/blob-gateway` → **281 passed, 2 skipped (LIVE_PREPROD-gated), 0 failed**
- [x] `pnpm tsc --noEmit` (services/blob-gateway) → **exit 0**
- [x] No TODO/FIXME left in new code
- [x] Tenant-binding wired AFTER auth, BEFORE aggregation (per #119 spec)
- [x] Bearer-only on `/billing/usage` (x-api-key intentionally not accepted — different table, no `tenant_id` column)

## Reconstruction adjustments (judgment calls)

1. **Inlined Bearer auth in `routes/billing.ts`** instead of using the shared `bearerAuth({required: true})` middleware, because the middleware does not surface `verify.tenantId` to downstream handlers. This is the same pattern #119's branch used.
2. **#119 tests had `"ten-A"` / `"ten-B"`** (uppercase) which fail the `[a-z0-9-]{4,64}` URL regex. Lowercased to `"ten-a"`/`"ten-b"` — the binding semantics are unchanged because `tenant_id` is treated as an opaque string for storage and exact-match for the binding check.
3. **#119 tests targeted `registerBillingRoutes()`** — the lost agent's billing.ts exports `billingRouter` (Express Router). Updated tests to mount with `app.use(billingRouter)` and provide the new endpoint's required `start_ms`/`end_ms` query params.
4. **#119 response-shape assertions** (`tenantId`, `accountSs58`, `lifetime`, `caps`) were against the simpler #119 endpoint. Updated to the richer #112 shape (`tenant_id`, `aggregate.record_count`).
5. **`chain_query` + `anchor_resolver` mocked** in the tenant-binding suite to keep it focused on auth/binding (no live RPC, no SSH dependency).

## Closes / supersedes

- Closes the orphan task-#112 work (Agent D's lost branch — see transcript path above).
- Supersedes `fix/billing-tenant-binding-task-119` (PR for that branch can be closed unmerged once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)