### PR TITLE
ci(blob-gateway): auto-build + push image on main pushes

### DIFF
--- a/.github/workflows/blob-gateway.yml
+++ b/.github/workflows/blob-gateway.yml
@@ -1,0 +1,61 @@
+name: Build and push blob-gateway image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/blob-gateway/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/blob-gateway.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/flux-point-studios/blob-gateway
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build TypeScript (populates services/blob-gateway/dist/)
+        run: pnpm --filter @orynq/blob-gateway build
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        working-directory: services/blob-gateway
+        run: |
+          docker build \
+            -t ${{ env.IMAGE }}:${{ github.sha }} \
+            -t ${{ env.IMAGE }}:latest \
+            .
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest


### PR DESCRIPTION
## Summary

The blob-gateway docker image had no auto-build workflow. `latest` tag was stuck at `fbd273a` (2026-04-30) until I built + pushed `9584ccfff…` manually today after PR #23 merged. Mirroring the existing `anchor-worker.yml` pattern so this is automated going forward.

## Trigger

Push to `main` that touches:
- `services/blob-gateway/**`
- `packages/**` (workspace deps)
- `pnpm-lock.yaml` / `pnpm-workspace.yaml`
- this workflow file

Plus `workflow_dispatch` for manual rebuild.

## Why path-filtered (not blanket)

Otherwise every commit to anchor-worker, anchors-cardano, etc., would rebuild the gateway image — wasteful and slow.

## Test plan

- [x] YAML schema valid (modeled directly on the working `anchor-worker.yml`)
- [ ] Post-merge: confirm a follow-up push to `main` touching `services/blob-gateway/**` triggers the workflow and pushes `:latest`
- [ ] (optional) `workflow_dispatch` invocation succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)