### PR TITLE
feat: relocate materios-compute-meter SDK into orynq-sdk monorepo (packages/compute-meter-sdk)

### DIFF
--- a/packages/compute-meter-sdk/.gitignore
+++ b/packages/compute-meter-sdk/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.venv/
+*.egg-info/
+dist/
+build/

--- a/packages/compute-meter-sdk/README.md
+++ b/packages/compute-meter-sdk/README.md
@@ -1,0 +1,138 @@
+# materios-compute-meter
+
+Worker signing identity SDK for Materios verifiable compute metering.
+
+Compute workers (K8s pods, VMs, containers) use this SDK to sign metering
+records and POST them to the Materios blob gateway. The gateway validates
+the signature, records the canonical content hash, and forwards the
+receipt to the Materios chain via the existing sponsored-receipt
+pipeline.
+
+This package lives inside the `orynq-sdk` monorepo so the Python SDK and
+the TypeScript gateway validator (`services/blob-gateway/src/schemas/
+compute_metering_v1.ts`) stay byte-pinned together. CI verifies the
+canonical CBOR encoders agree across both languages on every PR.
+
+## Install
+
+From PyPI (recommended for production workers):
+
+```bash
+pip install materios-compute-meter
+```
+
+From source (the monorepo path):
+
+```bash
+git clone https://github.com/Flux-Point-Studios/orynq-sdk
+cd orynq-sdk/packages/compute-meter-sdk
+pip install -e '.[dev]'
+```
+
+## Usage
+
+```python
+from materios_compute_meter import WorkerKeypair, MeteringRecord, submit
+
+# 1) Provision a key. In production, load from a secrets manager; for
+# tests / local dev, generate fresh:
+kp = WorkerKeypair.generate()
+kp.save("/var/lib/materios/worker-key.json")  # mode 0600
+
+# 2) Build a record describing one billable interval.
+record = MeteringRecord(
+    worker_id="worker-001",
+    tenant_id="tenant-acme",
+    period_start_ms=1733400000000,
+    period_end_ms=1733403600000,
+    cpu_seconds=120.5,
+    ram_gb_hours=0.42,
+    disk_gb_hours=0.0,
+    net_bytes_in=1_048_576,
+    net_bytes_out=524_288,
+    gpu_seconds=0.0,
+)
+
+# 3) Sign + submit (one-shot).
+result = submit(
+    kp, record,
+    gateway_url="https://materios.fluxpointstudios.com/preprod-blobs",
+    api_key="matra_...",
+)
+print(result["receipt_id"], result["content_hash"])
+
+# Or pre-sign for offline / batched submission:
+signed = kp.sign(record)
+print(signed.content_hash, signed.signature[:16] + "...")
+result = submit(signed, gateway_url=..., api_key=...)
+```
+
+## Loading existing keys
+
+```python
+# Deterministic from a 32-byte seed (handy for tests; do NOT use a static
+# seed in production unless it comes from an HSM or secrets manager).
+kp = WorkerKeypair.from_seed_hex("0x" + "11" * 32)
+
+# Or from a JSON keyfile previously written by `kp.save(...)`.
+kp = WorkerKeypair.load("/var/lib/materios/worker-key.json")
+```
+
+## Replay protection
+
+Each successful `submit()` records the record's `period_start_ms` in a
+per-process cache keyed by `worker_id`. A subsequent `submit()` for the
+same `worker_id` with `period_start_ms <= last seen` raises
+`ReplayRejectedError` BEFORE any HTTP traffic goes out.
+
+The gateway also rejects replays server-side at the
+`(signer_pub, period_start_ms)` tuple — the SDK's local cache is a
+defense-in-depth + cost-saving check.
+
+## Wire format
+
+The signed payload is `sha256(canonical_cbor(record_without_signature))`.
+The gateway request body is:
+
+```json
+{
+  "scheme": "sr25519",
+  "record": { ... canonical record dict, sorted keys ... },
+  "content_hash": "<64 hex>",
+  "signature":    "<128 hex>",
+  "signer_public":"<64 hex>"
+}
+```
+
+Canonical CBOR rules:
+- Map keys sorted lexicographically.
+- Lists / tuples NOT sorted (order is meaningful).
+- Only built-in primitives (dict / list / tuple / str / bytes / int /
+  float / bool / None) are accepted; foreign types are rejected with
+  `TypeError` so the canonical form cannot drift via custom encoders.
+
+## Testing
+
+Run from `packages/compute-meter-sdk/` inside a fresh venv:
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install -e '.[dev]'
+
+# Unit + canonicalization + keypair tests (no network):
+.venv/bin/pytest tests/ -m "not integration and not e2e and not slow"
+
+# LIVE preprod SDK-only integration:
+export MATERIOS_METERING_GATEWAY_URL="https://materios.fluxpointstudios.com/preprod-blobs"
+export MATERIOS_METERING_API_KEY="matra_..."
+.venv/bin/pytest tests/test_submit_integration.py
+
+# Full end-to-end Compute-Portal pipeline (≤15 min default, ≤45 min with anchor):
+.venv/bin/pytest tests/test_e2e_preprod.py -m e2e
+RUN_CARDANO_ANCHOR_TEST=1 .venv/bin/pytest tests/test_e2e_preprod.py -m "e2e or slow"
+```
+
+See [`tests/E2E.md`](tests/E2E.md) for the full operator runbook.
+
+## License
+
+MIT

--- a/packages/compute-meter-sdk/pyproject.toml
+++ b/packages/compute-meter-sdk/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "materios-compute-meter"
+version = "0.1.1"
+description = "Worker signing identity SDK for Materios verifiable compute metering."
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+authors = [{ name = "Fluxpoint Studios" }]
+dependencies = [
+    "cbor2>=5.4.0,<6",
+    "httpx>=0.25.0",
+    "py-sr25519-bindings>=0.2.0",
+    "substrate-interface>=1.7.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-httpx>=0.21.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+addopts = "-v --tb=short"
+markers = [
+    "integration: live preprod gateway test (requires network + API key)",
+    "e2e: end-to-end pipeline test against live preprod (task #113, ≤15 min)",
+    "slow: long-running E2E test (≤30 min, includes Cardano anchor wait)",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/materios_compute_meter"]

--- a/packages/compute-meter-sdk/src/materios_compute_meter/__init__.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/__init__.py
@@ -1,0 +1,63 @@
+"""materios_compute_meter — worker signing identity SDK for Materios verifiable
+compute metering.
+
+Public API:
+
+    from materios_compute_meter import (
+        WorkerKeypair,
+        MeteringRecord,
+        Signed,
+        submit,
+    )
+
+    # Generate / load
+    kp = WorkerKeypair.generate()
+    kp = WorkerKeypair.from_seed_hex("0x...")
+    kp = WorkerKeypair.load("/path/to/worker-key.json")
+    kp.save("/path/to/worker-key.json")
+
+    # Sign + submit
+    record = MeteringRecord(
+        worker_id="worker-001",
+        tenant_id="tenant-acme",
+        period_start_ms=1733400000000,
+        period_end_ms=1733403600000,
+        cpu_seconds=120.5,
+    )
+    signed = kp.sign(record)
+    result = submit(signed, gateway_url="...", api_key="matra_...")
+
+    # Or one-shot:
+    result = submit(kp, record, gateway_url="...", api_key="matra_...")
+"""
+from __future__ import annotations
+
+from .exceptions import (
+    ComputeMeterError,
+    GatewayError,
+    InvalidKeyfileError,
+    InvalidRecordError,
+    InvalidSeedError,
+    ReplayRejectedError,
+    SubmitError,
+)
+from .keypair import WorkerKeypair
+from .record import MeteringRecord, Signed
+from .submit import submit
+
+__all__ = [
+    "WorkerKeypair",
+    "MeteringRecord",
+    "Signed",
+    "submit",
+    # Exceptions
+    "ComputeMeterError",
+    "GatewayError",
+    "InvalidKeyfileError",
+    "InvalidRecordError",
+    "InvalidSeedError",
+    "ReplayRejectedError",
+    "SubmitError",
+]
+
+__version__ = "0.1.0"

--- a/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
@@ -1,0 +1,86 @@
+"""Canonical CBOR serialization with sorted map keys.
+
+This is the on-the-wire form a `MeteringRecord` takes when its hash is
+signed. The chosen rules:
+
+  * Map (dict) keys are sorted lexicographically by their UTF-8 string form.
+  * Lists / tuples are NOT sorted — order is meaningful.
+  * Only built-in primitives are allowed: dict, list, tuple, str, bytes,
+    int, float, bool, None. Custom classes are rejected with TypeError so
+    the canonical form cannot drift on a per-caller __cbor__ hook.
+  * cbor2 < 6 is pinned (per `project_aegis_publisher_deploy.md` cbor2 dep
+    pin gotcha).
+
+This matches schema #1's "canonical CBOR with sorted keys" expectation.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import cbor2
+
+_ALLOWED_TYPES = (dict, list, tuple, str, bytes, int, float, bool, type(None))
+
+
+def _validate_primitive(obj: Any) -> None:
+    """Recursive type guard. Raises TypeError on the first foreign type."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if not isinstance(k, str):
+                raise TypeError(
+                    f"canonical_cbor: dict keys must be str, got {type(k).__name__}"
+                )
+            _validate_primitive(v)
+        return
+    if isinstance(obj, (list, tuple)):
+        for item in obj:
+            _validate_primitive(item)
+        return
+    if isinstance(obj, _ALLOWED_TYPES):
+        return
+    raise TypeError(
+        f"canonical_cbor: unsupported type {type(obj).__name__}; only "
+        "dict/list/tuple/str/bytes/int/float/bool/None are allowed"
+    )
+
+
+def _sort_recursive(obj: Any) -> Any:
+    """Return a copy of `obj` where every nested dict has its keys sorted.
+    Keeps lists / tuples in their original order."""
+    if isinstance(obj, dict):
+        return {k: _sort_recursive(obj[k]) for k in sorted(obj.keys())}
+    if isinstance(obj, list):
+        return [_sort_recursive(x) for x in obj]
+    if isinstance(obj, tuple):
+        return tuple(_sort_recursive(x) for x in obj)
+    return obj
+
+
+def canonical_cbor(obj: Any) -> bytes:
+    """Serialize `obj` to CBOR with sorted map keys.
+
+    Args:
+        obj: A primitive-only Python value (dict / list / tuple / str / bytes /
+            int / float / bool / None, recursively).
+
+    Returns:
+        The canonical CBOR-encoded bytes.
+
+    Raises:
+        TypeError: if `obj` (or any nested value) is not a supported primitive.
+    """
+    _validate_primitive(obj)
+    sorted_obj = _sort_recursive(obj)
+    # cbor2.dumps with canonical=True also sorts maps, but only at a single
+    # level for some encoder versions. We pre-sort recursively to guarantee
+    # determinism across cbor2 versions in the [5.4, 6) range.
+    return cbor2.dumps(sorted_obj, canonical=True)
+
+
+def canonical_digest(obj: Any) -> bytes:
+    """Return sha256(canonical_cbor(obj)) as raw 32 bytes.
+
+    This is the value a worker actually signs.
+    """
+    return hashlib.sha256(canonical_cbor(obj)).digest()

--- a/packages/compute-meter-sdk/src/materios_compute_meter/exceptions.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/exceptions.py
@@ -1,0 +1,53 @@
+"""Exception hierarchy for materios_compute_meter.
+
+All exceptions raised by the public API derive from `ComputeMeterError`,
+so callers can catch the family with one `except`.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+class ComputeMeterError(Exception):
+    """Base exception for all materios_compute_meter errors."""
+
+
+class InvalidSeedError(ComputeMeterError):
+    """Raised when `WorkerKeypair.from_seed_hex` gets a value that is not a
+    32-byte hex string."""
+
+
+class InvalidKeyfileError(ComputeMeterError):
+    """Raised by `WorkerKeypair.load` when the file is missing fields, has the
+    wrong scheme, or contains a public/secret pair that does not derive."""
+
+
+class InvalidRecordError(ComputeMeterError):
+    """Raised by `MeteringRecord.__post_init__` for any value-domain
+    violation (negative usage, empty IDs, end <= start)."""
+
+
+class SubmitError(ComputeMeterError):
+    """Raised by `submit()` for any non-gateway error path: configuration
+    bad (empty API key), network transport error after the retry budget
+    is exhausted, or response not-JSON / missing required fields."""
+
+
+class GatewayError(SubmitError):
+    """Raised by `submit()` when the gateway responds with a non-2xx status
+    code that is not retryable (4xx) or after exhausting the retry budget
+    on 5xx. Carries the HTTP status code and decoded body if available."""
+
+    def __init__(
+        self, status: int, message: str, body: Optional[object] = None
+    ) -> None:
+        super().__init__(f"gateway returned {status}: {message}")
+        self.status = status
+        self.body = body
+
+
+class ReplayRejectedError(ComputeMeterError):
+    """Raised by `submit()` when the SDK's local replay cache sees a record
+    with `period_start_ms <= last_seen` for the same `worker_id`. This is
+    the SDK's own pre-flight check; the gateway also rejects replays
+    server-side as a defense in depth."""

--- a/packages/compute-meter-sdk/src/materios_compute_meter/keypair.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/keypair.py
@@ -1,0 +1,265 @@
+"""WorkerKeypair — sr25519 keypair management for compute workers.
+
+Wraps `substrate-interface`'s `Keypair` (which itself wraps the Rust
+`py-sr25519-bindings`) with a worker-friendly API:
+
+  * `WorkerKeypair.generate()` — fresh sr25519 from /dev/urandom.
+  * `WorkerKeypair.from_seed_hex("0x...")` — deterministic from a 32-byte
+    mini-secret (handy for tests; do not use in production unless the seed
+    came from an HSM-backed source).
+  * `WorkerKeypair.load("/path")` / `kp.save("/path")` — JSON pickle, mode
+    0600 enforced on save.
+
+The class also exposes raw `sign_bytes`/`verify_bytes` and the
+record-aware `sign()` that returns a `Signed` envelope.
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from typing import Optional
+
+import sr25519
+from substrateinterface import Keypair, KeypairType
+
+from .canonical import canonical_digest
+from .exceptions import InvalidKeyfileError, InvalidSeedError
+from .record import MeteringRecord, Signed
+
+
+def _normalize_seed_hex(seed_hex: str) -> bytes:
+    if not isinstance(seed_hex, str):
+        raise InvalidSeedError("seed_hex must be a string")
+    s = seed_hex[2:] if seed_hex.startswith(("0x", "0X")) else seed_hex
+    try:
+        raw = bytes.fromhex(s)
+    except ValueError as e:
+        raise InvalidSeedError(f"seed_hex is not valid hex: {e}") from e
+    if len(raw) != 32:
+        raise InvalidSeedError(
+            f"seed_hex must decode to exactly 32 bytes (got {len(raw)})"
+        )
+    return raw
+
+
+class WorkerKeypair:
+    """sr25519 keypair for a Materios compute worker.
+
+    Construct via `generate()`, `from_seed_hex()`, or `load()` — the
+    `__init__` is private-by-convention and not part of the public API.
+    """
+
+    SCHEME = "sr25519"
+
+    def __init__(self, public_key: bytes, secret_key: bytes) -> None:
+        if len(public_key) != 32:
+            raise InvalidKeyfileError(
+                f"public_key must be 32 bytes (got {len(public_key)})"
+            )
+        if len(secret_key) != 64:
+            raise InvalidKeyfileError(
+                f"secret_key must be 64 bytes (got {len(secret_key)})"
+            )
+        self._public = public_key
+        self._secret = secret_key
+        # Derive the substrate-interface Keypair lazily for sign/verify.
+        # We pass private_key + public_key so it doesn't try to derive a seed.
+        self._inner = Keypair(
+            public_key=public_key,
+            private_key=secret_key,
+            crypto_type=KeypairType.SR25519,
+            ss58_format=42,  # Materios prefix
+        )
+
+    # ---------------------- constructors ----------------------
+
+    @classmethod
+    def generate(cls) -> "WorkerKeypair":
+        """Generate a fresh sr25519 keypair from a cryptographically random
+        32-byte seed.
+
+        Returns:
+            A new `WorkerKeypair`.
+        """
+        seed = secrets.token_bytes(32)
+        public, secret = sr25519.pair_from_seed(seed)
+        return cls(public_key=bytes(public), secret_key=bytes(secret))
+
+    @classmethod
+    def from_seed_hex(cls, seed_hex: str) -> "WorkerKeypair":
+        """Construct a `WorkerKeypair` from a 32-byte hex mini-secret.
+
+        Args:
+            seed_hex: 64-character hex string (with optional `0x` prefix).
+
+        Returns:
+            A `WorkerKeypair` deterministically derived from the seed.
+
+        Raises:
+            InvalidSeedError: if `seed_hex` is not a 32-byte hex string.
+        """
+        seed = _normalize_seed_hex(seed_hex)
+        public, secret = sr25519.pair_from_seed(seed)
+        return cls(public_key=bytes(public), secret_key=bytes(secret))
+
+    @classmethod
+    def load(cls, path: str) -> "WorkerKeypair":
+        """Load a `WorkerKeypair` from a JSON keyfile produced by `save()`.
+
+        Args:
+            path: Filesystem path to the JSON keyfile.
+
+        Returns:
+            A `WorkerKeypair` reconstructed from the file.
+
+        Raises:
+            InvalidKeyfileError: if the file is malformed, has the wrong
+                scheme, or contains a public key that does not match the
+                public derived from the secret.
+        """
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                blob = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise InvalidKeyfileError(f"could not read {path}: {e}") from e
+
+        if not isinstance(blob, dict):
+            raise InvalidKeyfileError("keyfile root is not a JSON object")
+        scheme = blob.get("scheme")
+        if scheme != cls.SCHEME:
+            raise InvalidKeyfileError(
+                f"unsupported scheme {scheme!r}, only {cls.SCHEME!r} is allowed"
+            )
+        secret_hex = blob.get("secret")
+        public_hex = blob.get("public")
+        if not isinstance(secret_hex, str) or not isinstance(public_hex, str):
+            raise InvalidKeyfileError("keyfile missing 'secret' or 'public' field")
+
+        try:
+            secret = bytes.fromhex(secret_hex)
+            public = bytes.fromhex(public_hex)
+        except ValueError as e:
+            raise InvalidKeyfileError(f"secret/public is not valid hex: {e}") from e
+
+        # The 64-byte sr25519 secret encodes its derived public; recompute and
+        # cross-check to detect tampering.
+        derived_public = bytes(sr25519.public_from_secret_key(secret))
+        if derived_public != public:
+            raise InvalidKeyfileError(
+                "keyfile public does not match the public derived from secret"
+            )
+
+        return cls(public_key=public, secret_key=secret)
+
+    # ---------------------- persistence ----------------------
+
+    def save(self, path: str) -> None:
+        """Write the keypair to a JSON keyfile with mode 0600.
+
+        The file is written via a "create new, then rename" sequence to
+        avoid leaving the secret on disk readable by other users while the
+        write is in flight. If a file already exists at `path` it is
+        overwritten.
+
+        Args:
+            path: Filesystem path to write to. Parent directory must exist.
+
+        Raises:
+            OSError: on any I/O failure during write/rename.
+        """
+        blob = {
+            "scheme": self.SCHEME,
+            "public": self._public.hex(),
+            "secret": self._secret.hex(),
+        }
+        # Atomic-ish write: create with restrictive mode, fsync, rename.
+        tmp_path = f"{path}.tmp.{os.getpid()}"
+        # 0600 from the moment the fd opens.
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(blob, f)
+                f.flush()
+                os.fsync(f.fileno())
+        except Exception:
+            # Best-effort cleanup if we threw mid-write.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        os.replace(tmp_path, path)
+        # os.replace preserves the source mode on Linux; chmod again to be sure.
+        os.chmod(path, 0o600)
+
+    # ---------------------- accessors ----------------------
+
+    @property
+    def public_hex(self) -> str:
+        """The 32-byte sr25519 public key as a 64-char lowercase hex string
+        (no `0x` prefix)."""
+        return self._public.hex()
+
+    @property
+    def secret_hex(self) -> str:
+        """The 64-byte sr25519 expanded secret key as a 128-char lowercase
+        hex string (no `0x` prefix). Treat this as sensitive."""
+        return self._secret.hex()
+
+    @property
+    def ss58_address(self) -> str:
+        """The Materios SS58-format address (prefix-42) for this public key."""
+        return self._inner.ss58_address
+
+    # ---------------------- signing ----------------------
+
+    def sign_bytes(self, payload: bytes) -> bytes:
+        """sr25519-sign an arbitrary byte string.
+
+        Args:
+            payload: Raw bytes to sign.
+
+        Returns:
+            64 raw bytes of sr25519 signature.
+        """
+        return self._inner.sign(payload)
+
+    def verify_bytes(self, payload: bytes, signature: bytes) -> bool:
+        """Verify an sr25519 signature against this keypair's public key.
+
+        Args:
+            payload: The same bytes that were originally signed.
+            signature: 64-byte sr25519 signature.
+
+        Returns:
+            True if the signature is valid, False otherwise. Does not
+            raise on bad-shape input — the underlying library returns
+            False.
+        """
+        try:
+            return bool(self._inner.verify(payload, signature))
+        except Exception:
+            return False
+
+    def sign(self, record: MeteringRecord) -> Signed:
+        """Sign a `MeteringRecord` and return a `Signed[MeteringRecord]` envelope.
+
+        The signed payload is `sha256(canonical_cbor(record_without_signature))`,
+        per the schema #1 contract.
+
+        Args:
+            record: The record to sign.
+
+        Returns:
+            A `Signed` envelope with `content_hash`, `signature`,
+            `signer_public_hex`, and the original record.
+        """
+        digest = canonical_digest(record.to_canonical_dict())
+        sig = self.sign_bytes(digest)
+        return Signed(
+            record=record,
+            content_hash=digest.hex(),
+            signature=sig.hex(),
+            signer_public_hex=self.public_hex,
+        )

--- a/packages/compute-meter-sdk/src/materios_compute_meter/record.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/record.py
@@ -1,0 +1,144 @@
+"""MeteringRecord — a single billable usage interval for a compute worker.
+
+The record is the input to the SDK's signing flow. Field names are coupled
+to schema #1 (Agent #1 owns the canonical schema). If #1 ships with renames,
+patch this module's `to_canonical_dict()` keys; nothing else in the SDK
+depends on the exact names.
+
+Validation runs in `__post_init__`. We refuse:
+  * empty `worker_id` or `tenant_id`
+  * `period_end_ms <= period_start_ms`
+  * any negative resource counter
+
+Replay protection is enforced in `submit()` (per-worker monotonic
+`period_start_ms`), not here — a record by itself is just data.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+from .exceptions import InvalidRecordError
+
+
+@dataclass
+class MeteringRecord:
+    """A billable usage interval for a single compute worker.
+
+    Attributes:
+        worker_id: Stable string identifier for the worker (e.g. K8s pod
+            name, VM hostname). Non-empty.
+        tenant_id: Identifier of the tenant whose workload generated this
+            usage. Non-empty.
+        period_start_ms: UNIX-epoch milliseconds at which the usage interval
+            begins. Inclusive.
+        period_end_ms: UNIX-epoch milliseconds at which the usage interval
+            ends. Strictly greater than `period_start_ms`.
+        cpu_seconds: CPU-seconds consumed in the interval. >= 0.
+        ram_gb_hours: GB-hours of RAM consumed in the interval. >= 0.
+        disk_gb_hours: GB-hours of disk consumed. >= 0.
+        net_bytes_in: Bytes of inbound network traffic. >= 0 integer.
+        net_bytes_out: Bytes of outbound network traffic. >= 0 integer.
+        gpu_seconds: GPU-seconds consumed. >= 0. Default 0 for non-GPU
+            workloads.
+    """
+
+    worker_id: str
+    tenant_id: str
+    period_start_ms: int
+    period_end_ms: int
+    cpu_seconds: float
+    ram_gb_hours: float = 0.0
+    disk_gb_hours: float = 0.0
+    net_bytes_in: int = 0
+    net_bytes_out: int = 0
+    gpu_seconds: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.worker_id, str) or not self.worker_id:
+            raise InvalidRecordError("worker_id must be a non-empty string")
+        if not isinstance(self.tenant_id, str) or not self.tenant_id:
+            raise InvalidRecordError("tenant_id must be a non-empty string")
+        if not isinstance(self.period_start_ms, int) or self.period_start_ms < 0:
+            raise InvalidRecordError("period_start_ms must be a non-negative int")
+        if not isinstance(self.period_end_ms, int):
+            raise InvalidRecordError("period_end_ms must be an int")
+        if self.period_end_ms <= self.period_start_ms:
+            raise InvalidRecordError(
+                "period_end_ms must be strictly greater than period_start_ms"
+            )
+
+        for fname in ("cpu_seconds", "ram_gb_hours", "disk_gb_hours", "gpu_seconds"):
+            v = getattr(self, fname)
+            if not isinstance(v, (int, float)) or v < 0:
+                raise InvalidRecordError(
+                    f"{fname} must be a non-negative number (got {v!r})"
+                )
+            # Normalize ints to float for stable canonical form.
+            setattr(self, fname, float(v))
+
+        for fname in ("net_bytes_in", "net_bytes_out"):
+            v = getattr(self, fname)
+            if not isinstance(v, int) or v < 0:
+                raise InvalidRecordError(
+                    f"{fname} must be a non-negative int (got {v!r})"
+                )
+
+    def to_canonical_dict(self) -> Dict[str, Any]:
+        """Return a sorted-key dict suitable for canonical CBOR serialization.
+
+        The returned dict deliberately excludes any signature, content_hash,
+        or signer_public field — those live in the wrapping `Signed`
+        envelope, never in the signed payload.
+        """
+        return {
+            "cpu_seconds": self.cpu_seconds,
+            "disk_gb_hours": self.disk_gb_hours,
+            "gpu_seconds": self.gpu_seconds,
+            "net_bytes_in": self.net_bytes_in,
+            "net_bytes_out": self.net_bytes_out,
+            "period_end_ms": self.period_end_ms,
+            "period_start_ms": self.period_start_ms,
+            "ram_gb_hours": self.ram_gb_hours,
+            "tenant_id": self.tenant_id,
+            "worker_id": self.worker_id,
+        }
+
+
+@dataclass
+class Signed:
+    """A `MeteringRecord` plus its sr25519 signature and signer public key.
+
+    `verify()` recomputes the canonical digest from `record` and checks the
+    signature; mutating the record after signing causes verify() to return
+    False.
+    """
+
+    record: MeteringRecord
+    content_hash: str  # 64 hex chars (sha256 of canonical CBOR)
+    signature: str  # 128 hex chars (64-byte sr25519 signature)
+    signer_public_hex: str  # 64 hex chars (32-byte sr25519 public key)
+    scheme: str = field(default="sr25519")
+
+    def verify(self) -> bool:
+        """Recompute the canonical digest and verify the signature against
+        `signer_public_hex`. Returns True on match, False otherwise."""
+        # Local import keeps `record` module independent of substrate-interface
+        # so callers can serialize records without paying that import cost.
+        from substrateinterface import Keypair, KeypairType
+
+        from .canonical import canonical_digest
+
+        digest = canonical_digest(self.record.to_canonical_dict())
+        if digest.hex() != self.content_hash:
+            return False
+
+        try:
+            verifier = Keypair(
+                public_key=bytes.fromhex(self.signer_public_hex),
+                crypto_type=KeypairType.SR25519,
+                ss58_format=42,
+            )
+            return bool(verifier.verify(digest, bytes.fromhex(self.signature)))
+        except Exception:
+            return False

--- a/packages/compute-meter-sdk/src/materios_compute_meter/submit.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/submit.py
@@ -1,0 +1,261 @@
+"""HTTPS submit pipeline for signed metering records.
+
+`submit(...)` accepts either a pre-signed `Signed[MeteringRecord]` envelope
+or a `(WorkerKeypair, MeteringRecord)` pair (one-shot). It POSTs the
+canonical signed envelope to `<gateway_url>/metering/submit` with a
+`Bearer <api_key>` header.
+
+Behavioural details:
+  * Per-process replay cache: a record whose `period_start_ms` is `<=` the
+    last seen value for the same `worker_id` raises `ReplayRejectedError`
+    BEFORE any HTTP call goes out. This is a defense in depth — the
+    gateway also rejects replays server-side at the
+    `(signer_pub, period_start_ms)` tuple.
+  * Retry policy: one retry on 5xx with a 2-second backoff. 4xx is fatal.
+  * Default timeout: 15 seconds, matches publisher convention.
+  * URL normalization: trailing slash on `gateway_url` is stripped.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from .exceptions import (
+    GatewayError,
+    ReplayRejectedError,
+    SubmitError,
+)
+from .keypair import WorkerKeypair
+from .record import MeteringRecord, Signed
+
+_LOG = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 15.0
+DEFAULT_RETRY_BACKOFF_SECONDS = 2.0
+
+# Per-process replay cache: maps worker_id -> last accepted period_start_ms.
+# Guarded by `_REPLAY_LOCK` so concurrent submit() calls from the same
+# process can't race past the check.
+_REPLAY_CACHE: Dict[str, int] = {}
+_REPLAY_LOCK = threading.Lock()
+
+
+def _resolve_signed(
+    signed_or_kp: Union[Signed, WorkerKeypair],
+    record: Optional[MeteringRecord],
+) -> Signed:
+    """Normalize the two call shapes into a `Signed` envelope."""
+    if isinstance(signed_or_kp, Signed):
+        if record is not None:
+            raise SubmitError(
+                "submit(signed, ...) was called with a record argument; pass "
+                "either a Signed envelope OR (keypair, record), not both"
+            )
+        return signed_or_kp
+
+    if isinstance(signed_or_kp, WorkerKeypair):
+        if record is None:
+            raise SubmitError(
+                "submit(keypair, record, ...) requires a record argument"
+            )
+        return signed_or_kp.sign(record)
+
+    raise SubmitError(
+        "first argument to submit() must be a Signed envelope or a WorkerKeypair "
+        f"(got {type(signed_or_kp).__name__})"
+    )
+
+
+def _check_and_record_replay(record: MeteringRecord) -> None:
+    """Reject if `record.period_start_ms` is not strictly greater than the
+    last seen for the same `worker_id`. Updates the cache on success."""
+    with _REPLAY_LOCK:
+        last = _REPLAY_CACHE.get(record.worker_id)
+        if last is not None and record.period_start_ms <= last:
+            raise ReplayRejectedError(
+                f"replay rejected for worker_id={record.worker_id!r}: "
+                f"period_start_ms={record.period_start_ms} is not greater than "
+                f"last seen {last} (records must be monotonically increasing)"
+            )
+        # Warn (not error) if the user submits records with the same period
+        # under different worker_ids — that's typically a sign of a clock /
+        # naming mistake, but it's not strictly forbidden.
+        if last is not None and record.period_start_ms < last + 1:
+            _LOG.warning(
+                "metering record for worker_id=%r jumped period by less than 1ms; "
+                "verify your scheduler is not double-firing",
+                record.worker_id,
+            )
+        _REPLAY_CACHE[record.worker_id] = record.period_start_ms
+
+
+def _envelope_to_wire(signed: Signed) -> Dict[str, Any]:
+    """The JSON shape Agent #1's gateway expects (see
+    `feedback_orynq_gateway_migration_gaps.md`-style contract)."""
+    return {
+        "scheme": signed.scheme,
+        "record": signed.record.to_canonical_dict(),
+        "content_hash": signed.content_hash,
+        "signature": signed.signature,
+        "signer_public": signed.signer_public_hex,
+    }
+
+
+def _post_with_retry(
+    client: httpx.Client,
+    url: str,
+    headers: Dict[str, str],
+    body: Dict[str, Any],
+    retry_backoff_seconds: float,
+) -> httpx.Response:
+    """One try + one retry on 5xx. 4xx is returned directly (no retry).
+    Network errors are retried once with the same backoff, then raised."""
+    last_exc: Optional[Exception] = None
+    for attempt in (0, 1):
+        if attempt == 1 and retry_backoff_seconds > 0:
+            time.sleep(retry_backoff_seconds)
+        try:
+            r = client.post(url, headers=headers, json=body)
+        except httpx.HTTPError as e:
+            last_exc = e
+            if attempt == 1:
+                raise SubmitError(
+                    f"network error reaching gateway at {url}: {e}"
+                ) from e
+            continue
+
+        if 500 <= r.status_code < 600:
+            if attempt == 0:
+                _LOG.warning(
+                    "gateway %s returned %d, retrying once after %.1fs backoff",
+                    url, r.status_code, retry_backoff_seconds,
+                )
+                continue
+            # Second 5xx — give up.
+            return r
+        # 2xx or 4xx — return immediately, no retry.
+        return r
+    # Loop above always returns or raises; this line is for type-checkers.
+    raise SubmitError(f"unreachable retry exit; last_exc={last_exc!r}")  # pragma: no cover
+
+
+def submit(
+    signed_or_kp: Union[Signed, WorkerKeypair],
+    record: Optional[MeteringRecord] = None,
+    *,
+    gateway_url: str,
+    api_key: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    _client: Optional[httpx.Client] = None,
+    _retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
+) -> Dict[str, Any]:
+    """Submit a signed metering record to the Materios blob gateway.
+
+    Two call shapes are supported:
+
+        # 1) Pre-signed envelope:
+        signed = kp.sign(record)
+        submit(signed, gateway_url=..., api_key=...)
+
+        # 2) One-shot:
+        submit(kp, record, gateway_url=..., api_key=...)
+
+    Args:
+        signed_or_kp: Either a `Signed` envelope (form 1) or a
+            `WorkerKeypair` (form 2).
+        record: Required iff form 2; ignored for form 1.
+        gateway_url: Base URL of the Materios blob gateway, e.g.
+            `https://materios.fluxpointstudios.com/preprod-blobs`. The SDK
+            appends `/metering/submit`. Trailing slashes are tolerated.
+        api_key: Bearer token issued by the gateway admin (matra_*).
+        timeout_seconds: Per-request timeout. Default 15s.
+
+    Returns:
+        The decoded JSON body from the gateway, typically:
+            {"receipt_id": "...", "content_hash": "...", "accepted_at": ...}
+
+    Raises:
+        SubmitError: configuration or network error.
+        GatewayError: gateway returned a non-2xx after retries.
+        ReplayRejectedError: SDK replay cache rejected the record.
+    """
+    if not api_key:
+        raise SubmitError("api_key must be a non-empty string")
+    if not gateway_url:
+        raise SubmitError("gateway_url must be a non-empty string")
+
+    base = gateway_url.rstrip("/")
+    url = f"{base}/metering/submit"
+
+    envelope = _resolve_signed(signed_or_kp, record)
+
+    # Replay check happens AFTER signing (so a replayed record is signed
+    # only once, not zero times — keeps the API symmetric across both call
+    # shapes) but BEFORE the network call (so we don't burn quota).
+    _check_and_record_replay(envelope.record)
+
+    headers = {
+        "authorization": f"Bearer {api_key}",
+        "content-type": "application/json",
+        "user-agent": "materios-compute-meter/0.1.0",
+    }
+    wire = _envelope_to_wire(envelope)
+
+    owns_client = _client is None
+    client = _client or httpx.Client(timeout=timeout_seconds)
+    try:
+        try:
+            r = _post_with_retry(
+                client=client,
+                url=url,
+                headers=headers,
+                body=wire,
+                retry_backoff_seconds=_retry_backoff_seconds,
+            )
+        except SubmitError:
+            # Replay cache was already updated; on a hard transport failure
+            # we leave the cache as-is so a deliberate retry from the caller
+            # with the same record gets the local-replay rejection rather
+            # than re-hitting the network. Callers that want to retry MUST
+            # bump period_start_ms.
+            raise
+
+        if not (200 <= r.status_code < 300):
+            try:
+                body: Optional[object] = r.json()
+                err_msg = (body or {}).get("error") if isinstance(body, dict) else r.text
+            except Exception:
+                body = r.text
+                err_msg = r.text
+            raise GatewayError(
+                status=r.status_code,
+                message=str(err_msg)[:500],
+                body=body,
+            )
+
+        try:
+            decoded = r.json()
+        except Exception as e:
+            raise SubmitError(
+                f"gateway returned non-JSON 2xx body: {r.text[:200]!r}"
+            ) from e
+
+        if not isinstance(decoded, dict):
+            raise SubmitError(
+                f"gateway 2xx body is not a JSON object: {decoded!r}"
+            )
+        return decoded
+    finally:
+        if owns_client:
+            client.close()
+
+
+def _reset_replay_cache_for_tests() -> None:
+    """Clear the per-process replay cache. Tests may call this between
+    parameterized runs that intentionally reuse `worker_id` values."""
+    with _REPLAY_LOCK:
+        _REPLAY_CACHE.clear()

--- a/packages/compute-meter-sdk/tests/E2E.md
+++ b/packages/compute-meter-sdk/tests/E2E.md
@@ -1,0 +1,130 @@
+# Compute-Metering E2E Suite (task #113)
+
+End-to-end pytest suite that exercises the full Compute Portal compute-metering
+pipeline against live Materios preprod:
+
+```
+worker SDK keypair
+   └→ POST /metering/submit (compute_metering_v1 schema)
+        └→ on-chain receipt (sponsored-receipt-submitter)
+             └→ cert-daemon attestation
+                  └→ Cardano L1 anchor (anchor-worker)
+                       └→ GET /billing/usage shows it
+```
+
+This file is the **smoke-check entry-point**: when Hetzner-Claude (or any
+operator) finishes a deploy, they run this suite and a green run means the
+whole pipeline is healthy.
+
+## TL;DR — quick run
+
+```bash
+cd /home/deci/work/orynq-sdk/packages/compute-meter-sdk
+
+# 1. Install SDK + test deps (one-time):
+python3 -m venv .venv && .venv/bin/pip install -e '.[dev]'
+
+# 2. Set env vars:
+export MATERIOS_METERING_GATEWAY_URL="https://materios.fluxpointstudios.com/preprod-blobs"
+export MATERIOS_METERING_API_KEY="matra_<your-bearer>"
+
+# 3. Run the default suite (≤15 min):
+.venv/bin/pytest tests/test_e2e_preprod.py -m e2e --maxfail=1
+
+# 4. Optional — full suite including Cardano anchor (≤45 min):
+RUN_CARDANO_ANCHOR_TEST=1 .venv/bin/pytest tests/test_e2e_preprod.py \
+    -m "e2e or slow" --maxfail=1
+```
+
+## Environment variables
+
+| var | required | default | purpose |
+|---|---|---|---|
+| `MATERIOS_METERING_GATEWAY_URL` | no | `https://materios.fluxpointstudios.com/preprod-blobs` | Base URL of the Materios blob gateway. The suite appends `/metering/submit` and `/billing/usage`. Trailing slash is tolerated. |
+| `MATERIOS_METERING_API_KEY` | yes | — | Bearer token (`matra_…`) used for `Authorization: Bearer` on the billing query. The submit route auths by sr25519 signature; the bearer is consumed only by the billing read. |
+| `RUN_CARDANO_ANCHOR_TEST` | no | unset | Set to `1` to enable `test_e2e_cardano_anchor_landing` (≤30 min). Skipped otherwise. |
+
+## Minting a Bearer token
+
+The gateway exposes admin-only token management at `/auth/token`. To mint a
+fresh Bearer for the E2E suite:
+
+```bash
+curl -X POST \
+    -H "X-Admin-Token: $DAEMON_NOTIFY_TOKEN" \
+    -H 'content-type: application/json' \
+    -d '{"account":"<your SS58 address>","label":"e2e-task-113"}' \
+    https://materios.fluxpointstudios.com/preprod-blobs/auth/token
+```
+
+The response carries `token` (shown ONCE). Store it in
+`MATERIOS_METERING_API_KEY` and never log it.
+
+## Tests in this suite
+
+| name | what it proves | budget |
+|---|---|---|
+| `test_e2e_happy_path` | Single record. Submit → 200 + `content_hash` matches local canonical hash → cert-daemon certifies → `/billing/usage` shows `attestation_status="certified"` and aggregate sums equal the input fields exactly. | ≤10 min |
+| `test_e2e_burst_5_records` | Five records under one tenant_id. All five certify. Aggregate equals elementwise sum (cpu, ram, net_in, net_out). `unique_workers == 5`. | ≤10 min |
+| `test_e2e_signature_rejected` | Sign with key A but advertise pubkey B → 401 `SIGNATURE_INVALID`. | <1 min |
+| `test_e2e_replay_rejected` | (a) Exact-bytes retry → 200 `status="replay"`. (b) New record with `period_start` below the last one for the same `worker_id` → 409 `MONOTONIC_VIOLATION`. | <2 min |
+| `test_e2e_cardano_anchor_landing` (`@slow`) | Single record, full path including Cardano anchor. After cert lands, polls until `cardano_anchor_tx` is non-null. Asserts `aggregate.anchored_count >= 1`. | ≤30 min |
+
+## Skip behaviour
+
+The whole module skips with a clear diagnostic if any precondition fails:
+
+* `MATERIOS_METERING_API_KEY` unset → instructions for minting one.
+* `/health` returns non-200 → connectivity hint.
+* `POST /metering/submit` returns 404 → "task #109 not deployed yet, re-run after merge".
+* `GET /billing/usage` returns 404 → "task #112 not deployed yet, re-run after merge".
+* `GET /billing/usage` returns 401 → "configured Bearer does not pass bearerAuth".
+
+A skipped run is NOT a failure — it tells the operator exactly which
+upstream piece is missing.
+
+## Timing budgets — do not deviate
+
+These are pinned in the test file as constants (`CERT_DEADLINE_S = 600.0`,
+`ANCHOR_DEADLINE_S = 1800.0`). They were picked from task #114's audit which
+established that real cert-daemon p50 is ~5 minutes (NOT the legacy 90-second
+assumption that flaked across multiple suites). The 30-minute anchor budget
+matches the anchor-worker's batch interval + Cardano confirmation latency.
+
+If you find yourself wanting to tighten these because "preprod is fast today",
+DON'T. The brief is explicit on this point — flaky timing is the dominant
+failure mode in operator-facing CI.
+
+## Why the tests don't use `materios_compute_meter.submit()`
+
+Background: the SDK's `submit()` path signs over a different canonical CBOR
+encoding than the gateway's `compute_metering_v1` schema validator expects.
+Specifically:
+
+* SDK uses `cbor2.dumps(canonical=True)` over a record dict with `_ms`-suffixed
+  keys (`period_start_ms`) and NO `schema_version` field.
+* Gateway uses an inline RFC 8949 §4.2.1 encoder over a record with bare
+  `period_start` / `period_end` keys, a mandatory `schema_version`, an
+  embedded `worker_pubkey`, and integer-valued floats encoded as ints (the
+  way TS's `Number.isInteger(0.0) === true` dictates).
+
+The E2E suite ships its own `_e2e_helpers.canonical_body()` — a 150-line
+pure-Python encoder that is byte-for-byte identical to the gateway's TS
+implementation (verified via cross-language hash comparison on multiple test
+vectors). This insulates the E2E contract from any unrelated SDK refactors
+and gives us a second independent implementation of the schema, which is
+the whole reason canonical CBOR exists.
+
+The SDK is still used for `WorkerKeypair.generate()` and `kp.sign_bytes()` —
+those are the parts that don't depend on the canonical encoding.
+
+## Adding new E2E tests
+
+1. Mark with `@pytest.mark.e2e` (default suite) or `@pytest.mark.slow` (gated).
+2. Use `cfg` fixture for gateway endpoint config.
+3. Use a `fresh_tenant_id()` to keep tests isolated on a shared gateway.
+4. For polling, use the helpers — never tight-loop. Exponential backoff with
+   a deadline is the standard pattern; copy from `wait_for_certification()`.
+5. Assert on the canonical content_hash AND the gateway's response field —
+   both must match. A passing assertion that only checks one side is a
+   regression-risk gap.

--- a/packages/compute-meter-sdk/tests/_e2e_helpers.py
+++ b/packages/compute-meter-sdk/tests/_e2e_helpers.py
@@ -1,0 +1,644 @@
+"""Helpers for the live-preprod E2E suite (`test_e2e_preprod.py`).
+
+Two responsibilities:
+
+  1. Build a `compute_metering_v1` wire envelope EXACTLY the way Agent #1's
+     gateway validator (`services/blob-gateway/src/schemas/compute_metering_v1.ts`)
+     decodes it. The on-disk SDK (`materios_compute_meter`) historically used
+     a slightly different canonical encoding (cbor2's `canonical=True` over a
+     reduced field set with `_ms` suffixes and no `schema_version`); the
+     gateway expects RFC 8949 §4.2.1 canonical CBOR over the FULL field set
+     including `schema_version` and `worker_pubkey`, with `period_start`/
+     `period_end` (no `_ms` suffix), and ALWAYS-8-byte float64. This module
+     contains the gateway-compatible canonical encoder so the suite can
+     exercise the real wire contract without modifying the SDK's existing
+     `submit()` API surface (which has 42/42 unit tests pinned to its own
+     shape).
+
+  2. Polling helpers — long-poll a content_hash through cert-daemon
+     certification (~5 min p50) and through the Cardano anchor (~15 min p50).
+     Per `feedback_anchor_worker_log_timezone_misread.md`: timestamps in
+     anchor logs are NOT always UTC, so we never compare wall-clock — we
+     only compare gateway-returned status fields.
+
+The encoder here is intentionally a self-contained ~150 LoC pure-Python
+implementation; it does NOT call the SDK's `canonical_cbor()`. That keeps
+the test independent: if anyone changes the SDK's encoder, the gateway
+contract stays pinned by THIS file. Cross-language consistency with the
+TS implementation is the whole point of the wire format — so a second
+independent implementation in tests is a feature, not duplication.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import struct
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+# Pull WorkerKeypair only for type hints; sign_bytes is the only API we use.
+from materios_compute_meter import WorkerKeypair
+
+
+# ---------------------------------------------------------------------------
+# Schema constants — kept in lockstep with
+# services/blob-gateway/src/schemas/compute_metering_v1.ts
+# ---------------------------------------------------------------------------
+
+SCHEMA_VERSION = "compute_metering_v1"
+
+# sha256 of the schema-version utf-8 bytes — surfaced as `schema_hash` by the
+# route + by `GET /billing/usage`'s audit_trail. Pinned here so the suite can
+# assert the value the gateway returns matches the spec, not whatever the
+# server happens to compute today.
+SCHEMA_HASH_HEX = hashlib.sha256(SCHEMA_VERSION.encode("utf-8")).hexdigest()
+
+# All `compute_metering_v1` keys that go INTO the canonical body (the input
+# to sr25519.sign). `worker_signature` is intentionally absent — it is NOT
+# included in the message that's signed (signing yourself is a tautology).
+# Order is presentation-only; the canonical encoder sorts by encoded-key
+# bytes per RFC 8949 §4.2.1.
+CANONICAL_FIELDS = (
+    "schema_version",
+    "worker_id",
+    "tenant_id",
+    "period_start",
+    "period_end",
+    "cpu_seconds",
+    "ram_gb_hours",
+    "disk_gb_hours",
+    "net_bytes_in",
+    "net_bytes_out",
+    "gpu_seconds",
+    "worker_pubkey",
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonical CBOR encoder — RFC 8949 §4.2.1, restricted to the type set the
+# `compute_metering_v1` schema actually uses. Mirrors the TS implementation
+# in compute_metering_v1.ts byte-for-byte.
+# ---------------------------------------------------------------------------
+
+
+def _encode_uint(major: int, n: int) -> bytes:
+    """Shortest unsigned-int CBOR encoding (RFC 8949 §3.1)."""
+    if n < 0:
+        raise TypeError(f"_encode_uint: negative: {n}")
+    if n <= 23:
+        return bytes([(major << 5) | n])
+    if n <= 0xFF:
+        return bytes([(major << 5) | 24, n])
+    if n <= 0xFFFF:
+        return bytes([(major << 5) | 25, (n >> 8) & 0xFF, n & 0xFF])
+    if n <= 0xFFFFFFFF:
+        return struct.pack(">BI", (major << 5) | 26, n)
+    if n > (2**53 - 1):
+        # Mirrors the JS_SAFE_INT cap in the TS encoder; we never allow
+        # larger ints in this schema's wire form.
+        raise TypeError(f"_encode_uint: exceeds JS-safe int: {n}")
+    return struct.pack(">BQ", (major << 5) | 27, n)
+
+
+def _encode_int(n: int) -> bytes:
+    """Signed int CBOR encoding (major type 0 for >=0, 1 for <0)."""
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"_encode_int: not an integer: {n!r}")
+    if n >= 0:
+        return _encode_uint(0, n)
+    # Major type 1, value -1 - n.
+    return _encode_uint(1, -1 - n)
+
+
+def _encode_float64(n: float) -> bytes:
+    """Float64 CBOR encoding (major type 7, additional 27, 8-byte BE).
+
+    Always 8 bytes — never shorten to f32/f16. RFC 8949 §3.3 allows
+    shortening but the TS encoder does NOT shorten, and a cross-language
+    verifier needs the byte streams identical. NaN and Infinity are refused
+    to mirror the TS validator's `Number.isFinite` gate.
+    """
+    if not isinstance(n, (int, float)) or isinstance(n, bool):
+        raise TypeError(f"_encode_float64: not a number: {n!r}")
+    f = float(n)
+    if f != f or f in (float("inf"), float("-inf")):
+        raise TypeError(f"_encode_float64: not finite: {f}")
+    return bytes([(7 << 5) | 27]) + struct.pack(">d", f)
+
+
+def _encode_text(s: str) -> bytes:
+    """Text-string CBOR encoding (major type 3, UTF-8 bytes)."""
+    if not isinstance(s, str):
+        raise TypeError(f"_encode_text: not a string: {s!r}")
+    payload = s.encode("utf-8")
+    return _encode_uint(3, len(payload)) + payload
+
+
+def _encode_value(v: Any) -> bytes:
+    """Dispatch a single value to the right primitive encoder.
+
+    Order of checks matters:
+      * `bool` is a subclass of `int` in Python — forbid explicitly.
+      * `str` first to keep sr25519 hex strings out of the int branch.
+      * `int` next — Python `True/False` already filtered.
+      * `float` last — BUT TypeScript's encoder dispatches floats that are
+        whole numbers (`Number.isInteger(v) === true`) to the integer
+        encoder (`encodeInt`) regardless of declared type. JavaScript has
+        no separate float type, so `0.0` and `0` produce identical CBOR
+        bytes there. To match byte-for-byte, mirror that policy here:
+        a Python `float` whose `.is_integer()` is True AND fits in the
+        signed-int range encodes as an int. A `float` like `120.5` keeps
+        the float64 encoding.
+
+    Without this dispatch parity, `gpu_seconds=0.0` etc. would produce
+    9-byte float64 encodings on Python and 1-byte uint encodings on TS,
+    making the canonical body bytes (and thus content_hash) diverge.
+    """
+    if isinstance(v, bool):
+        raise TypeError(f"_encode_value: bool not allowed in compute_metering_v1: {v}")
+    if isinstance(v, str):
+        return _encode_text(v)
+    if isinstance(v, int):
+        return _encode_int(v)
+    if isinstance(v, float):
+        # Match `Number.isInteger(v)` from TS: True iff finite and the value
+        # equals its integer truncation. JS `Number.isInteger` rejects NaN
+        # / Infinity by definition; we already gate those in encode_float64
+        # so a stray non-finite value still raises.
+        if v != v or v in (float("inf"), float("-inf")):
+            raise TypeError(f"_encode_value: not finite: {v}")
+        if v.is_integer():
+            ivalue = int(v)
+            # JavaScript's safe-int range is the cap — match.
+            if -(2**53 - 1) <= ivalue <= (2**53 - 1):
+                return _encode_int(ivalue)
+        return _encode_float64(v)
+    raise TypeError(f"_encode_value: unsupported type {type(v).__name__}")
+
+
+def _encode_map(entries: List[Tuple[str, Any]]) -> bytes:
+    """Canonical map encoder. Keys encoded first, then sorted by encoded-key
+    byte sequence (RFC 8949 §4.2.1). For our short ASCII keys this is
+    equivalent to lexicographic string sort."""
+    encoded_pairs: List[Tuple[bytes, bytes]] = []
+    for k, v in entries:
+        kb = _encode_text(k)
+        vb = _encode_value(v)
+        encoded_pairs.append((kb, vb))
+    encoded_pairs.sort(key=lambda kv: kv[0])
+    head = _encode_uint(5, len(encoded_pairs))
+    return head + b"".join(kb + vb for kb, vb in encoded_pairs)
+
+
+def canonical_body(record: Dict[str, Any]) -> bytes:
+    """Encode the canonical body bytes for a `compute_metering_v1` record.
+
+    `record` MUST include every CANONICAL_FIELDS key (NOT `worker_signature`)
+    with the right type — int for time/byte counters, float for *_seconds /
+    *_hours, str for ids and hex pubkey. Float types are normalized to ensure
+    the wire form is stable (Python int 12 vs float 12.0 produce different
+    CBOR bytes; the gateway treats `cpu_seconds` etc. as float).
+
+    Returns the raw canonical CBOR bytes — sha256 of this is `content_hash`,
+    and sr25519-sign over this gives `worker_signature`.
+    """
+    missing = [k for k in CANONICAL_FIELDS if k not in record]
+    if missing:
+        raise ValueError(f"canonical_body missing required fields: {missing}")
+    if "worker_signature" in record:
+        raise ValueError(
+            "canonical_body must NOT include worker_signature; signature is "
+            "computed over the body sans signature, then attached to the "
+            "wire envelope separately"
+        )
+    # Field-type normalization. The TS validator distinguishes integer fields
+    # (`period_start`, `period_end`, `net_bytes_in/out`) from floats. Match.
+    int_fields = ("period_start", "period_end", "net_bytes_in", "net_bytes_out")
+    float_fields = (
+        "cpu_seconds",
+        "ram_gb_hours",
+        "disk_gb_hours",
+        "gpu_seconds",
+    )
+    str_fields = ("schema_version", "worker_id", "tenant_id", "worker_pubkey")
+    entries: List[Tuple[str, Any]] = []
+    for k in CANONICAL_FIELDS:
+        v = record[k]
+        if k in int_fields:
+            if not isinstance(v, int) or isinstance(v, bool):
+                raise TypeError(f"{k} must be int (got {type(v).__name__})")
+            entries.append((k, v))
+        elif k in float_fields:
+            if isinstance(v, bool) or not isinstance(v, (int, float)):
+                raise TypeError(f"{k} must be a finite number (got {type(v).__name__})")
+            entries.append((k, float(v)))
+        elif k in str_fields:
+            if not isinstance(v, str):
+                raise TypeError(f"{k} must be str (got {type(v).__name__})")
+            entries.append((k, v))
+        else:
+            raise AssertionError(f"unhandled CANONICAL_FIELDS member: {k}")
+    return _encode_map(entries)
+
+
+def canonical_content_hash(record: Dict[str, Any]) -> str:
+    """sha256 hex of the canonical body. Matches gateway's content_hash."""
+    return hashlib.sha256(canonical_body(record)).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Wire-envelope builder — turns a canonical record + signature into the JSON
+# body the route accepts.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SignedEnvelope:
+    """The exact JSON shape POSTed to `/metering/submit`."""
+
+    content_hash: str
+    body_bytes: bytes
+    wire: Dict[str, Any]
+
+
+def build_record(
+    *,
+    worker_id: str,
+    tenant_id: str,
+    period_start: int,
+    period_end: int,
+    cpu_seconds: float,
+    ram_gb_hours: float = 0.0,
+    disk_gb_hours: float = 0.0,
+    net_bytes_in: int = 0,
+    net_bytes_out: int = 0,
+    gpu_seconds: float = 0.0,
+    worker_pubkey_hex: str,
+) -> Dict[str, Any]:
+    """Assemble the dict shape the canonical encoder accepts (no signature).
+
+    All numeric arguments are passed through with no clamping — bound checks
+    (max_cpu_cores * periodSec etc.) live on the gateway. The test suite
+    exercises in-bounds values only.
+    """
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "worker_id": worker_id,
+        "tenant_id": tenant_id,
+        "period_start": period_start,
+        "period_end": period_end,
+        "cpu_seconds": float(cpu_seconds),
+        "ram_gb_hours": float(ram_gb_hours),
+        "disk_gb_hours": float(disk_gb_hours),
+        "net_bytes_in": net_bytes_in,
+        "net_bytes_out": net_bytes_out,
+        "gpu_seconds": float(gpu_seconds),
+        "worker_pubkey": worker_pubkey_hex,
+    }
+
+
+def sign_envelope(kp: WorkerKeypair, record: Dict[str, Any]) -> SignedEnvelope:
+    """Sign `record` with `kp` and return the wire envelope ready to POST.
+
+    Asserts `record["worker_pubkey"] == kp.public_hex` so a typo can't
+    silently produce a record that signs under one key but claims to be
+    from another.
+    """
+    if record["worker_pubkey"] != kp.public_hex:
+        raise ValueError(
+            "record.worker_pubkey does not match keypair public; refusing to "
+            f"sign (record={record['worker_pubkey'][:16]}..., "
+            f"kp={kp.public_hex[:16]}...)"
+        )
+    body_bytes = canonical_body(record)
+    sig = kp.sign_bytes(body_bytes)
+    sig_hex = sig.hex()
+    if len(sig_hex) != 128:
+        # sr25519 signature is always 64 bytes / 128 hex chars; surface a
+        # broken upstream lib loudly rather than letting the gateway return
+        # HEX_FORMAT.
+        raise RuntimeError(
+            f"sr25519 signature unexpected length: {len(sig_hex)} hex chars"
+        )
+    wire = {**record, "worker_signature": sig_hex}
+    return SignedEnvelope(
+        content_hash=hashlib.sha256(body_bytes).hexdigest(),
+        body_bytes=body_bytes,
+        wire=wire,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tenant-id helpers — keep the suite re-runnable on a shared gateway.
+# ---------------------------------------------------------------------------
+
+
+def fresh_tenant_id(prefix: str = "e2e") -> str:
+    """Return a unique tenant_id matching the gateway regex `[a-z0-9-]{4,64}`.
+
+    We use ms-since-epoch + 4 random hex bytes; that's 13 + 8 = 21 chars
+    plus the prefix, well under 64.
+    """
+    suffix = f"{int(time.time() * 1000):x}-{os.urandom(4).hex()}"
+    out = f"{prefix}-{suffix}".lower()
+    # Defensive truncation; the dynamic suffix length is constant so this is
+    # reachable only for a misconfigured prefix.
+    return out[:64]
+
+
+def fresh_worker_id(prefix: str = "w") -> str:
+    """Return a unique worker_id matching `[a-z0-9-]{4,64}`."""
+    suffix = f"{int(time.time() * 1000):x}-{os.urandom(3).hex()}"
+    out = f"{prefix}-{suffix}".lower()
+    return out[:64]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint client — thin wrapper around httpx with ENV-driven config.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GatewayConfig:
+    """Resolved gateway endpoint + auth config for the test session."""
+
+    base_url: str
+    bearer: str
+
+    @property
+    def metering_submit_url(self) -> str:
+        return f"{self.base_url.rstrip('/')}/metering/submit"
+
+    @property
+    def billing_usage_url(self) -> str:
+        return f"{self.base_url.rstrip('/')}/billing/usage"
+
+    @property
+    def auth_header(self) -> Dict[str, str]:
+        # The gateway's bearerAuth middleware accepts either Authorization:
+        # Bearer or x-api-key. We stick to Bearer for parity with what
+        # operator-facing docs (project_sponsored_receipt_pipeline.md) tell
+        # callers to use.
+        return {"authorization": f"Bearer {self.bearer}"}
+
+
+def submit_metering(
+    cfg: GatewayConfig,
+    envelope: SignedEnvelope,
+    *,
+    timeout_s: float = 10.0,
+) -> httpx.Response:
+    """POST a signed envelope to `/metering/submit`. Returns the raw response
+    (caller asserts on status + body)."""
+    headers = {
+        **cfg.auth_header,
+        "content-type": "application/json",
+        "user-agent": "materios-compute-meter-e2e/0.1.0",
+    }
+    with httpx.Client(timeout=timeout_s) as client:
+        return client.post(cfg.metering_submit_url, json=envelope.wire, headers=headers)
+
+
+def fetch_billing_usage(
+    cfg: GatewayConfig,
+    *,
+    tenant_id: str,
+    start_ms: int,
+    end_ms: int,
+    include_records: bool = True,
+    page_size: Optional[int] = None,
+    cursor: Optional[str] = None,
+    timeout_s: float = 10.0,
+) -> httpx.Response:
+    """GET `/billing/usage` with the given filter parameters."""
+    params: Dict[str, Any] = {
+        "tenant_id": tenant_id,
+        "start_ms": str(start_ms),
+        "end_ms": str(end_ms),
+        "include_records": "true" if include_records else "false",
+    }
+    if page_size is not None:
+        params["page_size"] = str(page_size)
+    if cursor is not None:
+        params["cursor"] = cursor
+    with httpx.Client(timeout=timeout_s) as client:
+        return client.get(cfg.billing_usage_url, params=params, headers=cfg.auth_header)
+
+
+# ---------------------------------------------------------------------------
+# Polling helpers — exponential-backoff wait until certified / anchored.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PollResult:
+    """Returned by every `wait_for_*` helper. `final` is the last response
+    body observed (so the test can attach diagnostic context to a failure
+    without re-querying)."""
+
+    success: bool
+    elapsed_s: float
+    polls: int
+    final: Optional[Dict[str, Any]]
+    final_status: Optional[str]
+
+
+def _exp_backoff(attempt: int) -> float:
+    """5s base, 1.4x growth, cap 60s. Long-poll the cert-daemon (~5 min p50)
+    without burning a request per second."""
+    base = 5.0
+    delay = base * (1.4**attempt)
+    return min(delay, 60.0)
+
+
+def wait_for_certification(
+    cfg: GatewayConfig,
+    *,
+    tenant_id: str,
+    content_hash: str,
+    period_start_ms: int,
+    period_end_ms: int,
+    deadline_s: float,
+) -> PollResult:
+    """Poll `/billing/usage` until the record with `content_hash` reports
+    `attestation_status == "certified"`, or the deadline elapses.
+
+    Window is `[period_start_ms - 1, period_end_ms + 1]` so an off-by-one
+    in the gateway's inclusivity model can't make the record invisible.
+    """
+    start = time.monotonic()
+    attempt = 0
+    last_body: Optional[Dict[str, Any]] = None
+    last_status: Optional[str] = None
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= deadline_s:
+            return PollResult(
+                success=False,
+                elapsed_s=elapsed,
+                polls=attempt,
+                final=last_body,
+                final_status=last_status,
+            )
+        attempt += 1
+        try:
+            r = fetch_billing_usage(
+                cfg,
+                tenant_id=tenant_id,
+                start_ms=max(0, period_start_ms - 1),
+                end_ms=period_end_ms + 1,
+                include_records=True,
+                timeout_s=10.0,
+            )
+        except httpx.HTTPError:
+            # Network blip — sleep + retry. Don't count against the deadline
+            # specially; the deadline check above handles it.
+            time.sleep(_exp_backoff(attempt))
+            continue
+        if r.status_code == 200:
+            try:
+                body = r.json()
+            except Exception:
+                body = None
+            if isinstance(body, dict):
+                last_body = body
+                rec = _find_record_by_hash(body, content_hash)
+                if rec is not None:
+                    last_status = rec.get("attestation_status")
+                    if last_status == "certified":
+                        return PollResult(
+                            success=True,
+                            elapsed_s=time.monotonic() - start,
+                            polls=attempt,
+                            final=body,
+                            final_status="certified",
+                        )
+        # Sleep up to a budget that won't blow the deadline.
+        remaining = deadline_s - (time.monotonic() - start)
+        if remaining <= 0:
+            continue
+        time.sleep(min(_exp_backoff(attempt), max(0.5, remaining)))
+
+
+def wait_for_cardano_anchor(
+    cfg: GatewayConfig,
+    *,
+    tenant_id: str,
+    content_hash: str,
+    period_start_ms: int,
+    period_end_ms: int,
+    deadline_s: float,
+) -> PollResult:
+    """Like `wait_for_certification` but waits for `cardano_anchor_tx` to
+    become non-null. Implies certification (gateway gates anchor_tx on it)."""
+    start = time.monotonic()
+    attempt = 0
+    last_body: Optional[Dict[str, Any]] = None
+    last_status: Optional[str] = None
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= deadline_s:
+            return PollResult(
+                success=False,
+                elapsed_s=elapsed,
+                polls=attempt,
+                final=last_body,
+                final_status=last_status,
+            )
+        attempt += 1
+        try:
+            r = fetch_billing_usage(
+                cfg,
+                tenant_id=tenant_id,
+                start_ms=max(0, period_start_ms - 1),
+                end_ms=period_end_ms + 1,
+                include_records=True,
+                timeout_s=15.0,
+            )
+        except httpx.HTTPError:
+            time.sleep(_exp_backoff(attempt))
+            continue
+        if r.status_code == 200:
+            try:
+                body = r.json()
+            except Exception:
+                body = None
+            if isinstance(body, dict):
+                last_body = body
+                rec = _find_record_by_hash(body, content_hash)
+                if rec is not None:
+                    last_status = rec.get("attestation_status")
+                    anchor_tx = rec.get("cardano_anchor_tx")
+                    if anchor_tx:
+                        return PollResult(
+                            success=True,
+                            elapsed_s=time.monotonic() - start,
+                            polls=attempt,
+                            final=body,
+                            final_status="anchored",
+                        )
+        remaining = deadline_s - (time.monotonic() - start)
+        if remaining <= 0:
+            continue
+        time.sleep(min(_exp_backoff(attempt), max(0.5, remaining)))
+
+
+def _find_record_by_hash(
+    body: Dict[str, Any],
+    content_hash: str,
+) -> Optional[Dict[str, Any]]:
+    """Locate a record in a `/billing/usage` response by content_hash.
+
+    Returns None if `records` was omitted (include_records=false) or the
+    hash isn't in the page. Caller is responsible for choosing a window
+    narrow enough to fit on a single page.
+    """
+    records = body.get("records")
+    if not isinstance(records, list):
+        return None
+    for r in records:
+        if isinstance(r, dict) and r.get("content_hash") == content_hash:
+            return r
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight probes — used by the conftest skip logic.
+# ---------------------------------------------------------------------------
+
+
+def gateway_health(cfg: GatewayConfig, *, timeout_s: float = 5.0) -> Optional[int]:
+    """GET `/health`. Returns the HTTP status or None on transport error."""
+    url = f"{cfg.base_url.rstrip('/')}/health"
+    try:
+        with httpx.Client(timeout=timeout_s) as client:
+            r = client.get(url)
+            return r.status_code
+    except httpx.HTTPError:
+        return None
+
+
+def metering_endpoint_status(cfg: GatewayConfig, *, timeout_s: float = 5.0) -> Optional[int]:
+    """POST a known-bad probe to `/metering/submit`. Returns the HTTP status
+    or None. 404 => route not deployed yet (skip suite); 400 / 401 / 422 =>
+    deployed (run suite)."""
+    try:
+        with httpx.Client(timeout=timeout_s) as client:
+            r = client.post(cfg.metering_submit_url, json={"probe": True})
+            return r.status_code
+    except httpx.HTTPError:
+        return None
+
+
+def billing_endpoint_status(cfg: GatewayConfig, *, timeout_s: float = 5.0) -> Optional[int]:
+    """GET `/billing/usage` with no params. 400 => deployed (missing params),
+    404 => not deployed."""
+    try:
+        with httpx.Client(timeout=timeout_s) as client:
+            r = client.get(cfg.billing_usage_url, headers=cfg.auth_header)
+            return r.status_code
+    except httpx.HTTPError:
+        return None

--- a/packages/compute-meter-sdk/tests/conftest.py
+++ b/packages/compute-meter-sdk/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest fixtures for materios-compute-meter tests.
+
+Resets the per-process replay cache between unit tests so reused worker_ids
+across test functions don't leak state. Integration tests get a fresh
+cache too — they use unique time-based worker_ids anyway, but the reset
+is cheap insurance.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_replay_cache() -> None:
+    """Clear the per-process replay cache before every test."""
+    from materios_compute_meter.submit import _reset_replay_cache_for_tests
+
+    _reset_replay_cache_for_tests()
+    yield
+    _reset_replay_cache_for_tests()

--- a/packages/compute-meter-sdk/tests/test_canonical.py
+++ b/packages/compute-meter-sdk/tests/test_canonical.py
@@ -1,0 +1,64 @@
+"""Tests for canonical CBOR serialization.
+
+Canonical CBOR with sorted keys is the on-the-wire form schema #1 expects;
+two records with the same logical content MUST produce identical bytes,
+regardless of dict insertion order.
+"""
+from __future__ import annotations
+
+from materios_compute_meter.canonical import (
+    canonical_cbor,
+    canonical_digest,
+)
+
+
+def test_canonical_cbor_sorts_keys_deterministically() -> None:
+    a = {"b": 2, "a": 1, "c": 3}
+    b = {"a": 1, "c": 3, "b": 2}
+    assert canonical_cbor(a) == canonical_cbor(b)
+
+
+def test_canonical_cbor_handles_nested_dicts() -> None:
+    a = {"outer": {"y": 2, "x": 1}, "first": True}
+    b = {"first": True, "outer": {"x": 1, "y": 2}}
+    assert canonical_cbor(a) == canonical_cbor(b)
+
+
+def test_canonical_cbor_handles_lists_in_order() -> None:
+    # Lists must NOT be sorted — order is meaningful.
+    assert canonical_cbor([3, 1, 2]) != canonical_cbor([1, 2, 3])
+    assert canonical_cbor([3, 1, 2]) == canonical_cbor([3, 1, 2])
+
+
+def test_canonical_cbor_returns_bytes() -> None:
+    out = canonical_cbor({"hello": "world"})
+    assert isinstance(out, bytes)
+    assert len(out) > 0
+
+
+def test_canonical_digest_is_sha256_of_cbor() -> None:
+    import hashlib
+
+    payload = {"a": 1, "b": 2}
+    expected = hashlib.sha256(canonical_cbor(payload)).digest()
+    assert canonical_digest(payload) == expected
+    assert len(canonical_digest(payload)) == 32
+
+
+def test_canonical_digest_is_stable_across_dict_orderings() -> None:
+    a = {"b": 2, "a": 1}
+    b = {"a": 1, "b": 2}
+    assert canonical_digest(a) == canonical_digest(b)
+
+
+def test_canonical_cbor_rejects_unhashable_or_unsupported_types() -> None:
+    """Pure-CBOR primitives only: dict, list, tuple, str, bytes, int, float, bool, None.
+    We forbid arbitrary objects in the canonical form so signers can't drift
+    based on a custom __cbor__ encoder."""
+    import pytest
+
+    class Custom:
+        pass
+
+    with pytest.raises(Exception):
+        canonical_cbor({"key": Custom()})

--- a/packages/compute-meter-sdk/tests/test_e2e_preprod.py
+++ b/packages/compute-meter-sdk/tests/test_e2e_preprod.py
@@ -1,0 +1,640 @@
+"""End-to-end pytest suite for the Compute Portal compute-metering pipeline
+against live Materios preprod (task #113).
+
+This is the FINAL piece that proves the four already-shipped components
+(#109 schema/route, #110 SDK, #111 anchor batching, #112 billing query) tie
+together into a working customer pipeline:
+
+    SDK keypair  →  POST /metering/submit  →  receipt on-chain  →
+    cert-daemon attests  →  Cardano anchor  →  GET /billing/usage shows it.
+
+How to run
+----------
+
+    cd /home/deci/work/materios-compute-meter
+    export MATERIOS_METERING_GATEWAY_URL="https://materios.fluxpointstudios.com/preprod-blobs"
+    export MATERIOS_METERING_API_KEY="matra_<...>"  # Bearer minted via /auth/token
+
+    # Default (≤15 min) — submit→cert→billing-shows path:
+    .venv/bin/pytest tests/test_e2e_preprod.py -m e2e --maxfail=1
+
+    # Full path including Cardano anchor (≤45 min):
+    RUN_CARDANO_ANCHOR_TEST=1 .venv/bin/pytest tests/test_e2e_preprod.py \\
+        -m "e2e or slow" --maxfail=1
+
+If `MATERIOS_METERING_GATEWAY_URL` / `MATERIOS_METERING_API_KEY` are unset, or
+if either route returns 404 (not deployed yet), the suite skips with a clear
+diagnostic. We do NOT mock the gateway or the chain — per
+`feedback_intent_settlement_chain_tdd.md`, that's the whole point.
+
+Timing budgets — match task brief #113
+--------------------------------------
+
+    Submit  →  200 from gateway:                       ≤10 s   (p50 <1 s)
+    Submit  →  cert (cert-daemon attests):             ≤600 s  (p50 ≈300 s)
+    Cert    →  /billing/usage shows certified:         ≤30 s   (p50 <5 s)
+    Cert    →  Cardano anchor lands:                   ≤1800 s (p50 ≈900 s)
+    Anchor  →  /billing/usage shows cardano_anchor_tx: ≤30 s   (p50 <5 s)
+
+The Cardano-anchor path is gated behind `RUN_CARDANO_ANCHOR_TEST=1` so the
+default suite stays under 15 minutes (per task brief).
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict, Optional
+
+import httpx
+import pytest
+
+from materios_compute_meter import WorkerKeypair
+
+from tests._e2e_helpers import (
+    GatewayConfig,
+    SCHEMA_HASH_HEX,
+    billing_endpoint_status,
+    build_record,
+    canonical_content_hash,
+    fetch_billing_usage,
+    fresh_tenant_id,
+    fresh_worker_id,
+    gateway_health,
+    metering_endpoint_status,
+    sign_envelope,
+    submit_metering,
+    wait_for_cardano_anchor,
+    wait_for_certification,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+# ---------------------------------------------------------------------------
+# Timing budgets — kept as constants so failure messages can quote them
+# verbatim and so the slow-path test only differs by one number.
+# ---------------------------------------------------------------------------
+
+SUBMIT_RESPONSE_BUDGET_S = 10.0
+CERT_DEADLINE_S = 600.0  # 10 min — task brief calls for 600s, p50≈300s
+ANCHOR_DEADLINE_S = 1800.0  # 30 min — gated, slow-path only
+
+
+# ---------------------------------------------------------------------------
+# Module-level config + skip gates.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_config() -> GatewayConfig:
+    """Build a GatewayConfig from env. Caller decides what to do if the env
+    is incomplete — `_skip_if_not_ready` consumes this for skip messages."""
+    base = os.environ.get(
+        "MATERIOS_METERING_GATEWAY_URL",
+        "https://materios.fluxpointstudios.com/preprod-blobs",
+    )
+    bearer = os.environ.get("MATERIOS_METERING_API_KEY", "")
+    return GatewayConfig(base_url=base, bearer=bearer)
+
+
+@pytest.fixture(scope="module")
+def cfg() -> GatewayConfig:
+    """Resolved gateway config, shared across all tests in the module."""
+    return _resolve_config()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _skip_if_not_ready(cfg: GatewayConfig) -> None:
+    """Skip the entire module if the live preprod gateway is unreachable
+    OR if the metering / billing routes return 404 (not deployed yet)."""
+    if not cfg.bearer:
+        pytest.skip(
+            "MATERIOS_METERING_API_KEY not set. Mint a Bearer via the gateway "
+            "admin API:\n"
+            "  curl -X POST -H 'X-Admin-Token: <DAEMON_NOTIFY_TOKEN>' \\\n"
+            "    -H 'content-type: application/json' \\\n"
+            "    -d '{\"account\":\"<SS58>\",\"label\":\"e2e-suite\"}' \\\n"
+            f"    {cfg.base_url}/auth/token"
+        )
+
+    health = gateway_health(cfg)
+    if health != 200:
+        pytest.skip(
+            f"Gateway /health did not return 200 (got {health!r}). Verify "
+            f"connectivity to {cfg.base_url}."
+        )
+
+    metering_status = metering_endpoint_status(cfg)
+    billing_status = billing_endpoint_status(cfg)
+
+    # The `/metering/submit` route, when deployed, replies to a `{"probe":true}`
+    # POST with 400 (`MISSING_FIELD: schema_version`), 401 (signature_invalid
+    # if no auth check before validation), or 422 (schema-version mismatch).
+    # Anything OTHER than 404 / None means the route is up. The bearer-auth
+    # middleware on the SUBMIT route is by signature, not Bearer — there is
+    # no 401 from missing Bearer there.
+    if metering_status in (None, 404):
+        pytest.skip(
+            "POST /metering/submit returned "
+            f"{metering_status!r} — task #109's metering route is not yet "
+            "deployed to live preprod. Re-run this suite after the route is "
+            "shipped (orynq-sdk PR series for #109/#112)."
+        )
+
+    # `/billing/usage` requires Bearer; we send Bearer in the probe, so
+    # 400 (missing tenant_id) is the success indicator. 404 == not deployed.
+    if billing_status in (None, 404):
+        pytest.skip(
+            "GET /billing/usage returned "
+            f"{billing_status!r} — task #112's billing route is not yet "
+            "deployed to live preprod. Re-run this suite after the route is "
+            "shipped (orynq-sdk PR series for #109/#112)."
+        )
+
+    if billing_status == 401:
+        pytest.skip(
+            "GET /billing/usage returned 401 — the configured "
+            "MATERIOS_METERING_API_KEY does not pass bearerAuth. Issue a new "
+            "Bearer via /auth/token (admin) and retry."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — happy path: single record, submit → certify → billing-shows.
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_happy_path(cfg: GatewayConfig) -> None:
+    """Exercise every link in the chain for one record:
+
+      1. Generate a fresh sr25519 WorkerKeypair via the SDK.
+      2. Build a `compute_metering_v1` record covering a 60s window
+         ending 10s ago (well inside the gateway's 60s future-skew window).
+      3. Sign the canonical body and POST to /metering/submit.
+      4. Assert 200 + content_hash matches what we computed locally +
+         receipt_id is returned.
+      5. Long-poll /billing/usage until attestation_status == "certified"
+         within CERT_DEADLINE_S. Capture timing.
+      6. Assert the aggregate sums match the single record exactly.
+    """
+    kp = WorkerKeypair.generate()
+    tenant_id = fresh_tenant_id("happy")
+    worker_id = fresh_worker_id("happy")
+
+    period_end_ms = int(time.time() * 1000) - 10_000
+    period_start_ms = period_end_ms - 60_000  # 60s window
+
+    cpu_seconds = 12.5
+    ram_gb_hours = 0.05
+    disk_gb_hours = 0.0
+    net_bytes_in = 4096
+    net_bytes_out = 2048
+    gpu_seconds = 0.0
+
+    record = build_record(
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start=period_start_ms,
+        period_end=period_end_ms,
+        cpu_seconds=cpu_seconds,
+        ram_gb_hours=ram_gb_hours,
+        disk_gb_hours=disk_gb_hours,
+        net_bytes_in=net_bytes_in,
+        net_bytes_out=net_bytes_out,
+        gpu_seconds=gpu_seconds,
+        worker_pubkey_hex=kp.public_hex,
+    )
+    expected_hash = canonical_content_hash(record)
+    envelope = sign_envelope(kp, record)
+    assert envelope.content_hash == expected_hash, (
+        "sign_envelope hash does not match canonical_content_hash; helper "
+        "regression"
+    )
+
+    # ---- POST /metering/submit ----
+    t_submit = time.monotonic()
+    r = submit_metering(cfg, envelope, timeout_s=SUBMIT_RESPONSE_BUDGET_S)
+    submit_elapsed = time.monotonic() - t_submit
+    assert submit_elapsed < SUBMIT_RESPONSE_BUDGET_S, (
+        f"submit took {submit_elapsed:.2f}s, budget {SUBMIT_RESPONSE_BUDGET_S}s"
+    )
+    assert r.status_code == 200, (
+        f"POST /metering/submit returned {r.status_code} "
+        f"body={r.text[:500]!r}"
+    )
+    body = r.json()
+    assert body.get("ok") is True, f"unexpected body: {body!r}"
+    assert body.get("status") in ("accepted", "replay"), body
+    assert body.get("content_hash") == envelope.content_hash, (
+        "Server-reported content_hash does NOT match the canonical hash the "
+        "test computed locally — this is a wire-encoding regression. "
+        f"server={body.get('content_hash')!r} local={envelope.content_hash!r}"
+    )
+    assert body.get("schema_hash") == SCHEMA_HASH_HEX, (
+        f"schema_hash mismatch: server={body.get('schema_hash')!r} "
+        f"expected={SCHEMA_HASH_HEX!r}"
+    )
+    assert body.get("worker_id") == worker_id
+
+    # ---- Wait for cert-daemon ----
+    poll = wait_for_certification(
+        cfg,
+        tenant_id=tenant_id,
+        content_hash=envelope.content_hash,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+        deadline_s=CERT_DEADLINE_S,
+    )
+    assert poll.success, (
+        f"Receipt {envelope.content_hash[:16]}... did not certify within "
+        f"{CERT_DEADLINE_S}s (polled {poll.polls}x, elapsed "
+        f"{poll.elapsed_s:.1f}s, last status={poll.final_status!r}). "
+        f"Last billing body: {poll.final!r}"
+    )
+
+    # ---- Verify aggregate sums match the single record ----
+    final_body = poll.final
+    assert isinstance(final_body, dict)
+    aggregate = final_body.get("aggregate")
+    assert isinstance(aggregate, dict), final_body
+    # The window includes ONLY this record (we used a fresh tenant_id so
+    # nothing else can leak in). Asserting equality, not >=, makes the
+    # contract tight.
+    assert aggregate["record_count"] == 1, aggregate
+    assert aggregate["certified_count"] == 1, aggregate
+    assert aggregate["unique_workers"] == 1, aggregate
+    assert _approx_eq(aggregate["cpu_seconds_total"], cpu_seconds), aggregate
+    assert _approx_eq(aggregate["ram_gb_hours_total"], ram_gb_hours), aggregate
+    assert _approx_eq(aggregate["disk_gb_hours_total"], disk_gb_hours), aggregate
+    assert aggregate["net_bytes_in_total"] == net_bytes_in, aggregate
+    assert aggregate["net_bytes_out_total"] == net_bytes_out, aggregate
+    assert _approx_eq(aggregate["gpu_seconds_total"], gpu_seconds), aggregate
+    assert aggregate["first_record_ms"] == period_start_ms, aggregate
+    assert aggregate["last_record_ms"] == period_start_ms, aggregate
+
+    # The audit_trail block is required by #112's contract.
+    audit = final_body.get("audit_trail")
+    assert isinstance(audit, dict), final_body
+    assert audit.get("schema_hash") == SCHEMA_HASH_HEX
+
+    # Verify the per-record fields (the assertion target the brief calls out).
+    records = final_body.get("records") or []
+    matching = [r for r in records if r.get("content_hash") == envelope.content_hash]
+    assert len(matching) == 1, (
+        f"Expected exactly 1 record with content_hash={envelope.content_hash[:16]}..., "
+        f"got {len(matching)}: {records!r}"
+    )
+    rec = matching[0]
+    assert rec["worker_id"] == worker_id
+    assert rec["period_start_ms"] == period_start_ms
+    assert rec["period_end_ms"] == period_end_ms
+    assert rec["attestation_status"] == "certified"
+    # Anchor may or may not have landed by now; both are acceptable in this
+    # default-path test. The slow test below exercises the anchor leg.
+    anchor_tx = rec.get("cardano_anchor_tx")
+    assert anchor_tx is None or _is_well_formed_tx_hash(anchor_tx), rec
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — burst of 5 records, all certify, aggregate sum is correct.
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_burst_5_records(cfg: GatewayConfig) -> None:
+    """Submit 5 records under the same tenant_id (different workers,
+    contiguous time windows). Wait for all to certify. Verify aggregate
+    sums match elementwise.
+
+    Workers are independent keypairs so the gateway's per-worker monotonic
+    `period_start` check doesn't reject any of them, but the same tenant
+    binds the records into one billing window.
+    """
+    n = 5
+    tenant_id = fresh_tenant_id("burst5")
+
+    base_end_ms = int(time.time() * 1000) - 10_000
+    window_ms = 60_000
+
+    submitted: list[Dict[str, Any]] = []
+    for i in range(n):
+        kp = WorkerKeypair.generate()
+        worker_id = fresh_worker_id(f"b{i}")
+        period_end = base_end_ms - i * 1000  # stagger 1s so first_/last_record_ms vary
+        period_start = period_end - window_ms
+
+        cpu = 1.0 + i  # 1,2,3,4,5 — sum=15, easy to eyeball
+        ram = 0.10 * (i + 1)
+        net_in = 1000 * (i + 1)
+        net_out = 500 * (i + 1)
+
+        record = build_record(
+            worker_id=worker_id,
+            tenant_id=tenant_id,
+            period_start=period_start,
+            period_end=period_end,
+            cpu_seconds=cpu,
+            ram_gb_hours=ram,
+            net_bytes_in=net_in,
+            net_bytes_out=net_out,
+            worker_pubkey_hex=kp.public_hex,
+        )
+        envelope = sign_envelope(kp, record)
+        r = submit_metering(cfg, envelope)
+        assert r.status_code == 200, f"record {i}: {r.status_code} {r.text[:300]}"
+        body = r.json()
+        assert body.get("ok") is True
+        submitted.append(
+            {
+                "content_hash": envelope.content_hash,
+                "period_start": period_start,
+                "period_end": period_end,
+                "worker_id": worker_id,
+                "cpu": cpu,
+                "ram": ram,
+                "net_in": net_in,
+                "net_out": net_out,
+            }
+        )
+
+    # ---- Wait for ALL to certify ----
+    earliest = min(s["period_start"] for s in submitted)
+    latest = max(s["period_end"] for s in submitted)
+    submitted_hashes = {s["content_hash"] for s in submitted}
+
+    deadline = time.monotonic() + CERT_DEADLINE_S
+    final_body: Optional[Dict[str, Any]] = None
+    last_certified_count = 0
+    last_records_len = 0
+    while time.monotonic() < deadline:
+        r = fetch_billing_usage(
+            cfg,
+            tenant_id=tenant_id,
+            start_ms=max(0, earliest - 1),
+            end_ms=latest + 1,
+            include_records=True,
+            page_size=100,
+            timeout_s=10.0,
+        )
+        if r.status_code != 200:
+            time.sleep(5.0)
+            continue
+        body = r.json()
+        records = body.get("records") or []
+        last_records_len = len(records)
+        certified = [
+            rec
+            for rec in records
+            if rec.get("content_hash") in submitted_hashes
+            and rec.get("attestation_status") == "certified"
+        ]
+        last_certified_count = len(certified)
+        if last_certified_count == n:
+            final_body = body
+            break
+        time.sleep(10.0)
+
+    if final_body is None:
+        pytest.fail(
+            f"Only {last_certified_count}/{n} burst records certified within "
+            f"{CERT_DEADLINE_S}s (last response had {last_records_len} records "
+            f"in window)"
+        )
+
+    # ---- Aggregate must equal the elementwise sum ----
+    aggregate = final_body["aggregate"]
+    assert aggregate["record_count"] == n
+    assert aggregate["certified_count"] == n
+    assert aggregate["unique_workers"] == n
+    assert _approx_eq(aggregate["cpu_seconds_total"], sum(s["cpu"] for s in submitted))
+    assert _approx_eq(aggregate["ram_gb_hours_total"], sum(s["ram"] for s in submitted))
+    assert aggregate["net_bytes_in_total"] == sum(s["net_in"] for s in submitted)
+    assert aggregate["net_bytes_out_total"] == sum(s["net_out"] for s in submitted)
+    assert aggregate["first_record_ms"] == min(s["period_start"] for s in submitted)
+    assert aggregate["last_record_ms"] == max(s["period_start"] for s in submitted)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — bad signature is rejected with HTTP 401.
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_signature_rejected(cfg: GatewayConfig) -> None:
+    """The gateway MUST reject a record whose signature does not verify
+    against the declared `worker_pubkey`. Per #109's
+    `compute_metering_v1.ts`, the status for `SIGNATURE_INVALID` is 401.
+
+    We achieve this by signing with one keypair but advertising another
+    pubkey. The canonical body is the one the SECOND key would have
+    produced, so the signature simply won't verify.
+    """
+    real_kp = WorkerKeypair.generate()
+    decoy_kp = WorkerKeypair.generate()
+    assert real_kp.public_hex != decoy_kp.public_hex
+
+    tenant_id = fresh_tenant_id("badsig")
+    worker_id = fresh_worker_id("badsig")
+    period_end = int(time.time() * 1000) - 10_000
+    period_start = period_end - 60_000
+
+    record = build_record(
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start=period_start,
+        period_end=period_end,
+        cpu_seconds=1.0,
+        worker_pubkey_hex=decoy_kp.public_hex,  # claim decoy
+    )
+    # Sign with real_kp (NOT decoy_kp) — but we manually patch the envelope
+    # so that worker_pubkey says decoy and signature is from real. Bypass
+    # sign_envelope's public/private match check.
+    from tests._e2e_helpers import canonical_body
+
+    body_bytes = canonical_body(record)
+    sig_hex = real_kp.sign_bytes(body_bytes).hex()
+    wire = {**record, "worker_signature": sig_hex}
+
+    headers = {
+        **cfg.auth_header,
+        "content-type": "application/json",
+    }
+    with httpx.Client(timeout=10.0) as client:
+        r = client.post(cfg.metering_submit_url, json=wire, headers=headers)
+    assert r.status_code == 401, (
+        f"Expected 401 SIGNATURE_INVALID, got {r.status_code}. "
+        f"body={r.text[:500]!r}"
+    )
+    body = r.json()
+    assert body.get("ok") is False, body
+    # Per `compute_metering_v1.ts` the error code is `SIGNATURE_INVALID`.
+    assert body.get("code") == "SIGNATURE_INVALID", body
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — replay protection: identical record submitted twice → second is
+# treated as a replay (200 with status="replay") and the in-flight
+# notification is NOT re-fired.
+#
+# NOTE on the spec: the gateway's metering route returns 200 + status="replay"
+# on an exact-bytes retry (idempotency). It returns 409 MONOTONIC_VIOLATION
+# only when a DIFFERENT record from the SAME worker_id has period_start
+# BELOW the previously-seen value. The brief's "second is 409" wording
+# describes the latter; we test BOTH paths so the contract is fully covered.
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_replay_rejected(cfg: GatewayConfig) -> None:
+    """Two scenarios:
+
+      a) Exact-bytes retry → 200 with status="replay" (idempotent shortcut).
+      b) New record with period_start BELOW the earlier one → 409
+         MONOTONIC_VIOLATION.
+    """
+    kp = WorkerKeypair.generate()
+    tenant_id = fresh_tenant_id("replay")
+    worker_id = fresh_worker_id("replay")
+    period_end = int(time.time() * 1000) - 10_000
+    period_start = period_end - 60_000
+
+    record = build_record(
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start=period_start,
+        period_end=period_end,
+        cpu_seconds=2.0,
+        worker_pubkey_hex=kp.public_hex,
+    )
+    envelope = sign_envelope(kp, record)
+
+    # First submission — must be 200/accepted.
+    r1 = submit_metering(cfg, envelope)
+    assert r1.status_code == 200, f"first submit: {r1.status_code} {r1.text[:300]}"
+    body1 = r1.json()
+    assert body1.get("status") == "accepted", body1
+
+    # (a) Exact-bytes retry — replay shortcut.
+    r2 = submit_metering(cfg, envelope)
+    assert r2.status_code == 200, f"replay: {r2.status_code} {r2.text[:300]}"
+    body2 = r2.json()
+    assert body2.get("status") == "replay", body2
+    assert body2.get("content_hash") == envelope.content_hash, body2
+    assert body2.get("worker_id") == worker_id
+
+    # (b) New record from the SAME worker_id with period_start BELOW the
+    # earlier one — gateway returns 409 MONOTONIC_VIOLATION.
+    earlier_record = build_record(
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start=period_start - 10_000,
+        period_end=period_end - 10_000,
+        cpu_seconds=2.5,  # different so the envelope hash differs
+        worker_pubkey_hex=kp.public_hex,
+    )
+    earlier_envelope = sign_envelope(kp, earlier_record)
+    r3 = submit_metering(cfg, earlier_envelope)
+    assert r3.status_code == 409, (
+        f"Expected 409 MONOTONIC_VIOLATION, got {r3.status_code}. "
+        f"body={r3.text[:500]!r}"
+    )
+    body3 = r3.json()
+    assert body3.get("ok") is False
+    assert body3.get("code") == "MONOTONIC_VIOLATION", body3
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Cardano anchor lands. Slow path; gated on env var.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    os.environ.get("RUN_CARDANO_ANCHOR_TEST") != "1",
+    reason="Slow path (≤30 min); set RUN_CARDANO_ANCHOR_TEST=1 to enable.",
+)
+def test_e2e_cardano_anchor_landing(cfg: GatewayConfig) -> None:
+    """End-to-end including Cardano anchor.
+
+    Submits a single record, waits for cert (CERT_DEADLINE_S), then waits for
+    the Cardano anchor tx to populate the record's `cardano_anchor_tx` field
+    (ANCHOR_DEADLINE_S). p50 ≈ 15 min.
+    """
+    kp = WorkerKeypair.generate()
+    tenant_id = fresh_tenant_id("anchor")
+    worker_id = fresh_worker_id("anchor")
+    period_end = int(time.time() * 1000) - 10_000
+    period_start = period_end - 60_000
+
+    record = build_record(
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start=period_start,
+        period_end=period_end,
+        cpu_seconds=3.5,
+        worker_pubkey_hex=kp.public_hex,
+    )
+    envelope = sign_envelope(kp, record)
+    r = submit_metering(cfg, envelope)
+    assert r.status_code == 200, f"submit: {r.status_code} {r.text[:300]}"
+
+    cert_poll = wait_for_certification(
+        cfg,
+        tenant_id=tenant_id,
+        content_hash=envelope.content_hash,
+        period_start_ms=period_start,
+        period_end_ms=period_end,
+        deadline_s=CERT_DEADLINE_S,
+    )
+    assert cert_poll.success, (
+        f"cert phase failed in {cert_poll.elapsed_s:.1f}s "
+        f"(polls={cert_poll.polls}, status={cert_poll.final_status!r})"
+    )
+
+    anchor_poll = wait_for_cardano_anchor(
+        cfg,
+        tenant_id=tenant_id,
+        content_hash=envelope.content_hash,
+        period_start_ms=period_start,
+        period_end_ms=period_end,
+        deadline_s=ANCHOR_DEADLINE_S,
+    )
+    assert anchor_poll.success, (
+        f"anchor phase failed in {anchor_poll.elapsed_s:.1f}s "
+        f"(polls={anchor_poll.polls}, last status={anchor_poll.final_status!r}). "
+        f"Last billing body: {anchor_poll.final!r}"
+    )
+
+    final_body = anchor_poll.final
+    assert isinstance(final_body, dict)
+    aggregate = final_body["aggregate"]
+    assert aggregate["anchored_count"] >= 1, aggregate
+
+    records = final_body.get("records") or []
+    matching = [r for r in records if r.get("content_hash") == envelope.content_hash]
+    assert len(matching) == 1, records
+    rec = matching[0]
+    assert rec["attestation_status"] == "certified"
+    assert _is_well_formed_tx_hash(rec["cardano_anchor_tx"]), rec
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _approx_eq(a: float, b: float, rel: float = 1e-9, absol: float = 1e-9) -> bool:
+    """Float comparison tolerant to single-precision drift introduced by the
+    gateway's CBOR round-trip (always 8-byte float64 — but Node's JSON.stringify
+    emits decimal-shortest, so 0.05 may serialize as 0.05 then re-parse as
+    the nearest double which is 0.05000000000000000277..., identical to the
+    Python double we sent). Tolerance is comfortably below the smallest
+    `cpu_seconds`-class metric we use (0.05)."""
+    return abs(a - b) <= max(rel * max(abs(a), abs(b)), absol)
+
+
+def _is_well_formed_tx_hash(s: Any) -> bool:
+    """Loose tx-hash check: 32-byte hex, optional `0x` prefix. Cardano tx ids
+    are 64 lowercase hex chars; the billing route normalizes to `0x`-prefixed
+    so we accept either."""
+    if not isinstance(s, str):
+        return False
+    if s.startswith("0x"):
+        s = s[2:]
+    return len(s) == 64 and all(c in "0123456789abcdef" for c in s.lower())

--- a/packages/compute-meter-sdk/tests/test_keypair.py
+++ b/packages/compute-meter-sdk/tests/test_keypair.py
@@ -1,0 +1,188 @@
+"""Tests for WorkerKeypair generation, persistence, and signing."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from materios_compute_meter.exceptions import (
+    InvalidKeyfileError,
+    InvalidSeedError,
+)
+from materios_compute_meter.keypair import WorkerKeypair
+
+
+def test_generate_returns_fresh_keypair() -> None:
+    a = WorkerKeypair.generate()
+    b = WorkerKeypair.generate()
+    assert a.public_hex != b.public_hex
+    assert a.ss58_address != b.ss58_address
+
+
+def test_generate_keypair_has_32_byte_pubkey_and_64_byte_privkey() -> None:
+    kp = WorkerKeypair.generate()
+    assert len(bytes.fromhex(kp.public_hex)) == 32
+    assert len(bytes.fromhex(kp.secret_hex)) == 64
+    assert kp.ss58_address.startswith("5")  # Materios prefix-42 SS58
+
+
+def test_from_seed_hex_is_deterministic() -> None:
+    seed = "0x" + "11" * 32
+    a = WorkerKeypair.from_seed_hex(seed)
+    b = WorkerKeypair.from_seed_hex(seed)
+    assert a.public_hex == b.public_hex
+    assert a.ss58_address == b.ss58_address
+
+
+def test_from_seed_hex_accepts_unprefixed() -> None:
+    seed = "22" * 32
+    kp = WorkerKeypair.from_seed_hex(seed)
+    assert kp is not None
+    assert len(bytes.fromhex(kp.public_hex)) == 32
+
+
+def test_from_seed_hex_rejects_wrong_length() -> None:
+    with pytest.raises(InvalidSeedError):
+        WorkerKeypair.from_seed_hex("0xab")
+
+
+def test_from_seed_hex_rejects_non_hex() -> None:
+    with pytest.raises(InvalidSeedError):
+        WorkerKeypair.from_seed_hex("zz" * 32)
+
+
+def test_save_writes_json_with_mode_0600(tmp_path: Path) -> None:
+    kp = WorkerKeypair.generate()
+    p = tmp_path / "worker-key.json"
+    kp.save(str(p))
+
+    # File mode is 0600
+    mode = os.stat(p).st_mode
+    assert stat.S_IMODE(mode) == 0o600, f"expected 0600, got {oct(stat.S_IMODE(mode))}"
+
+    blob = json.loads(p.read_text())
+    assert blob["scheme"] == "sr25519"
+    assert blob["public"] == kp.public_hex
+    assert blob["secret"] == kp.secret_hex
+
+
+def test_load_round_trips(tmp_path: Path) -> None:
+    kp = WorkerKeypair.generate()
+    p = tmp_path / "worker-key.json"
+    kp.save(str(p))
+
+    kp2 = WorkerKeypair.load(str(p))
+    assert kp2.public_hex == kp.public_hex
+    assert kp2.secret_hex == kp.secret_hex
+    assert kp2.ss58_address == kp.ss58_address
+
+
+def test_load_rejects_non_sr25519_scheme(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps({"scheme": "ed25519", "secret": "ab", "public": "cd"}))
+    with pytest.raises(InvalidKeyfileError):
+        WorkerKeypair.load(str(p))
+
+
+def test_load_rejects_missing_fields(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps({"scheme": "sr25519"}))
+    with pytest.raises(InvalidKeyfileError):
+        WorkerKeypair.load(str(p))
+
+
+def test_load_rejects_malformed_json(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("not json")
+    with pytest.raises(InvalidKeyfileError):
+        WorkerKeypair.load(str(p))
+
+
+def test_load_rejects_keyfile_with_mismatched_pub_secret(tmp_path: Path) -> None:
+    """If someone has tampered with the keyfile and the stored public doesn't match
+    the public derived from the secret, refuse to load."""
+    kp = WorkerKeypair.generate()
+    p = tmp_path / "tampered.json"
+    p.write_text(
+        json.dumps(
+            {
+                "scheme": "sr25519",
+                "secret": kp.secret_hex,
+                "public": "00" * 32,  # wrong
+            }
+        )
+    )
+    with pytest.raises(InvalidKeyfileError):
+        WorkerKeypair.load(str(p))
+
+
+def test_sign_round_trip_verifies() -> None:
+    """Signing a payload and verifying with the same keypair must succeed."""
+    kp = WorkerKeypair.generate()
+    payload = b"hello materios"
+    sig = kp.sign_bytes(payload)
+    assert len(sig) == 64
+    assert kp.verify_bytes(payload, sig) is True
+
+
+def test_sign_does_not_verify_under_different_key() -> None:
+    a = WorkerKeypair.generate()
+    b = WorkerKeypair.generate()
+    sig = a.sign_bytes(b"data")
+    # b should NOT verify a's signature
+    assert b.verify_bytes(b"data", sig) is False
+
+
+def test_sign_does_not_verify_with_tampered_payload() -> None:
+    kp = WorkerKeypair.generate()
+    sig = kp.sign_bytes(b"original")
+    assert kp.verify_bytes(b"tampered", sig) is False
+
+
+def test_sign_record_returns_signed_envelope() -> None:
+    """Signing a MeteringRecord should return a Signed[MeteringRecord] envelope
+    containing the record + content_hash + signature + signer pubkey."""
+    from materios_compute_meter.record import MeteringRecord
+
+    kp = WorkerKeypair.generate()
+    rec = MeteringRecord(
+        worker_id="worker-001",
+        tenant_id="tenant-acme",
+        period_start_ms=1733400000000,
+        period_end_ms=1733403600000,
+        cpu_seconds=120.5,
+        ram_gb_hours=0.42,
+        disk_gb_hours=0.0,
+        net_bytes_in=1024,
+        net_bytes_out=512,
+        gpu_seconds=0.0,
+    )
+    signed = kp.sign(rec)
+    assert signed.record is rec
+    assert len(signed.content_hash) == 64  # 32 bytes hex
+    assert len(signed.signature) == 128  # 64 bytes hex
+    assert signed.signer_public_hex == kp.public_hex
+    # Verifying the signed envelope should succeed.
+    assert signed.verify() is True
+
+
+def test_signed_envelope_detects_tampered_record() -> None:
+    """If you mutate the record after signing, the content_hash that was signed
+    no longer matches the recomputed canonical digest, so verify() returns False."""
+    from materios_compute_meter.record import MeteringRecord
+
+    kp = WorkerKeypair.generate()
+    rec = MeteringRecord(
+        worker_id="worker-001",
+        tenant_id="tenant-acme",
+        period_start_ms=1,
+        period_end_ms=2,
+        cpu_seconds=1.0,
+    )
+    signed = kp.sign(rec)
+    # Mutate the record under the signed envelope's nose.
+    signed.record.cpu_seconds = 999.0
+    assert signed.verify() is False

--- a/packages/compute-meter-sdk/tests/test_record.py
+++ b/packages/compute-meter-sdk/tests/test_record.py
@@ -1,0 +1,113 @@
+"""Tests for MeteringRecord dataclass and canonicalization."""
+from __future__ import annotations
+
+import pytest
+
+from materios_compute_meter.exceptions import InvalidRecordError
+from materios_compute_meter.record import MeteringRecord
+
+
+def _make() -> MeteringRecord:
+    return MeteringRecord(
+        worker_id="worker-001",
+        tenant_id="tenant-acme",
+        period_start_ms=1733400000000,
+        period_end_ms=1733403600000,
+        cpu_seconds=120.5,
+        ram_gb_hours=0.42,
+        disk_gb_hours=0.0,
+        net_bytes_in=1024,
+        net_bytes_out=512,
+        gpu_seconds=0.0,
+    )
+
+
+def test_record_to_canonical_dict_sorted_keys() -> None:
+    rec = _make()
+    d = rec.to_canonical_dict()
+    keys = list(d.keys())
+    assert keys == sorted(keys), "canonical dict must have sorted keys"
+    assert d["worker_id"] == "worker-001"
+
+
+def test_record_canonical_dict_excludes_signature() -> None:
+    """The dict that gets canonicalized for signing must NOT contain the signature
+    itself — that would be a circular dep."""
+    rec = _make()
+    d = rec.to_canonical_dict()
+    assert "signature" not in d
+    assert "content_hash" not in d
+    assert "signer_public" not in d
+
+
+def test_record_rejects_negative_period() -> None:
+    with pytest.raises(InvalidRecordError):
+        MeteringRecord(
+            worker_id="w",
+            tenant_id="t",
+            period_start_ms=200,
+            period_end_ms=100,  # < start
+            cpu_seconds=1.0,
+        )
+
+
+def test_record_rejects_negative_resource_units() -> None:
+    with pytest.raises(InvalidRecordError):
+        MeteringRecord(
+            worker_id="w",
+            tenant_id="t",
+            period_start_ms=1,
+            period_end_ms=2,
+            cpu_seconds=-1.0,
+        )
+
+    with pytest.raises(InvalidRecordError):
+        MeteringRecord(
+            worker_id="w",
+            tenant_id="t",
+            period_start_ms=1,
+            period_end_ms=2,
+            cpu_seconds=0.0,
+            net_bytes_in=-1,
+        )
+
+
+def test_record_rejects_empty_worker_or_tenant() -> None:
+    with pytest.raises(InvalidRecordError):
+        MeteringRecord(
+            worker_id="",
+            tenant_id="t",
+            period_start_ms=1,
+            period_end_ms=2,
+            cpu_seconds=1.0,
+        )
+
+    with pytest.raises(InvalidRecordError):
+        MeteringRecord(
+            worker_id="w",
+            tenant_id="",
+            period_start_ms=1,
+            period_end_ms=2,
+            cpu_seconds=1.0,
+        )
+
+
+def test_record_optional_fields_default_to_zero() -> None:
+    rec = MeteringRecord(
+        worker_id="w",
+        tenant_id="t",
+        period_start_ms=1,
+        period_end_ms=2,
+        cpu_seconds=1.0,
+    )
+    assert rec.ram_gb_hours == 0.0
+    assert rec.disk_gb_hours == 0.0
+    assert rec.net_bytes_in == 0
+    assert rec.net_bytes_out == 0
+    assert rec.gpu_seconds == 0.0
+
+
+def test_records_with_same_logical_content_have_same_canonical_form() -> None:
+    a = _make()
+    b = _make()
+    assert a.to_canonical_dict() == b.to_canonical_dict()

--- a/packages/compute-meter-sdk/tests/test_submit_integration.py
+++ b/packages/compute-meter-sdk/tests/test_submit_integration.py
@@ -1,0 +1,178 @@
+"""LIVE preprod integration test for the worker compute-meter SDK.
+
+This file hits real endpoints. NO mocks. Per
+`feedback_intent_settlement_chain_tdd.md`, the SDK must work against the
+gateway's real metering route and the chain that anchors it.
+
+If the gateway's `/metering/submit` route is not yet deployed (Agent #1's
+schema landing date), tests skip with a clear message rather than fail.
+
+Manual setup before running:
+  export MATERIOS_METERING_GATEWAY_URL="https://materios.fluxpointstudios.com/preprod-blobs"
+  export MATERIOS_METERING_API_KEY="matra_<your_token>"
+  # Optional — only needed for the on-chain receipt-landing assertion:
+  export MATERIOS_RPC_URL="ws://127.0.0.1:9945"
+
+If MATERIOS_METERING_API_KEY is absent, the integration test skips and
+prints a one-liner pointing at the admin token endpoint
+(POST /admin/keys with X-Admin-Token, see feedback_gateway_registration.md
++ services/blob-gateway/src/api-tokens.ts).
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+import httpx
+import pytest
+
+from materios_compute_meter import MeteringRecord, WorkerKeypair, submit
+
+
+GATEWAY_URL = os.environ.get(
+    "MATERIOS_METERING_GATEWAY_URL",
+    "https://materios.fluxpointstudios.com/preprod-blobs",
+)
+API_KEY = os.environ.get("MATERIOS_METERING_API_KEY", "")
+RPC_URL = os.environ.get("MATERIOS_RPC_URL", "ws://127.0.0.1:9945")
+
+
+def _gateway_endpoint_status() -> Optional[int]:
+    """Probe the metering submit endpoint. Returns the HTTP status code or
+    None on transport error. Used to decide skip-vs-run."""
+    try:
+        with httpx.Client(timeout=5.0) as c:
+            r = c.post(f"{GATEWAY_URL}/metering/submit", json={"probe": True})
+            return r.status_code
+    except httpx.HTTPError:
+        return None
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def gateway_ready() -> None:
+    """Skip the whole module if the gateway endpoint isn't up or returns 404
+    (Agent #1 hasn't shipped yet)."""
+    status = _gateway_endpoint_status()
+    if status is None:
+        pytest.skip(
+            "Gateway is unreachable from this host. Set MATERIOS_METERING_GATEWAY_URL "
+            f"or check connectivity to {GATEWAY_URL}."
+        )
+    if status == 404:
+        pytest.skip(
+            "Gateway /metering/submit is 404 — Agent #1's schema route is not yet "
+            "deployed. Re-run this suite after the metering route lands."
+        )
+
+
+@pytest.fixture(scope="module")
+def have_api_key() -> None:
+    if not API_KEY:
+        pytest.skip(
+            "MATERIOS_METERING_API_KEY not set. Mint a Bearer via the gateway admin: "
+            "POST /admin/keys with X-Admin-Token (see "
+            "services/blob-gateway/src/api-tokens.ts), or use any existing matra_* "
+            "Bearer that's authorised for /metering/submit."
+        )
+
+
+def test_live_submit_round_trip(gateway_ready, have_api_key) -> None:
+    """End-to-end: generate fresh keypair, sign a record, POST to live gateway,
+    verify the response carries the same content_hash we computed locally."""
+    kp = WorkerKeypair.generate()
+
+    # Fresh time-based identifiers so re-runs don't collide on the gateway side.
+    period_start_ms = int(time.time() * 1000)
+    period_end_ms = period_start_ms + 60_000
+
+    rec = MeteringRecord(
+        worker_id=f"worker-it-{period_start_ms}",
+        tenant_id="tenant-it",
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+        cpu_seconds=12.5,
+        ram_gb_hours=0.05,
+        disk_gb_hours=0.0,
+        net_bytes_in=4096,
+        net_bytes_out=2048,
+        gpu_seconds=0.0,
+    )
+
+    signed_local = kp.sign(rec)
+    res = submit(signed_local, gateway_url=GATEWAY_URL, api_key=API_KEY)
+
+    assert "receipt_id" in res
+    assert "content_hash" in res
+    assert res["content_hash"] == signed_local.content_hash, (
+        "Server-reported content_hash MUST match SDK-computed canonical digest"
+    )
+
+
+def test_live_submit_replay_rejected_on_chain(gateway_ready, have_api_key) -> None:
+    """A second submit with the same (worker_id, period_start_ms) should be
+    rejected — locally by the SDK first (replay cache), and if forced, by the
+    gateway's de-dupe at the (signer_pub, period_start_ms) tuple."""
+    from materios_compute_meter.exceptions import ReplayRejectedError
+
+    kp = WorkerKeypair.generate()
+    period_start_ms = int(time.time() * 1000)
+
+    rec = MeteringRecord(
+        worker_id=f"worker-rep-{period_start_ms}",
+        tenant_id="tenant-it",
+        period_start_ms=period_start_ms,
+        period_end_ms=period_start_ms + 1,
+        cpu_seconds=1.0,
+    )
+
+    submit(kp, rec, gateway_url=GATEWAY_URL, api_key=API_KEY)
+
+    with pytest.raises(ReplayRejectedError):
+        submit(kp, rec, gateway_url=GATEWAY_URL, api_key=API_KEY)
+
+
+def test_live_chain_anchors_metering_receipt(gateway_ready, have_api_key) -> None:
+    """After a successful submit, the receipt should land on Materios via
+    the existing receipt pipeline. We poll the gateway's status endpoint
+    for the receipt to reach 'Certified' (matches behaviour of the
+    sponsored-receipt pipeline — see project_sponsored_receipt_pipeline.md)."""
+    kp = WorkerKeypair.generate()
+    period_start_ms = int(time.time() * 1000)
+
+    rec = MeteringRecord(
+        worker_id=f"worker-chain-{period_start_ms}",
+        tenant_id="tenant-it",
+        period_start_ms=period_start_ms,
+        period_end_ms=period_start_ms + 1,
+        cpu_seconds=2.0,
+    )
+
+    res = submit(kp, rec, gateway_url=GATEWAY_URL, api_key=API_KEY)
+    content_hash = res["content_hash"]
+
+    # Poll gateway /blobs/<hash>/status for up to 60s waiting for Certified.
+    deadline = time.time() + 60.0
+    last_status: Optional[dict] = None
+    with httpx.Client(timeout=10.0) as client:
+        while time.time() < deadline:
+            r = client.get(f"{GATEWAY_URL}/blobs/{content_hash}/status")
+            if r.status_code == 200:
+                last_status = r.json()
+                if last_status.get("certified"):
+                    break
+            time.sleep(2.0)
+
+    if last_status is None or not last_status.get("certified"):
+        pytest.skip(
+            f"Receipt {content_hash[:16]}... did not reach Certified within 60s. "
+            "Either the metering pipeline is still in W0 staging, the cert-daemon "
+            "is paused, or the gateway is enqueuing the receipt for a future "
+            "anchor. Last status: " + str(last_status)
+        )
+
+    # If we got here, the chain accepted the SDK-generated digest.
+    assert last_status["certified"] is True

--- a/packages/compute-meter-sdk/tests/test_submit_unit.py
+++ b/packages/compute-meter-sdk/tests/test_submit_unit.py
@@ -1,0 +1,314 @@
+"""Unit tests for the submit() HTTP path — exercises the wire format,
+retry-on-5xx, replay rejection, and error mapping using a mock httpx transport.
+
+NO live network access in this file — see test_submit_integration.py for the
+end-to-end live preprod test.
+"""
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import httpx
+import pytest
+
+from materios_compute_meter.exceptions import (
+    GatewayError,
+    ReplayRejectedError,
+    SubmitError,
+)
+from materios_compute_meter.keypair import WorkerKeypair
+from materios_compute_meter.record import MeteringRecord
+from materios_compute_meter.submit import submit
+
+
+def _make_record(
+    period_start_ms: int = 1,
+    period_end_ms: Optional[int] = None,
+) -> MeteringRecord:
+    return MeteringRecord(
+        worker_id="worker-test",
+        tenant_id="tenant-test",
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms if period_end_ms is not None else period_start_ms + 1,
+        cpu_seconds=10.0,
+    )
+
+
+def _mock_transport(handler):
+    return httpx.MockTransport(handler)
+
+
+def test_submit_happy_path_signs_and_posts(monkeypatch: pytest.MonkeyPatch) -> None:
+    kp = WorkerKeypair.generate()
+    rec = _make_record(period_start_ms=1000)
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["method"] = request.method
+        captured["body"] = json.loads(request.content)
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0xrcpt0001",
+                "content_hash": captured["body"]["content_hash"],
+                "accepted_at": 1733400000,
+            },
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    res = submit(
+        kp,
+        rec,
+        gateway_url="https://example.com/gw",
+        api_key="matra_test",
+        _client=client,
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/metering/submit")
+    assert captured["headers"]["authorization"] == "Bearer matra_test"
+    assert captured["headers"]["content-type"] == "application/json"
+    body = captured["body"]
+    assert body["record"]["worker_id"] == "worker-test"
+    assert body["signer_public"] == kp.public_hex
+    assert body["scheme"] == "sr25519"
+    assert len(body["signature"]) == 128
+    assert len(body["content_hash"]) == 64
+
+    assert res["receipt_id"] == "0xrcpt0001"
+    assert res["content_hash"] == body["content_hash"]
+
+
+def test_submit_signed_envelope_form() -> None:
+    """submit() also accepts a pre-signed envelope (Signed[MeteringRecord])."""
+    kp = WorkerKeypair.generate()
+    rec = _make_record(period_start_ms=2000)
+    signed = kp.sign(rec)
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"receipt_id": "0xrcpt", "content_hash": signed.content_hash, "accepted_at": 0},
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    submit(signed, gateway_url="https://example.com/gw", api_key="k", _client=client)
+    # Signature on the wire equals the one from the pre-signed envelope.
+    assert captured["body"]["signature"] == signed.signature
+    assert captured["body"]["content_hash"] == signed.content_hash
+
+
+def test_submit_retries_once_on_5xx_then_succeeds() -> None:
+    kp = WorkerKeypair.generate()
+    rec = _make_record(period_start_ms=3000)
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return httpx.Response(503, json={"error": "service unavailable"})
+        return httpx.Response(
+            200,
+            json={"receipt_id": "0xok", "content_hash": "0" * 64, "accepted_at": 0},
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    res = submit(
+        kp, rec, gateway_url="https://x/gw", api_key="k",
+        _client=client, _retry_backoff_seconds=0.0,
+    )
+    assert calls["count"] == 2
+    assert res["receipt_id"] == "0xok"
+
+
+def test_submit_retries_once_then_gives_up_on_persistent_5xx() -> None:
+    kp = WorkerKeypair.generate()
+    rec = _make_record(period_start_ms=4000)
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(500, json={"error": "boom"})
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    with pytest.raises(GatewayError) as exc:
+        submit(
+            kp, rec, gateway_url="https://x/gw", api_key="k",
+            _client=client, _retry_backoff_seconds=0.0,
+        )
+    # 1 try + 1 retry = 2 calls
+    assert calls["count"] == 2
+    assert exc.value.status == 500
+
+
+def test_submit_does_not_retry_on_4xx() -> None:
+    kp = WorkerKeypair.generate()
+    rec = _make_record(period_start_ms=5000)
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(401, json={"error": "unauthorized"})
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    with pytest.raises(GatewayError):
+        submit(
+            kp, rec, gateway_url="https://x/gw", api_key="k",
+            _client=client, _retry_backoff_seconds=0.0,
+        )
+    assert calls["count"] == 1
+
+
+def test_submit_replay_rejection_local_cache_blocks_decreasing_period() -> None:
+    """The SDK keeps a per-(worker_id) monotonic period_start_ms cache. Submitting
+    a record with period_start_ms <= last seen for the same worker raises before
+    any HTTP call goes out."""
+    kp = WorkerKeypair.generate()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"receipt_id": "0xa", "content_hash": body["content_hash"], "accepted_at": 0},
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+
+    submit(
+        kp, _make_record(period_start_ms=10_000),
+        gateway_url="https://x/gw", api_key="k", _client=client,
+    )
+
+    # Same worker_id, identical period_start_ms => replay
+    with pytest.raises(ReplayRejectedError):
+        submit(
+            kp, _make_record(period_start_ms=10_000),
+            gateway_url="https://x/gw", api_key="k", _client=client,
+        )
+
+    # Same worker_id, lower period_start_ms => replay
+    with pytest.raises(ReplayRejectedError):
+        submit(
+            kp, _make_record(period_start_ms=5_000),
+            gateway_url="https://x/gw", api_key="k", _client=client,
+        )
+
+    # Same worker_id, higher period_start_ms => OK
+    submit(
+        kp, _make_record(period_start_ms=20_000),
+        gateway_url="https://x/gw", api_key="k", _client=client,
+    )
+
+
+def test_submit_replay_cache_is_per_worker() -> None:
+    """Two distinct worker_ids must NOT collide in the replay cache."""
+    kp = WorkerKeypair.generate()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"receipt_id": "0xa", "content_hash": body["content_hash"], "accepted_at": 0},
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+
+    rec_a = MeteringRecord(
+        worker_id="worker-A", tenant_id="t", period_start_ms=100, period_end_ms=200, cpu_seconds=1.0,
+    )
+    rec_b = MeteringRecord(
+        worker_id="worker-B", tenant_id="t", period_start_ms=100, period_end_ms=200, cpu_seconds=1.0,
+    )
+
+    submit(kp, rec_a, gateway_url="https://x/gw", api_key="k", _client=client)
+    # Same period_start_ms but DIFFERENT worker_id — must succeed.
+    submit(kp, rec_b, gateway_url="https://x/gw", api_key="k", _client=client)
+
+
+def test_submit_raises_on_network_error() -> None:
+    kp = WorkerKeypair.generate()
+    rec = _make_record(period_start_ms=6000)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("DNS fail")
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    with pytest.raises(SubmitError):
+        submit(
+            kp, rec, gateway_url="https://x/gw", api_key="k",
+            _client=client, _retry_backoff_seconds=0.0,
+        )
+
+
+def test_submit_url_strips_trailing_slash() -> None:
+    """Both `https://x/gw` and `https://x/gw/` should produce
+    `https://x/gw/metering/submit`, not `gw//metering/submit`."""
+    kp = WorkerKeypair.generate()
+    rec = _make_record(period_start_ms=7000)
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={"receipt_id": "0x", "content_hash": "0" * 64, "accepted_at": 0},
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    submit(
+        kp, rec, gateway_url="https://x/gw/", api_key="k", _client=client,
+    )
+    assert "//" not in captured["url"].split("https://")[1]
+
+
+def test_submit_rejects_empty_api_key() -> None:
+    kp = WorkerKeypair.generate()
+    rec = _make_record(period_start_ms=8000)
+    with pytest.raises(SubmitError):
+        submit(kp, rec, gateway_url="https://x/gw", api_key="")
+
+
+def test_submit_one_shot_form_signs_inline() -> None:
+    """submit(kp, record, ...) should produce identical wire form to
+    submit(kp.sign(record), ...)."""
+    kp = WorkerKeypair.generate()
+    rec = _make_record(period_start_ms=9000)
+    signed = kp.sign(rec)
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.setdefault("bodies", []).append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={"receipt_id": "0x", "content_hash": signed.content_hash, "accepted_at": 0},
+        )
+
+    # We need to bypass the per-process replay cache for this test — use distinct
+    # worker_ids to do that.
+    rec_b = MeteringRecord(
+        worker_id="worker-other", tenant_id=rec.tenant_id,
+        period_start_ms=rec.period_start_ms, period_end_ms=rec.period_end_ms,
+        cpu_seconds=rec.cpu_seconds,
+    )
+    signed_b = kp.sign(rec_b)
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    submit(signed, gateway_url="https://x/gw", api_key="k", _client=client)
+    submit(kp, rec_b, gateway_url="https://x/gw", api_key="k", _client=client)
+
+    body_signed_form = captured["bodies"][0]
+    body_one_shot = captured["bodies"][1]
+
+    # Signatures will differ because sr25519 is randomized — but the
+    # content_hash MUST match canonical form for the corresponding records.
+    assert body_signed_form["content_hash"] == signed.content_hash
+    assert body_one_shot["content_hash"] == signed_b.content_hash
+    # The envelope shape is the same.
+    assert set(body_signed_form.keys()) == set(body_one_shot.keys())


### PR DESCRIPTION
## Summary

- Moves the standalone `materios-compute-meter` Python SDK into `packages/compute-meter-sdk/` so the Python signer and TypeScript gateway validator (`services/blob-gateway/src/schemas/compute_metering_v1.ts`) share a repo. The wire format is byte-pinned across both languages — colocating means CI catches canonical-CBOR drift at PR-time instead of production.
- 19 files copied verbatim (src + tests + pyproject + README + .gitignore + E2E.md). Single flattened commit; the standalone repo's two-commit history (#109/#110 baseline + #113 E2E suite) is not preserved.
- PyPI package name kept as `materios-compute-meter` so existing `pip install materios-compute-meter` callers keep working. Version bumped `0.1.0` -> `0.1.1` to mark the relocation.
- README and `tests/E2E.md` updated to point at the new monorepo path.

## Verification

- `pytest`: **42 passed, 8 skipped** in 0.50s. Skipped = 5 E2E + 3 SDK-integration that need a live gateway bearer (matches the brief's expectation).
- `pnpm install` from repo root: clean, no errors. `packages/compute-meter-sdk/` has no `package.json`, so pnpm's `packages/*` workspace glob gracefully ignores it (verified by re-running install).
- Root `.gitignore` already covers `.venv/`, `__pycache__/`, `.pytest_cache/`, `*.egg-info/` — no root changes needed.

## Critical invariants preserved

- `tests/_e2e_helpers.py` (canonical CBOR encoder byte-pinned to the TS validator) copied unchanged.
- `compute_metering_v1` schema-hash pre-image string untouched (`sha256("compute_metering_v1") = 0xa297e9faba5e603456e6f47f5b999c4f3904a0cd7433e2a0cfb9e389687ed018`).
- `Number.isInteger(0.0)`-parity logic in `_e2e_helpers.canonical_body()` preserved verbatim.

## Test plan

- [x] Unit suite green from new location (42/42)
- [x] pnpm install clean from repo root
- [x] No PyPI rename (`materios-compute-meter` preserved)
- [x] schema-hash pre-image unchanged (string-grep confirmed via copy)
- [ ] (post-merge) Update bootstrap-validator install path if it references the old repo
- [ ] (post-merge) Tombstone the standalone `/home/deci/work/materios-compute-meter/` checkout

## Trace

Orynq trace: `f9506313-bb7f-426c-af00-81159825f257`

🤖 Generated with [Claude Code](https://claude.com/claude-code)