### PR TITLE
feat(compute-metering-v2): hardware-bounded schema + observer co-sig (Wave 1+2 Team 1)

### DIFF
--- a/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
@@ -84,3 +84,348 @@ def canonical_digest(obj: Any) -> bytes:
     This is the value a worker actually signs.
     """
     return hashlib.sha256(canonical_cbor(obj)).digest()
+
+
+# ===========================================================================
+# compute_metering_v2 — Wave 1+2 hardware-bounded + observer-co-signed schema
+# ===========================================================================
+#
+# v2 adds two trust layers on top of v1: a fleet-operator-signed `hardware_spec`
+# and an optional independent-observer co-signature. See the matching TS file
+# at `services/blob-gateway/src/schemas/compute_metering_v2.ts` for the full
+# schema description and signature pre-image specification.
+#
+# --- Why a hand-rolled encoder for v2 ---
+#
+# `cbor2(canonical=True)` SHORTENS floats: 1.5 becomes a 3-byte float16, not
+# a 9-byte float64. The TS encoder at @polkadot's `DataView.setFloat64` does
+# NOT shorten — it always emits 8 bytes. If we use cbor2 here we'll silently
+# diverge from TS by 6 bytes per float and every cross-language signature
+# verification on a non-trivially-valued field will fail.
+#
+# v2 therefore ships a hand-rolled encoder that mirrors the TS encoder
+# byte-for-byte: definite-length, RFC 8949 §4.2.1 sorted map keys, shortest
+# integer head, ALWAYS 8-byte float64, byte-strings (major 2) for pubkeys
+# and signatures.
+#
+# v1's `canonical_cbor` continues to work for the v1 record shape. v2's
+# helpers are SEPARATE — `canonical_cbor_for_worker_sig` /
+# `canonical_cbor_for_fleet_op_sig` — and never call into the v1 path.
+
+import struct
+from dataclasses import dataclass
+from typing import List, Tuple, Union
+
+# --- v2 schema constants (mirror TS exports) ---
+
+SCHEMA_VERSION_V2 = "compute_metering_v2"
+SCHEMA_HASH_V2_HEX = hashlib.sha256(SCHEMA_VERSION_V2.encode("utf-8")).hexdigest()
+FLEET_OP_TAG_V2 = "fleet_op_attestation_v1"
+
+
+# --- Tagged value types for the canonical encoder ---
+
+
+@dataclass(frozen=True)
+class _CborInt:
+    v: int
+
+
+@dataclass(frozen=True)
+class _CborFloat:
+    v: float
+
+
+@dataclass(frozen=True)
+class _CborText:
+    v: str
+
+
+@dataclass(frozen=True)
+class _CborBytes:
+    v: bytes
+
+
+@dataclass(frozen=True)
+class _CborArray:
+    v: Tuple["_CborValue", ...]
+
+
+@dataclass(frozen=True)
+class _CborMap:
+    """Ordered (key, value) pairs. Encoder sorts by encoded-key bytes."""
+
+    v: Tuple[Tuple[str, "_CborValue"], ...]
+
+
+_CborValue = Union[_CborInt, _CborFloat, _CborText, _CborBytes, _CborArray, _CborMap]
+
+
+def _v2_cbor_int(v: int) -> _CborValue:
+    # Reject bool early: in Python `True is 1` and `int(True) == 1` would
+    # silently coerce a boolean to the integer encoding path. We want a
+    # caller passing `True` for a metric to fail loudly.
+    if isinstance(v, bool) or not isinstance(v, int):
+        raise TypeError(f"_v2_cbor_int: not an int: {type(v).__name__}")
+    return _CborInt(v)
+
+
+def _v2_cbor_float(v: float) -> _CborValue:
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
+        raise TypeError(f"_v2_cbor_float: not a number: {type(v).__name__}")
+    return _CborFloat(float(v))
+
+
+def _v2_cbor_text(v: str) -> _CborValue:
+    return _CborText(v)
+
+
+def _v2_cbor_bytes(v: bytes) -> _CborValue:
+    return _CborBytes(bytes(v))
+
+
+def _v2_cbor_array(v: List[_CborValue]) -> _CborValue:
+    return _CborArray(tuple(v))
+
+
+def _v2_cbor_map(pairs: List[Tuple[str, _CborValue]]) -> _CborValue:
+    return _CborMap(tuple(pairs))
+
+
+# --- low-level primitives ---
+
+
+def _v2_encode_uint(major: int, n: int) -> bytes:
+    """Shortest CBOR head per RFC 8949 §3.1. `n` must be a non-negative int."""
+    if n < 0:
+        raise TypeError(f"_v2_encode_uint: out of range: {n}")
+    if n <= 23:
+        return bytes(((major << 5) | n,))
+    if n <= 0xFF:
+        return bytes(((major << 5) | 24, n))
+    if n <= 0xFFFF:
+        return bytes(((major << 5) | 25,)) + n.to_bytes(2, "big")
+    if n <= 0xFFFFFFFF:
+        return bytes(((major << 5) | 26,)) + n.to_bytes(4, "big")
+    if n > (1 << 64) - 1:
+        raise TypeError(f"_v2_encode_uint: exceeds 64-bit unsigned: {n}")
+    return bytes(((major << 5) | 27,)) + n.to_bytes(8, "big")
+
+
+def _v2_encode_int(n: int) -> bytes:
+    if not isinstance(n, int) or isinstance(n, bool):
+        # `bool` is a subclass of `int` in Python — exclude it explicitly so a
+        # caller can't accidentally encode `True` as the integer 1.
+        raise TypeError(f"_v2_encode_int: not an int: {type(n).__name__}")
+    if n >= 0:
+        return _v2_encode_uint(0, n)
+    return _v2_encode_uint(1, -1 - n)
+
+
+def _v2_encode_float64(n: float) -> bytes:
+    """Always 8-byte float64 (major 7, additional 27, 8-byte BE).
+
+    NEVER shortens to f32/f16 — cross-language byte-equality with the TS
+    encoder requires this. NaN/Infinity rejected up front.
+    """
+    if not isinstance(n, (int, float)) or isinstance(n, bool):
+        raise TypeError(f"_v2_encode_float64: not a number: {type(n).__name__}")
+    f = float(n)
+    if f != f:  # NaN
+        raise TypeError("_v2_encode_float64: NaN not permitted")
+    if f in (float("inf"), float("-inf")):
+        raise TypeError("_v2_encode_float64: Infinity not permitted")
+    return bytes(((7 << 5) | 27,)) + struct.pack(">d", f)
+
+
+def _v2_encode_text(s: str) -> bytes:
+    b = s.encode("utf-8")
+    return _v2_encode_uint(3, len(b)) + b
+
+
+def _v2_encode_bytes(b: bytes) -> bytes:
+    return _v2_encode_uint(2, len(b)) + b
+
+
+def _v2_encode_cbor(val: _CborValue) -> bytes:
+    """Encode a tagged CBOR value to canonical bytes."""
+    if isinstance(val, _CborInt):
+        return _v2_encode_int(val.v)
+    if isinstance(val, _CborFloat):
+        return _v2_encode_float64(val.v)
+    if isinstance(val, _CborText):
+        return _v2_encode_text(val.v)
+    if isinstance(val, _CborBytes):
+        return _v2_encode_bytes(val.v)
+    if isinstance(val, _CborArray):
+        head = _v2_encode_uint(4, len(val.v))
+        return head + b"".join(_v2_encode_cbor(item) for item in val.v)
+    if isinstance(val, _CborMap):
+        # Encode keys + values, then sort by encoded-key bytes per RFC 8949
+        # §4.2.1. All-ASCII keys make this equivalent to a string lex sort,
+        # but we sort on the actual encoded bytes for correctness.
+        pairs = [(_v2_encode_text(k), _v2_encode_cbor(v)) for k, v in val.v]
+        pairs.sort(key=lambda kv: kv[0])
+        head = _v2_encode_uint(5, len(pairs))
+        return head + b"".join(k + v for k, v in pairs)
+    raise TypeError(
+        f"_v2_encode_cbor: unsupported tagged value type {type(val).__name__}"
+    )
+
+
+# --- pre-image builders (mirror TS canonicalCborForFleetOpSig / forWorkerSig) ---
+
+
+def _v2_metrics_to_cbor(metrics: dict) -> _CborValue:
+    """Build the metrics sub-map as canonical CBOR.
+
+    Each field's CBOR type is fixed by the schema, NOT by the runtime Python
+    type. This mirrors the TS encoder, which dodges
+    `Number.isInteger(0.0) === true` by tagging types up front. We do the
+    equivalent here by always routing the float-typed fields through
+    `_v2_cbor_float` and the int-typed fields through `_v2_cbor_int`.
+    """
+    return _v2_cbor_map(
+        [
+            ("cpu_seconds", _v2_cbor_float(metrics["cpu_seconds"])),
+            ("disk_gb_hours", _v2_cbor_float(metrics["disk_gb_hours"])),
+            ("gpu_seconds", _v2_cbor_float(metrics["gpu_seconds"])),
+            ("net_bytes_in", _v2_cbor_int(metrics["net_bytes_in"])),
+            ("net_bytes_out", _v2_cbor_int(metrics["net_bytes_out"])),
+            ("ram_gb_hours", _v2_cbor_float(metrics["ram_gb_hours"])),
+        ]
+    )
+
+
+def _v2_hex_to_bytes(hex_str: str) -> bytes:
+    """Decode a 0x-prefix-less lowercase hex string to raw bytes."""
+    if not isinstance(hex_str, str):
+        raise TypeError(f"hex must be str, got {type(hex_str).__name__}")
+    return bytes.fromhex(hex_str)
+
+
+def _v2_hardware_spec_no_sig_to_cbor(spec: dict) -> _CborValue:
+    """`hardware_spec` map MINUS `fleet_operator_signature`.
+
+    Pubkey is encoded as raw bytes (32) — the TS schema docs spec the
+    pre-image as bytes, not hex.
+    """
+    return _v2_cbor_map(
+        [
+            ("cpu_cores", _v2_cbor_int(spec["cpu_cores"])),
+            (
+                "fleet_operator_pubkey",
+                _v2_cbor_bytes(_v2_hex_to_bytes(spec["fleet_operator_pubkey"])),
+            ),
+            ("gpu_count", _v2_cbor_int(spec["gpu_count"])),
+            ("gpu_type", _v2_cbor_text(spec["gpu_type"])),
+            ("issued_ms", _v2_cbor_int(spec["issued_ms"])),
+            ("ram_gb", _v2_cbor_int(spec["ram_gb"])),
+        ]
+    )
+
+
+def _v2_hardware_spec_full_to_cbor(spec: dict) -> _CborValue:
+    """Full `hardware_spec` including the fleet-op signature (bytes-64)."""
+    return _v2_cbor_map(
+        [
+            ("cpu_cores", _v2_cbor_int(spec["cpu_cores"])),
+            (
+                "fleet_operator_pubkey",
+                _v2_cbor_bytes(_v2_hex_to_bytes(spec["fleet_operator_pubkey"])),
+            ),
+            (
+                "fleet_operator_signature",
+                _v2_cbor_bytes(_v2_hex_to_bytes(spec["fleet_operator_signature"])),
+            ),
+            ("gpu_count", _v2_cbor_int(spec["gpu_count"])),
+            ("gpu_type", _v2_cbor_text(spec["gpu_type"])),
+            ("issued_ms", _v2_cbor_int(spec["issued_ms"])),
+            ("ram_gb", _v2_cbor_int(spec["ram_gb"])),
+        ]
+    )
+
+
+def canonical_cbor_for_fleet_op_sig(record: dict) -> bytes:
+    """Build canonical CBOR bytes for the fleet-op-attestation pre-image.
+
+        [ "fleet_op_attestation_v1", worker_id, hardware_spec_no_sig, issued_ms ]
+
+    Mirrors the TS `canonicalCborForFleetOpSig`. Output bytes are guaranteed
+    byte-identical across the two languages.
+
+    Args:
+        record: A dict with at least `worker_id` (str) and `hardware_spec`
+            (dict containing `cpu_cores`, `ram_gb`, `gpu_type`, `gpu_count`,
+            `fleet_operator_pubkey` (hex64), `fleet_operator_signature`
+            (hex128 — IGNORED for this pre-image), `issued_ms`).
+
+    Returns:
+        Canonical CBOR-encoded bytes, deterministic per RFC 8949 §4.2.1.
+    """
+    if "worker_id" not in record:
+        raise KeyError("canonical_cbor_for_fleet_op_sig: missing 'worker_id'")
+    if "hardware_spec" not in record:
+        raise KeyError("canonical_cbor_for_fleet_op_sig: missing 'hardware_spec'")
+    spec = record["hardware_spec"]
+    return _v2_encode_cbor(
+        _v2_cbor_array(
+            [
+                _v2_cbor_text(FLEET_OP_TAG_V2),
+                _v2_cbor_text(record["worker_id"]),
+                _v2_hardware_spec_no_sig_to_cbor(spec),
+                _v2_cbor_int(spec["issued_ms"]),
+            ]
+        )
+    )
+
+
+def canonical_cbor_for_worker_sig(record: dict) -> bytes:
+    """Build canonical CBOR bytes for the worker-signature pre-image.
+
+        [ "compute_metering_v2", worker_id, tenant_id, period_start_ms,
+          period_end_ms, metrics, hardware_spec_full, worker_pubkey_bytes ]
+
+    The observer signature, when present, signs THESE EXACT BYTES under the
+    observer pubkey — never re-encode for the observer.
+
+    Args:
+        record: A dict with all required v2 fields. `worker_signature` is
+            ignored; `observer` is ignored. `worker_pubkey` is hex64.
+
+    Returns:
+        Canonical CBOR-encoded bytes, deterministic per RFC 8949 §4.2.1.
+    """
+    required = (
+        "worker_id",
+        "tenant_id",
+        "period_start_ms",
+        "period_end_ms",
+        "metrics",
+        "hardware_spec",
+        "worker_pubkey",
+    )
+    for k in required:
+        if k not in record:
+            raise KeyError(f"canonical_cbor_for_worker_sig: missing '{k}'")
+    return _v2_encode_cbor(
+        _v2_cbor_array(
+            [
+                _v2_cbor_text(SCHEMA_VERSION_V2),
+                _v2_cbor_text(record["worker_id"]),
+                _v2_cbor_text(record["tenant_id"]),
+                _v2_cbor_int(record["period_start_ms"]),
+                _v2_cbor_int(record["period_end_ms"]),
+                _v2_metrics_to_cbor(record["metrics"]),
+                _v2_hardware_spec_full_to_cbor(record["hardware_spec"]),
+                _v2_cbor_bytes(_v2_hex_to_bytes(record["worker_pubkey"])),
+            ]
+        )
+    )
+
+
+def canonical_content_hash_v2(record: dict) -> str:
+    """SHA-256 hex of the worker-signature pre-image. The upstream
+    `content_hash` for the v2 sponsored-receipt anchor.
+    """
+    return hashlib.sha256(canonical_cbor_for_worker_sig(record)).hexdigest()

--- a/packages/compute-meter-sdk/tests/_v2_ts_encoder.mts
+++ b/packages/compute-meter-sdk/tests/_v2_ts_encoder.mts
@@ -1,0 +1,66 @@
+/**
+ * Cross-language byte-pinning harness for compute_metering_v2.
+ *
+ * Reads a JSON record from stdin, prints to stdout (one line each):
+ *   FLEET_PRE_HEX <hex>
+ *   WORKER_PRE_HEX <hex>
+ *   CONTENT_HASH <hex>
+ *   SCHEMA_HASH <hex>
+ *
+ * The Python test in `test_v2_cross_lang.py` invokes this script via tsx and
+ * asserts byte-equality against the Python encoder's output. This is the
+ * SOLE existence-reason for Team 1: the worker SDK (Python) and gateway
+ * validator (TS) must produce identical canonical CBOR bytes, otherwise
+ * gateway-validates-but-worker-can't-sign (or vice versa).
+ *
+ * NOT shipped as a runtime artefact — strictly a tests harness invoked by
+ * pytest. No network I/O, no side effects beyond stdout.
+ */
+
+import {
+  canonicalCborForFleetOpSig,
+  canonicalCborForWorkerSig,
+  canonicalContentHash,
+  SCHEMA_HASH_HEX,
+} from "../../../services/blob-gateway/src/schemas/compute_metering_v2.ts";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+async function main(): Promise<void> {
+  const raw = await readStdin();
+  const record = JSON.parse(raw);
+  const fleetPre = canonicalCborForFleetOpSig(record.worker_id, record.hardware_spec);
+  const workerPre = canonicalCborForWorkerSig({
+    schema_version: "compute_metering_v2",
+    worker_id: record.worker_id,
+    tenant_id: record.tenant_id,
+    period_start_ms: record.period_start_ms,
+    period_end_ms: record.period_end_ms,
+    metrics: record.metrics,
+    hardware_spec: record.hardware_spec,
+    worker_pubkey: record.worker_pubkey,
+  });
+  const contentHash = canonicalContentHash({
+    schema_version: "compute_metering_v2",
+    worker_id: record.worker_id,
+    tenant_id: record.tenant_id,
+    period_start_ms: record.period_start_ms,
+    period_end_ms: record.period_end_ms,
+    metrics: record.metrics,
+    hardware_spec: record.hardware_spec,
+    worker_pubkey: record.worker_pubkey,
+  });
+  process.stdout.write(`FLEET_PRE_HEX ${Buffer.from(fleetPre).toString("hex")}\n`);
+  process.stdout.write(`WORKER_PRE_HEX ${Buffer.from(workerPre).toString("hex")}\n`);
+  process.stdout.write(`CONTENT_HASH ${contentHash}\n`);
+  process.stdout.write(`SCHEMA_HASH ${SCHEMA_HASH_HEX}\n`);
+}
+
+main().catch((e) => {
+  process.stderr.write(`harness error: ${e instanceof Error ? e.stack : String(e)}\n`);
+  process.exit(1);
+});

--- a/packages/compute-meter-sdk/tests/test_v2_cross_lang.py
+++ b/packages/compute-meter-sdk/tests/test_v2_cross_lang.py
@@ -1,0 +1,362 @@
+"""Cross-language byte-pinning tests for compute_metering_v2.
+
+Real bytes — not mocks. For each fixed test vector:
+
+  1. Python encoder produces canonical CBOR via `canonical_cbor_for_*`.
+  2. The TS encoder is invoked via `tsx` against the same JSON input.
+  3. Outputs are asserted byte-identical (hex-equal).
+
+If these tests fail, the schema contract has drifted between languages and
+Team 2 (gateway validator) and Team 3 (worker SDK envelope) will produce
+records that don't cross-verify.
+
+Six fixed vectors cover:
+
+  V1: Minimal happy path, no GPU, no observer (zeros + 1.5 cpu_seconds).
+  V2: GPU workload, gpu_count > 0, observer-style record.
+  V3: Edge metrics — `0.0`, `0` int, large u64 net_bytes near 2^53-1.
+  V4: All-floats record (cpu/ram/disk/gpu non-trivial decimals).
+  V5: Worker-id with non-ASCII UTF-8 (CBOR text-string handling).
+  V6: Maximum-size hardware_spec with `custom` gpu_type.
+
+Skips gracefully if `tsx` is not on PATH (e.g. fresh clone without
+node_modules). pytest emits a warning rather than a fail in that case.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+# Test path so we can run pytest without installing the SDK.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from materios_compute_meter.canonical import (  # noqa: E402
+    SCHEMA_HASH_V2_HEX,
+    canonical_cbor_for_fleet_op_sig,
+    canonical_cbor_for_worker_sig,
+    canonical_content_hash_v2,
+)
+
+
+HARNESS_PATH = Path(__file__).resolve().parent / "_v2_ts_encoder.mts"
+WORKTREE_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _have_tsx() -> bool:
+    return shutil.which("tsx") is not None or shutil.which("npx") is not None
+
+
+def _run_ts_harness(record: Dict) -> Dict[str, str]:
+    """Invoke the TS encoder harness with the record as JSON on stdin.
+
+    Returns a dict with keys FLEET_PRE_HEX, WORKER_PRE_HEX, CONTENT_HASH,
+    SCHEMA_HASH (all hex strings).
+    """
+    if not _have_tsx():
+        pytest.skip("tsx/npx not available — install node deps to run cross-lang tests")
+    cmd: List[str]
+    if shutil.which("tsx") is not None:
+        cmd = ["tsx", str(HARNESS_PATH)]
+    else:
+        cmd = ["npx", "--no-install", "tsx", str(HARNESS_PATH)]
+
+    proc = subprocess.run(
+        cmd,
+        input=json.dumps(record),
+        capture_output=True,
+        text=True,
+        cwd=str(WORKTREE_ROOT),
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"TS harness failed (exit {proc.returncode}):\n"
+            f"stderr:\n{proc.stderr}\n"
+            f"stdout:\n{proc.stdout}\n"
+        )
+    out: Dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        head, _, rest = line.partition(" ")
+        out[head.strip()] = rest.strip()
+    for required in ("FLEET_PRE_HEX", "WORKER_PRE_HEX", "CONTENT_HASH", "SCHEMA_HASH"):
+        if required not in out:
+            raise AssertionError(
+                f"TS harness output missing {required}:\n{proc.stdout}"
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Fixed test vectors. Each vector is a pure-data dict with no time-of-day
+# dependence — runs deterministically forever.
+# ---------------------------------------------------------------------------
+
+# Reusable signature/pubkey hex blobs (FIXED — not random — so the encoder
+# output is fully deterministic across CI runs).
+PUBKEY_FLEET = "11" * 32
+SIG_FLEET = "22" * 64
+PUBKEY_WORKER = "33" * 32
+PUBKEY_OBSERVER = "44" * 32
+
+VECTOR_V1_MINIMAL = {
+    "schema_version": "compute_metering_v2",
+    "worker_id": "wkr-001",
+    "tenant_id": "tenant-acme",
+    "period_start_ms": 1_735_689_600_000,
+    "period_end_ms": 1_735_689_600_000 + 1_000,
+    "metrics": {
+        "cpu_seconds": 1.5,
+        "ram_gb_hours": 0.0,
+        "disk_gb_hours": 0.0,
+        "net_bytes_in": 0,
+        "net_bytes_out": 0,
+        "gpu_seconds": 0.0,
+    },
+    "hardware_spec": {
+        "cpu_cores": 4,
+        "ram_gb": 16,
+        "gpu_type": "none",
+        "gpu_count": 0,
+        "fleet_operator_pubkey": PUBKEY_FLEET,
+        "fleet_operator_signature": SIG_FLEET,
+        "issued_ms": 1_735_689_600_000,
+    },
+    "worker_pubkey": PUBKEY_WORKER,
+}
+
+VECTOR_V2_GPU = {
+    "schema_version": "compute_metering_v2",
+    "worker_id": "gpu-worker-007",
+    "tenant_id": "tenant-foo",
+    "period_start_ms": 1_735_689_600_000,
+    "period_end_ms": 1_735_689_600_000 + 3_600_000,  # 1 hr
+    "metrics": {
+        "cpu_seconds": 1234.5,
+        "ram_gb_hours": 8.0,
+        "disk_gb_hours": 16.0,
+        "net_bytes_in": 1_048_576,
+        "net_bytes_out": 524_288,
+        "gpu_seconds": 3500.0,
+    },
+    "hardware_spec": {
+        "cpu_cores": 32,
+        "ram_gb": 256,
+        "gpu_type": "nvidia-h100",
+        "gpu_count": 4,
+        "fleet_operator_pubkey": PUBKEY_FLEET,
+        "fleet_operator_signature": SIG_FLEET,
+        "issued_ms": 1_735_689_600_000,
+    },
+    "worker_pubkey": PUBKEY_WORKER,
+}
+
+VECTOR_V3_EDGE_INTS = {
+    "schema_version": "compute_metering_v2",
+    "worker_id": "wkr-edge-ints",
+    "tenant_id": "tenant-edge",
+    "period_start_ms": 1_735_689_600_000,
+    "period_end_ms": 1_735_689_600_000 + 86_400_000,  # exact 24h
+    "metrics": {
+        # `gpu_seconds: 0.0` is the JS Number.isInteger trap — must encode as
+        # float64 (9 bytes), not int (1 byte). This is THE reason the encoder
+        # tags types up front rather than runtime-dispatching.
+        "cpu_seconds": 0.0,
+        "ram_gb_hours": 0.0,
+        "disk_gb_hours": 0.0,
+        "net_bytes_in": 9_007_199_254_740_991,  # JS_SAFE_INT (2^53-1)
+        "net_bytes_out": 0,
+        "gpu_seconds": 0.0,
+    },
+    "hardware_spec": {
+        "cpu_cores": 1,
+        "ram_gb": 1,
+        "gpu_type": "none",
+        "gpu_count": 0,
+        "fleet_operator_pubkey": PUBKEY_FLEET,
+        "fleet_operator_signature": SIG_FLEET,
+        "issued_ms": 1,
+    },
+    "worker_pubkey": PUBKEY_WORKER,
+}
+
+VECTOR_V4_ALL_FLOATS = {
+    "schema_version": "compute_metering_v2",
+    "worker_id": "wkr-floats-001",
+    "tenant_id": "tenant-floats",
+    "period_start_ms": 1_700_000_000_000,
+    "period_end_ms": 1_700_000_000_000 + 60_000,  # 1 min
+    "metrics": {
+        "cpu_seconds": 42.123_456_789,
+        "ram_gb_hours": 0.1,
+        "disk_gb_hours": 0.25,
+        "net_bytes_in": 1_000,
+        "net_bytes_out": 1_001,
+        "gpu_seconds": 7.5,
+    },
+    "hardware_spec": {
+        "cpu_cores": 64,
+        "ram_gb": 128,
+        "gpu_type": "amd-mi300",
+        "gpu_count": 2,
+        "fleet_operator_pubkey": PUBKEY_FLEET,
+        "fleet_operator_signature": SIG_FLEET,
+        "issued_ms": 1_699_999_999_000,
+    },
+    "worker_pubkey": PUBKEY_WORKER,
+}
+
+# Worker_id allows arbitrary UTF-8 except spaces and commas. Pick characters
+# that span 1- 2- and 3-byte UTF-8 encodings to stress the text-encoder head
+# (length is byte-count, NOT character-count, so a small mistake here would
+# silently produce wrong-length CBOR).
+VECTOR_V5_UTF8 = {
+    "schema_version": "compute_metering_v2",
+    "worker_id": "héllo-世界-001",
+    "tenant_id": "tenant-utf",
+    "period_start_ms": 1_735_689_600_000,
+    "period_end_ms": 1_735_689_600_000 + 1_000,
+    "metrics": {
+        "cpu_seconds": 0.5,
+        "ram_gb_hours": 0.0,
+        "disk_gb_hours": 0.0,
+        "net_bytes_in": 0,
+        "net_bytes_out": 0,
+        "gpu_seconds": 0.0,
+    },
+    "hardware_spec": {
+        "cpu_cores": 8,
+        "ram_gb": 32,
+        "gpu_type": "nvidia-a100",
+        "gpu_count": 1,
+        "fleet_operator_pubkey": PUBKEY_FLEET,
+        "fleet_operator_signature": SIG_FLEET,
+        "issued_ms": 1_735_689_600_000,
+    },
+    "worker_pubkey": PUBKEY_WORKER,
+}
+
+VECTOR_V6_MAX_HARDWARE = {
+    "schema_version": "compute_metering_v2",
+    "worker_id": "wkr-max-hw",
+    "tenant_id": "tenant-max",
+    "period_start_ms": 1_735_689_600_000,
+    "period_end_ms": 1_735_689_600_000 + 86_400_000,
+    "metrics": {
+        "cpu_seconds": 1024 * 86400.0,  # exactly cap
+        "ram_gb_hours": 16384 * 24.0,  # exactly cap
+        "disk_gb_hours": 1_000_000.0,
+        "net_bytes_in": 1_000_000_000,
+        "net_bytes_out": 999_999_999,
+        "gpu_seconds": 16 * 86400.0,
+    },
+    "hardware_spec": {
+        "cpu_cores": 1024,
+        "ram_gb": 16384,
+        "gpu_type": "custom",
+        "gpu_count": 16,
+        "fleet_operator_pubkey": PUBKEY_FLEET,
+        "fleet_operator_signature": SIG_FLEET,
+        "issued_ms": 1_735_689_600_000,
+    },
+    "worker_pubkey": PUBKEY_WORKER,
+}
+
+ALL_VECTORS = [
+    ("V1_minimal", VECTOR_V1_MINIMAL),
+    ("V2_gpu", VECTOR_V2_GPU),
+    ("V3_edge_ints", VECTOR_V3_EDGE_INTS),
+    ("V4_all_floats", VECTOR_V4_ALL_FLOATS),
+    ("V5_utf8", VECTOR_V5_UTF8),
+    ("V6_max_hardware", VECTOR_V6_MAX_HARDWARE),
+]
+
+
+@pytest.mark.parametrize("name,vector", ALL_VECTORS, ids=lambda x: x if isinstance(x, str) else "vec")
+def test_cross_lang_fleet_op_pre_image_byte_equal(name: str, vector: Dict) -> None:
+    """Python and TS produce byte-identical fleet-op-attestation pre-images."""
+    py_bytes = canonical_cbor_for_fleet_op_sig(vector)
+    ts_out = _run_ts_harness(vector)
+    assert ts_out["FLEET_PRE_HEX"] == py_bytes.hex(), (
+        f"[{name}] fleet_op pre-image bytes differ between TS and Python"
+    )
+
+
+@pytest.mark.parametrize("name,vector", ALL_VECTORS, ids=lambda x: x if isinstance(x, str) else "vec")
+def test_cross_lang_worker_pre_image_byte_equal(name: str, vector: Dict) -> None:
+    """Python and TS produce byte-identical worker-signature pre-images."""
+    py_bytes = canonical_cbor_for_worker_sig(vector)
+    ts_out = _run_ts_harness(vector)
+    assert ts_out["WORKER_PRE_HEX"] == py_bytes.hex(), (
+        f"[{name}] worker pre-image bytes differ between TS and Python"
+    )
+
+
+@pytest.mark.parametrize("name,vector", ALL_VECTORS, ids=lambda x: x if isinstance(x, str) else "vec")
+def test_cross_lang_content_hash_equal(name: str, vector: Dict) -> None:
+    """Python and TS produce the same content_hash (sha256 of worker pre-image)."""
+    py_hash = canonical_content_hash_v2(vector)
+    ts_out = _run_ts_harness(vector)
+    assert ts_out["CONTENT_HASH"] == py_hash, (
+        f"[{name}] content_hash differs: TS={ts_out['CONTENT_HASH']}, Python={py_hash}"
+    )
+
+
+def test_cross_lang_schema_hash_constant() -> None:
+    """SCHEMA_HASH_V2_HEX is identical TS-side and Python-side."""
+    ts_out = _run_ts_harness(VECTOR_V1_MINIMAL)
+    assert ts_out["SCHEMA_HASH"] == SCHEMA_HASH_V2_HEX
+
+
+def test_python_self_consistency_float_zero_routes_through_float_path() -> None:
+    """`gpu_seconds: 0.0` and `net_bytes_in: 0` produce different bytes.
+
+    `0.0` must encode as 9-byte float64 (head 0xfb + 8 zero bytes), `0` as
+    1 byte (0x00). If both routed through the int path the encoder is
+    silently broken — same JS quirk in Python: `isinstance(0.0, int)` is
+    False, but a careless dispatch could still confuse them. Pin both
+    behaviours.
+    """
+    rec = dict(VECTOR_V3_EDGE_INTS)
+    pre = canonical_cbor_for_worker_sig(rec)
+    # The metrics map order (sorted by encoded key) is:
+    #   cpu_seconds(float) disk_gb_hours(float) gpu_seconds(float)
+    #   net_bytes_in(int)  net_bytes_out(int)   ram_gb_hours(float)
+    # We don't assert positional bytes (the array head + earlier elements
+    # have variable lengths), but we DO assert the encoded form contains
+    # the float64-zero byte sequence (fb 00 00 00 00 00 00 00 00) at least
+    # 4 times (cpu/disk/gpu/ram are all 0.0 in this vector).
+    f64_zero = bytes.fromhex("fb0000000000000000")
+    assert pre.count(f64_zero) >= 4, (
+        f"expected >= 4 float64-zero markers in pre-image, got {pre.count(f64_zero)}"
+    )
+
+
+def test_python_canonical_keys_sort_order() -> None:
+    """metrics map keys appear in the encoded bytes in sorted order.
+
+    Even if the user passes a dict with keys in arbitrary order (Python 3.7+
+    preserves insertion order), the encoded CBOR map MUST list keys in
+    sorted-by-encoded-key-bytes order per RFC 8949 §4.2.1.
+    """
+    a = canonical_cbor_for_worker_sig(VECTOR_V1_MINIMAL)
+
+    # Reorder the input dicts to insertion-shuffle the keys.
+    shuffled = dict(VECTOR_V1_MINIMAL)
+    metrics = dict(VECTOR_V1_MINIMAL["metrics"])
+    # Pull keys out in reverse-alpha order
+    rev_metrics = {k: metrics[k] for k in sorted(metrics.keys(), reverse=True)}
+    shuffled["metrics"] = rev_metrics
+    hw = dict(VECTOR_V1_MINIMAL["hardware_spec"])
+    rev_hw = {k: hw[k] for k in sorted(hw.keys(), reverse=True)}
+    shuffled["hardware_spec"] = rev_hw
+
+    b = canonical_cbor_for_worker_sig(shuffled)
+    assert a == b, "encoder must be stable regardless of input dict iteration order"

--- a/packages/compute-meter-sdk/tests/test_v2_validation.py
+++ b/packages/compute-meter-sdk/tests/test_v2_validation.py
@@ -1,0 +1,372 @@
+"""Python-side validation + signature tests for compute_metering_v2.
+
+Exercises the Python encoders against the SAME spec rules as the TS-side
+test file (`services/blob-gateway/src/schemas/__tests__/compute_metering_v2.test.ts`):
+
+  - The Python encoder produces a deterministic worker pre-image.
+  - Real sr25519 keypairs sign the pre-image and verify against it.
+  - Tampering with the record breaks signature verification.
+  - The pre-image format mirrors the spec (array head, sorted maps, byte
+    pubkeys, etc.).
+
+The Python side does NOT validate structural rules (range / regex / period)
+— that's the gateway's job (TS-side). What it MUST guarantee is that the
+canonical-CBOR pre-image bytes match TS exactly AND that round-trip signing
+works. Those are the cross-language invariants the worker SDK relies on
+to produce a record the gateway will accept.
+
+No mocks for crypto — uses `Keypair.create_from_uri('//URI')` for
+reproducibility.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+from typing import Dict
+
+import pytest
+from substrateinterface import Keypair, KeypairType
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from materios_compute_meter.canonical import (  # noqa: E402
+    SCHEMA_HASH_V2_HEX,
+    SCHEMA_VERSION_V2,
+    canonical_cbor_for_fleet_op_sig,
+    canonical_cbor_for_worker_sig,
+    canonical_content_hash_v2,
+)
+
+
+def _keypair(uri: str) -> Keypair:
+    return Keypair.create_from_uri(uri, crypto_type=KeypairType.SR25519, ss58_format=42)
+
+
+def _build_record(
+    *,
+    worker_uri: str = "//ComputeWorker0",
+    fleet_uri: str = "//FleetOperator0",
+    observer_uri: str | None = None,
+    period_start_ms: int = 1_735_689_600_000,
+    period_end_ms: int = 1_735_689_600_000 + 3_600_000,
+    metrics_overrides: Dict | None = None,
+    hardware_overrides: Dict | None = None,
+    worker_id: str = "worker-001",
+    tenant_id: str = "tenant-acme",
+) -> Dict:
+    """Build a fully-signed valid record and return it as a dict."""
+    fleet = _keypair(fleet_uri)
+    worker = _keypair(worker_uri)
+
+    metrics = {
+        "cpu_seconds": 60.5,
+        "ram_gb_hours": 0.5,
+        "disk_gb_hours": 1.25,
+        "net_bytes_in": 1_048_576,
+        "net_bytes_out": 524_288,
+        "gpu_seconds": 0.0,
+    }
+    if metrics_overrides:
+        metrics.update(metrics_overrides)
+
+    base_spec = {
+        "cpu_cores": 4,
+        "ram_gb": 16,
+        "gpu_type": "none",
+        "gpu_count": 0,
+        "issued_ms": period_start_ms,
+        "fleet_operator_pubkey": fleet.public_key.hex(),
+    }
+    if hardware_overrides:
+        base_spec.update(hardware_overrides)
+
+    # Sign the fleet-op pre-image (which excludes the signature field).
+    pre_for_fleet = canonical_cbor_for_fleet_op_sig(
+        {
+            "worker_id": worker_id,
+            # The function ignores fleet_operator_signature — pass placeholder.
+            "hardware_spec": {**base_spec, "fleet_operator_signature": "00" * 64},
+        }
+    )
+    fleet_sig = fleet.sign(pre_for_fleet)
+    hardware_spec = {**base_spec, "fleet_operator_signature": fleet_sig.hex()}
+
+    record = {
+        "schema_version": SCHEMA_VERSION_V2,
+        "worker_id": worker_id,
+        "tenant_id": tenant_id,
+        "period_start_ms": period_start_ms,
+        "period_end_ms": period_end_ms,
+        "metrics": metrics,
+        "hardware_spec": hardware_spec,
+        "worker_pubkey": worker.public_key.hex(),
+    }
+    pre_for_worker = canonical_cbor_for_worker_sig(record)
+    record["worker_signature"] = worker.sign(pre_for_worker).hex()
+
+    if observer_uri:
+        observer = _keypair(observer_uri)
+        observer_sig = observer.sign(pre_for_worker)
+        record["observer"] = {
+            "observer_pubkey": observer.public_key.hex(),
+            "observer_signature": observer_sig.hex(),
+        }
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Schema constants
+# ---------------------------------------------------------------------------
+
+
+def test_schema_hash_is_sha256_of_version_string() -> None:
+    expected = hashlib.sha256(SCHEMA_VERSION_V2.encode("utf-8")).hexdigest()
+    assert SCHEMA_HASH_V2_HEX == expected
+
+
+def test_schema_hash_v2_differs_from_v1() -> None:
+    v1 = hashlib.sha256(b"compute_metering_v1").hexdigest()
+    assert SCHEMA_HASH_V2_HEX != v1
+
+
+# ---------------------------------------------------------------------------
+# Pre-image structure (rule 8 byte-pinning)
+# ---------------------------------------------------------------------------
+
+
+def test_worker_pre_image_starts_with_array_head_8_elements() -> None:
+    """The worker pre-image is an 8-element CBOR array. Major type 4,
+    8 elements ≤ 23 → first byte = (4 << 5) | 8 = 0x88.
+    """
+    rec = _build_record()
+    pre = canonical_cbor_for_worker_sig(rec)
+    assert pre[0] == 0x88, f"expected 0x88 (array of 8), got {pre[0]:#04x}"
+
+
+def test_fleet_pre_image_starts_with_array_head_4_elements() -> None:
+    """Fleet-op pre-image is a 4-element CBOR array → 0x84."""
+    rec = _build_record()
+    pre = canonical_cbor_for_fleet_op_sig(rec)
+    assert pre[0] == 0x84, f"expected 0x84 (array of 4), got {pre[0]:#04x}"
+
+
+def test_worker_pre_image_contains_schema_version_text() -> None:
+    """The schema version string 'compute_metering_v2' must appear (in
+    UTF-8) right after the array head."""
+    rec = _build_record()
+    pre = canonical_cbor_for_worker_sig(rec)
+    assert b"compute_metering_v2" in pre
+
+
+def test_fleet_pre_image_contains_fleet_op_tag() -> None:
+    rec = _build_record()
+    pre = canonical_cbor_for_fleet_op_sig(rec)
+    assert b"fleet_op_attestation_v1" in pre
+
+
+# ---------------------------------------------------------------------------
+# Round-trip signing (rule 7, 8, 9 — Python side)
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_sig_verifies_against_fleet_pubkey() -> None:
+    rec = _build_record()
+    fleet_pre = canonical_cbor_for_fleet_op_sig(rec)
+    fleet_pk = bytes.fromhex(rec["hardware_spec"]["fleet_operator_pubkey"])
+    fleet_sig = bytes.fromhex(rec["hardware_spec"]["fleet_operator_signature"])
+    verifier = Keypair(public_key=fleet_pk, crypto_type=KeypairType.SR25519, ss58_format=42)
+    assert verifier.verify(fleet_pre, fleet_sig) is True
+
+
+def test_worker_sig_verifies_against_worker_pubkey() -> None:
+    rec = _build_record()
+    worker_pre = canonical_cbor_for_worker_sig(rec)
+    worker_pk = bytes.fromhex(rec["worker_pubkey"])
+    worker_sig = bytes.fromhex(rec["worker_signature"])
+    verifier = Keypair(public_key=worker_pk, crypto_type=KeypairType.SR25519, ss58_format=42)
+    assert verifier.verify(worker_pre, worker_sig) is True
+
+
+def test_observer_sig_verifies_against_observer_pubkey_over_worker_pre_image() -> None:
+    """Observer signs the EXACT SAME bytes as worker. Verifier reconstructs
+    the worker pre-image and runs sr25519::verify under observer_pubkey.
+    """
+    rec = _build_record(observer_uri="//Observer0")
+    worker_pre = canonical_cbor_for_worker_sig(rec)
+    obs_pk = bytes.fromhex(rec["observer"]["observer_pubkey"])
+    obs_sig = bytes.fromhex(rec["observer"]["observer_signature"])
+    verifier = Keypair(public_key=obs_pk, crypto_type=KeypairType.SR25519, ss58_format=42)
+    assert verifier.verify(worker_pre, obs_sig) is True
+
+
+# ---------------------------------------------------------------------------
+# Tampering breaks verify (negative tests)
+# ---------------------------------------------------------------------------
+
+
+def test_tampering_metrics_breaks_worker_sig_verify() -> None:
+    rec = _build_record()
+    rec["metrics"]["cpu_seconds"] += 1
+    new_pre = canonical_cbor_for_worker_sig(rec)
+    worker_pk = bytes.fromhex(rec["worker_pubkey"])
+    worker_sig = bytes.fromhex(rec["worker_signature"])
+    verifier = Keypair(public_key=worker_pk, crypto_type=KeypairType.SR25519, ss58_format=42)
+    assert verifier.verify(new_pre, worker_sig) is False
+
+
+def test_tampering_hardware_spec_breaks_both_sigs() -> None:
+    """Bumping cpu_cores breaks fleet-op sig (different fleet pre-image)
+    AND breaks worker sig (different worker pre-image, since it embeds
+    the full hardware_spec including fleet sig)."""
+    rec = _build_record()
+    fleet_pre_orig = canonical_cbor_for_fleet_op_sig(rec)
+    worker_pre_orig = canonical_cbor_for_worker_sig(rec)
+    fleet_sig = bytes.fromhex(rec["hardware_spec"]["fleet_operator_signature"])
+    worker_sig = bytes.fromhex(rec["worker_signature"])
+    fleet_pk = bytes.fromhex(rec["hardware_spec"]["fleet_operator_pubkey"])
+    worker_pk = bytes.fromhex(rec["worker_pubkey"])
+
+    # Sanity: original sigs verify against original pre-images.
+    fv = Keypair(public_key=fleet_pk, crypto_type=KeypairType.SR25519, ss58_format=42)
+    wv = Keypair(public_key=worker_pk, crypto_type=KeypairType.SR25519, ss58_format=42)
+    assert fv.verify(fleet_pre_orig, fleet_sig) is True
+    assert wv.verify(worker_pre_orig, worker_sig) is True
+
+    # Bump cpu_cores. Both pre-images now differ.
+    rec["hardware_spec"]["cpu_cores"] = 8
+    fleet_pre_new = canonical_cbor_for_fleet_op_sig(rec)
+    worker_pre_new = canonical_cbor_for_worker_sig(rec)
+    assert fleet_pre_new != fleet_pre_orig
+    assert worker_pre_new != worker_pre_orig
+    assert fv.verify(fleet_pre_new, fleet_sig) is False
+    assert wv.verify(worker_pre_new, worker_sig) is False
+
+
+def test_swapping_fleet_pubkey_breaks_fleet_sig_verify() -> None:
+    rec = _build_record()
+    other_fleet = _keypair("//FleetOperator1")
+    rec["hardware_spec"]["fleet_operator_pubkey"] = other_fleet.public_key.hex()
+    # Fleet pre-image now references the new pubkey, but sig was made by
+    # FleetOperator0. Verifying under FleetOperator1's key fails.
+    new_pre = canonical_cbor_for_fleet_op_sig(rec)
+    sig = bytes.fromhex(rec["hardware_spec"]["fleet_operator_signature"])
+    verifier = Keypair(
+        public_key=other_fleet.public_key,
+        crypto_type=KeypairType.SR25519,
+        ss58_format=42,
+    )
+    assert verifier.verify(new_pre, sig) is False
+
+
+def test_observer_signing_wrong_bytes_breaks_observer_verify() -> None:
+    rec = _build_record(observer_uri="//Observer0")
+    # Observer signed bytes(b'wrong') instead of the worker pre-image.
+    observer = _keypair("//Observer0")
+    bogus_sig = observer.sign(b"wrong").hex()
+    rec["observer"]["observer_signature"] = bogus_sig
+
+    worker_pre = canonical_cbor_for_worker_sig(rec)
+    obs_pk = bytes.fromhex(rec["observer"]["observer_pubkey"])
+    verifier = Keypair(public_key=obs_pk, crypto_type=KeypairType.SR25519, ss58_format=42)
+    assert verifier.verify(worker_pre, bytes.fromhex(bogus_sig)) is False
+
+
+# ---------------------------------------------------------------------------
+# Encoder negative path — types, NaN, infinity
+# ---------------------------------------------------------------------------
+
+
+def test_encoder_rejects_nan_in_metrics() -> None:
+    rec = _build_record()
+    rec["metrics"]["cpu_seconds"] = float("nan")
+    with pytest.raises(TypeError, match="NaN"):
+        canonical_cbor_for_worker_sig(rec)
+
+
+def test_encoder_rejects_infinity_in_metrics() -> None:
+    rec = _build_record()
+    rec["metrics"]["cpu_seconds"] = float("inf")
+    with pytest.raises(TypeError, match="Infinity"):
+        canonical_cbor_for_worker_sig(rec)
+
+
+def test_encoder_rejects_bool_where_int_expected() -> None:
+    """`True` is `int` in Python — the encoder must NOT silently encode it
+    as the integer 1. (TS encoder also blocks bool implicitly because
+    typeof True === 'boolean', not 'number'.)"""
+    rec = _build_record()
+    rec["metrics"]["net_bytes_in"] = True  # type: ignore[assignment]
+    with pytest.raises(TypeError):
+        canonical_cbor_for_worker_sig(rec)
+
+
+# ---------------------------------------------------------------------------
+# Float-zero quirk: gpu_seconds=0.0 must encode as float64, not int
+# ---------------------------------------------------------------------------
+
+
+def test_gpu_seconds_zero_float_encodes_as_float64() -> None:
+    """Schema-typed float fields ALWAYS emit float64 even when the runtime
+    value is an integer-valued float. Mirrors the JS quirk
+    `Number.isInteger(0.0) === true`. Verifies via direct byte inspection
+    of the metrics map.
+    """
+    rec = _build_record(metrics_overrides={"gpu_seconds": 0.0})
+    pre = canonical_cbor_for_worker_sig(rec)
+    # The metrics map keys (sorted by encoded-key bytes) are:
+    #   cpu_seconds disk_gb_hours gpu_seconds net_bytes_in net_bytes_out ram_gb_hours
+    # Since cpu_seconds=60.5 is a non-trivial float in the default record,
+    # we expect at least 4 occurrences of the float64-zero pattern (disk,
+    # gpu, ram are 0.0 here in the default record? No — disk=1.25 in default.
+    # Use a fresh all-zero record).
+    rec_zeros = _build_record(
+        metrics_overrides={
+            "cpu_seconds": 0.0,
+            "ram_gb_hours": 0.0,
+            "disk_gb_hours": 0.0,
+            "gpu_seconds": 0.0,
+        }
+    )
+    pre_zeros = canonical_cbor_for_worker_sig(rec_zeros)
+    f64_zero_marker = bytes.fromhex("fb0000000000000000")
+    # 4 floats are exactly 0.0 in this vector (cpu/ram/disk/gpu).
+    assert pre_zeros.count(f64_zero_marker) == 4, (
+        f"expected 4 float64-zero markers, got {pre_zeros.count(f64_zero_marker)}; "
+        f"pre[hex]={pre_zeros.hex()}"
+    )
+    # And `pre` must not silently encode gpu_seconds=0.0 as int (which would
+    # be just a single 0x00 byte and would NOT contain the f64 marker for
+    # that field).
+    assert pre.count(f64_zero_marker) >= 1
+
+
+# ---------------------------------------------------------------------------
+# content_hash matches sha256(worker pre-image)
+# ---------------------------------------------------------------------------
+
+
+def test_content_hash_matches_sha256_of_worker_pre_image() -> None:
+    rec = _build_record()
+    pre = canonical_cbor_for_worker_sig(rec)
+    expected = hashlib.sha256(pre).hexdigest()
+    assert canonical_content_hash_v2(rec) == expected
+
+
+# ---------------------------------------------------------------------------
+# Determinism across input dict iteration order
+# ---------------------------------------------------------------------------
+
+
+def test_worker_pre_image_stable_under_dict_reordering() -> None:
+    rec_a = _build_record()
+    # Reverse-sort metrics + hardware_spec key order on the way in.
+    rec_b = dict(rec_a)
+    rec_b["metrics"] = {
+        k: rec_a["metrics"][k] for k in sorted(rec_a["metrics"].keys(), reverse=True)
+    }
+    rec_b["hardware_spec"] = {
+        k: rec_a["hardware_spec"][k]
+        for k in sorted(rec_a["hardware_spec"].keys(), reverse=True)
+    }
+    assert canonical_cbor_for_worker_sig(rec_a) == canonical_cbor_for_worker_sig(rec_b)

--- a/services/blob-gateway/src/schemas/__tests__/compute_metering_v2.test.ts
+++ b/services/blob-gateway/src/schemas/__tests__/compute_metering_v2.test.ts
@@ -1,0 +1,1030 @@
+/**
+ * Validation tests for `compute_metering_v2`.
+ *
+ * Coverage matrix — every rule from the schema spec, positive + negative:
+ *
+ *   1. period_end_ms - period_start_ms <= 86_400_000 (24h window)
+ *   2. period_end_ms <= now + 60_000 (no future submissions)
+ *   3. All metric values >= 0
+ *   4. cpu_seconds <= cpu_cores × period_seconds × 1.05
+ *   5. ram_gb_hours <= ram_gb × period_hours × 1.05
+ *   6. gpu_seconds = 0 if gpu_type == "none" OR gpu_count == 0
+ *   7. fleet_operator_signature valid under fleet_operator_pubkey
+ *   8. worker_signature valid under worker_pubkey
+ *   9. observer_signature valid under observer_pubkey (over worker pre-image)
+ *
+ * Plus all the structural checks (missing fields, wrong types, hex format,
+ * gpu_type whitelist, monotonic period_start, etc.).
+ *
+ * No mocks — uses real sr25519 keypairs from `//URI` derivation for
+ * reproducibility.
+ */
+import { describe, test, expect, beforeAll } from "vitest";
+import { Keyring } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+import { createHash } from "crypto";
+
+import {
+  validateComputeMeteringV2,
+  canonicalCborForFleetOpSig,
+  canonicalCborForWorkerSig,
+  canonicalContentHash,
+  workerPubkeyToSs58,
+  SCHEMA_VERSION,
+  SCHEMA_HASH_HEX,
+  MAX_PERIOD_MS,
+  FUTURE_SKEW_MS,
+  JITTER_FACTOR,
+  GPU_TYPES,
+  type ComputeMeteringV2,
+  type HardwareSpecV2,
+  type MetricsV2,
+} from "../compute_metering_v2.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let keyring: Keyring;
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+  keyring = new Keyring({ type: "sr25519" });
+});
+
+interface BuildOpts {
+  worker_id?: string;
+  tenant_id?: string;
+  period_start_ms?: number;
+  period_end_ms?: number;
+  metrics?: Partial<MetricsV2>;
+  hardware_spec?: Partial<Omit<HardwareSpecV2, "fleet_operator_signature">>;
+  /** Override the fleet-op signing keypair URI. */
+  fleet_uri?: string;
+  /** Override the worker signing keypair URI. */
+  worker_uri?: string;
+  /** Override the observer signing keypair URI. Set to add observer. */
+  observer_uri?: string;
+  /** When set, replace the fleet-op signature with this hex (corruption tests). */
+  override_fleet_signature?: string;
+  /** When set, replace the worker signature with this hex. */
+  override_worker_signature?: string;
+  /** When set, replace the observer signature with this hex. */
+  override_observer_signature?: string;
+  /** When set, replace the fleet-op pubkey with this hex (mismatch tests). */
+  override_fleet_pubkey?: string;
+  /** When set, replace the worker pubkey. */
+  override_worker_pubkey?: string;
+  /** When set, replace the observer pubkey. */
+  override_observer_pubkey?: string;
+}
+
+const DEFAULT_PERIOD_START = 1_735_689_600_000;
+const DEFAULT_PERIOD_END = DEFAULT_PERIOD_START + 3_600_000; // 1h
+
+function buildSignedV2(opts: BuildOpts = {}): ComputeMeteringV2 {
+  const fleetPair = keyring.addFromUri(opts.fleet_uri ?? "//FleetOperator0");
+  const workerPair = keyring.addFromUri(opts.worker_uri ?? "//ComputeWorker0");
+
+  const period_start_ms = opts.period_start_ms ?? DEFAULT_PERIOD_START;
+  const period_end_ms = opts.period_end_ms ?? DEFAULT_PERIOD_END;
+
+  const baseMetrics: MetricsV2 = {
+    cpu_seconds: 60.5,
+    ram_gb_hours: 0.5,
+    disk_gb_hours: 1.25,
+    net_bytes_in: 1_048_576,
+    net_bytes_out: 524_288,
+    gpu_seconds: 0,
+  };
+  const metrics: MetricsV2 = { ...baseMetrics, ...(opts.metrics ?? {}) };
+
+  // Build the hardware spec WITHOUT signature first.
+  const baseSpec = {
+    cpu_cores: 4,
+    ram_gb: 16,
+    gpu_type: "none" as const,
+    gpu_count: 0,
+    issued_ms: DEFAULT_PERIOD_START,
+  };
+  const partialSpec = {
+    ...baseSpec,
+    ...(opts.hardware_spec ?? {}),
+    fleet_operator_pubkey:
+      opts.override_fleet_pubkey ?? u8aToHex(fleetPair.publicKey, undefined, false),
+  };
+
+  // Sign the hardware_spec_no_sig pre-image.
+  const fleetPreImageSpec: HardwareSpecV2 = {
+    ...partialSpec,
+    fleet_operator_signature: "00".repeat(64), // placeholder — pre-image strips it
+  };
+  const fleetPreImage = canonicalCborForFleetOpSig(opts.worker_id ?? "worker-001", fleetPreImageSpec);
+  const fleetSigBytes = fleetPair.sign(fleetPreImage);
+  const fleet_operator_signature =
+    opts.override_fleet_signature ?? u8aToHex(fleetSigBytes, undefined, false);
+
+  const hardware_spec: HardwareSpecV2 = {
+    ...partialSpec,
+    fleet_operator_signature,
+  };
+
+  // Build the worker pre-image and sign it.
+  const worker_pubkey =
+    opts.override_worker_pubkey ?? u8aToHex(workerPair.publicKey, undefined, false);
+  const workerPreImage = canonicalCborForWorkerSig({
+    schema_version: SCHEMA_VERSION,
+    worker_id: opts.worker_id ?? "worker-001",
+    tenant_id: opts.tenant_id ?? "tenant-acme",
+    period_start_ms,
+    period_end_ms,
+    metrics,
+    hardware_spec,
+    worker_pubkey,
+  });
+  const worker_signature =
+    opts.override_worker_signature ?? u8aToHex(workerPair.sign(workerPreImage), undefined, false);
+
+  const base: ComputeMeteringV2 = {
+    schema_version: SCHEMA_VERSION,
+    worker_id: opts.worker_id ?? "worker-001",
+    tenant_id: opts.tenant_id ?? "tenant-acme",
+    period_start_ms,
+    period_end_ms,
+    metrics,
+    hardware_spec,
+    worker_pubkey,
+    worker_signature,
+  };
+
+  if (opts.observer_uri) {
+    const observerPair = keyring.addFromUri(opts.observer_uri);
+    const observer_pubkey =
+      opts.override_observer_pubkey ?? u8aToHex(observerPair.publicKey, undefined, false);
+    const observer_signature =
+      opts.override_observer_signature ??
+      u8aToHex(observerPair.sign(workerPreImage), undefined, false);
+    return {
+      ...base,
+      observer: { observer_pubkey, observer_signature },
+    };
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Schema constants & determinism
+// ---------------------------------------------------------------------------
+
+describe("v2 schema constants", () => {
+  test("SCHEMA_HASH_HEX is sha256 of 'compute_metering_v2'", () => {
+    const expected = createHash("sha256")
+      .update("compute_metering_v2", "utf-8")
+      .digest("hex");
+    expect(SCHEMA_HASH_HEX).toBe(expected);
+  });
+
+  test("SCHEMA_HASH_HEX differs from v1's hash", () => {
+    const v1Hash = createHash("sha256")
+      .update("compute_metering_v1", "utf-8")
+      .digest("hex");
+    expect(SCHEMA_HASH_HEX).not.toBe(v1Hash);
+  });
+
+  test("GPU_TYPES is the exact whitelist from the spec", () => {
+    expect([...GPU_TYPES]).toEqual([
+      "none",
+      "nvidia-h100",
+      "nvidia-h200",
+      "nvidia-b100",
+      "nvidia-a100",
+      "amd-mi300",
+      "custom",
+    ]);
+  });
+
+  test("JITTER_FACTOR is exactly 1.05 (pinned)", () => {
+    expect(JITTER_FACTOR).toBe(1.05);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Canonical encoder determinism
+// ---------------------------------------------------------------------------
+
+describe("v2 canonical encoder", () => {
+  test("worker pre-image is stable across input dict iteration order", () => {
+    const a = canonicalCborForWorkerSig({
+      schema_version: SCHEMA_VERSION,
+      worker_id: "wkr-001",
+      tenant_id: "tenant-foo",
+      period_start_ms: 1_735_689_600_000,
+      period_end_ms: 1_735_689_600_000 + 1000,
+      metrics: {
+        cpu_seconds: 1.5,
+        ram_gb_hours: 0.0,
+        disk_gb_hours: 0.0,
+        net_bytes_in: 0,
+        net_bytes_out: 0,
+        gpu_seconds: 0.0,
+      },
+      hardware_spec: {
+        cpu_cores: 4,
+        ram_gb: 16,
+        gpu_type: "none",
+        gpu_count: 0,
+        fleet_operator_pubkey: "11".repeat(32),
+        fleet_operator_signature: "22".repeat(64),
+        issued_ms: 1_735_689_600_000,
+      },
+      worker_pubkey: "33".repeat(32),
+    });
+    const b = canonicalCborForWorkerSig({
+      worker_pubkey: "33".repeat(32),
+      hardware_spec: {
+        issued_ms: 1_735_689_600_000,
+        ram_gb: 16,
+        cpu_cores: 4,
+        gpu_count: 0,
+        gpu_type: "none",
+        fleet_operator_signature: "22".repeat(64),
+        fleet_operator_pubkey: "11".repeat(32),
+      },
+      metrics: {
+        gpu_seconds: 0.0,
+        net_bytes_out: 0,
+        ram_gb_hours: 0.0,
+        cpu_seconds: 1.5,
+        disk_gb_hours: 0.0,
+        net_bytes_in: 0,
+      },
+      period_end_ms: 1_735_689_600_000 + 1000,
+      period_start_ms: 1_735_689_600_000,
+      tenant_id: "tenant-foo",
+      worker_id: "wkr-001",
+      schema_version: SCHEMA_VERSION,
+    });
+    expect(u8aToHex(a)).toBe(u8aToHex(b));
+  });
+
+  test("content_hash equals sha256(worker pre-image)", () => {
+    const rec = {
+      schema_version: SCHEMA_VERSION,
+      worker_id: "wkr-001",
+      tenant_id: "tenant-foo",
+      period_start_ms: 1_735_689_600_000,
+      period_end_ms: 1_735_689_600_000 + 1000,
+      metrics: {
+        cpu_seconds: 1.5,
+        ram_gb_hours: 0.0,
+        disk_gb_hours: 0.0,
+        net_bytes_in: 0,
+        net_bytes_out: 0,
+        gpu_seconds: 0.0,
+      },
+      hardware_spec: {
+        cpu_cores: 4,
+        ram_gb: 16,
+        gpu_type: "none" as const,
+        gpu_count: 0,
+        fleet_operator_pubkey: "11".repeat(32),
+        fleet_operator_signature: "22".repeat(64),
+        issued_ms: 1_735_689_600_000,
+      },
+      worker_pubkey: "33".repeat(32),
+    };
+    const pre = canonicalCborForWorkerSig(rec);
+    const expected = createHash("sha256").update(pre).digest("hex");
+    expect(canonicalContentHash(rec)).toBe(expected);
+  });
+
+  test("workerPubkeyToSs58 round-trips through Keyring address", () => {
+    const pair = keyring.addFromUri("//ComputeWorker0");
+    const hex = u8aToHex(pair.publicKey, undefined, false);
+    expect(workerPubkeyToSs58(hex)).toBe(pair.address);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Happy path
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — happy path", () => {
+  test("valid record without observer → ok", () => {
+    const rec = buildSignedV2();
+    const res = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1000 });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.content_hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(res.schema_hash).toBe(SCHEMA_HASH_HEX);
+      expect(res.worker_pre_image).toBeInstanceOf(Uint8Array);
+      expect(res.worker_pre_image.length).toBeGreaterThan(0);
+      expect(res.fleet_op_pre_image).toBeInstanceOf(Uint8Array);
+      expect(res.fleet_op_pre_image.length).toBeGreaterThan(0);
+      expect(res.record.observer).toBeUndefined();
+      expect(
+        createHash("sha256").update(res.worker_pre_image).digest("hex"),
+      ).toBe(res.content_hash);
+    }
+  });
+
+  test("valid record WITH observer → ok and observer present", () => {
+    const rec = buildSignedV2({ observer_uri: "//Observer0" });
+    const res = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1000 });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.record.observer).toBeDefined();
+      expect(res.record.observer?.observer_pubkey).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  test("zero-valued metrics allowed (when gpu_type=none)", () => {
+    const rec = buildSignedV2({
+      metrics: {
+        cpu_seconds: 0,
+        ram_gb_hours: 0,
+        disk_gb_hours: 0,
+        net_bytes_in: 0,
+        net_bytes_out: 0,
+        gpu_seconds: 0,
+      },
+    });
+    const res = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1000 });
+    expect(res.ok).toBe(true);
+  });
+
+  test("observer absent (no key) → no observer in normalized record", () => {
+    const rec = buildSignedV2();
+    expect(rec).not.toHaveProperty("observer");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Missing required fields
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — missing fields", () => {
+  const TOPLEVEL: Array<keyof Omit<ComputeMeteringV2, "observer">> = [
+    "schema_version",
+    "worker_id",
+    "tenant_id",
+    "period_start_ms",
+    "period_end_ms",
+    "metrics",
+    "hardware_spec",
+    "worker_pubkey",
+    "worker_signature",
+  ];
+
+  for (const f of TOPLEVEL) {
+    test(`missing ${f} → MISSING_FIELD with field=${f}`, () => {
+      const rec = buildSignedV2() as Record<string, unknown>;
+      delete rec[f];
+      const res = validateComputeMeteringV2(rec, {
+        now_ms: DEFAULT_PERIOD_END + 1000,
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.code).toBe("MISSING_FIELD");
+        expect(res.field).toBe(f);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. Wrong root type
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — wrong root type", () => {
+  test("null → WRONG_TYPE", () => {
+    const r = validateComputeMeteringV2(null);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_TYPE");
+  });
+
+  test("array → WRONG_TYPE", () => {
+    const r = validateComputeMeteringV2([1, 2]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_TYPE");
+  });
+
+  test("string → WRONG_TYPE", () => {
+    const r = validateComputeMeteringV2("not an object");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_TYPE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Schema version
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — schema_version", () => {
+  test("rejects v1 record", () => {
+    const rec = { ...buildSignedV2(), schema_version: "compute_metering_v1" };
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_SCHEMA_VERSION");
+  });
+
+  test("rejects case mismatch", () => {
+    const rec = { ...buildSignedV2(), schema_version: "Compute_Metering_V2" };
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_SCHEMA_VERSION");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. ID format
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — ID format", () => {
+  test("worker_id with space rejected", () => {
+    const r = validateComputeMeteringV2(buildSignedV2({ worker_id: "wkr 001" }), {
+      now_ms: DEFAULT_PERIOD_END + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("ID_FORMAT");
+      expect(r.field).toBe("worker_id");
+    }
+  });
+
+  test("worker_id with comma rejected", () => {
+    const r = validateComputeMeteringV2(buildSignedV2({ worker_id: "wkr,001" }), {
+      now_ms: DEFAULT_PERIOD_END + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("ID_FORMAT");
+  });
+
+  test("worker_id empty string rejected", () => {
+    const r = validateComputeMeteringV2(buildSignedV2({ worker_id: "" }), {
+      now_ms: DEFAULT_PERIOD_END + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("ID_FORMAT");
+  });
+
+  test("worker_id over 128 chars rejected", () => {
+    const r = validateComputeMeteringV2(
+      buildSignedV2({ worker_id: "a".repeat(129) }),
+      { now_ms: DEFAULT_PERIOD_END + 1 },
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("ID_FORMAT");
+  });
+
+  test("worker_id with underscore + dot accepted (looser than tenant_id)", () => {
+    // worker_id allows anything UTF-8 except spaces and commas — e.g. K8s pod
+    // names with dots, hostnames with underscores.
+    const rec = buildSignedV2({ worker_id: "pod_42.cluster.local" });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(true);
+  });
+
+  test("tenant_id with uppercase rejected", () => {
+    const r = validateComputeMeteringV2(
+      buildSignedV2({ tenant_id: "Tenant-01" }),
+      { now_ms: DEFAULT_PERIOD_END + 1 },
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("ID_FORMAT");
+      expect(r.field).toBe("tenant_id");
+    }
+  });
+
+  test("tenant_id too short (< 4) rejected", () => {
+    const r = validateComputeMeteringV2(buildSignedV2({ tenant_id: "abc" }), {
+      now_ms: DEFAULT_PERIOD_END + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("ID_FORMAT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Period (rule 1, rule 2)
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — period (rules 1, 2)", () => {
+  test("period_end_ms - period_start_ms == 24h boundary accepted", () => {
+    const start = DEFAULT_PERIOD_START;
+    const end = start + MAX_PERIOD_MS;
+    const rec = buildSignedV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      // Keep below cpu cap (4 cores × 86400s × 1.05 = 362,880).
+      metrics: { cpu_seconds: 100, ram_gb_hours: 0, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 0 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: end + 1 });
+    expect(r.ok).toBe(true);
+  });
+
+  test("period_end_ms - period_start_ms > 24h rejected (rule 1)", () => {
+    const start = DEFAULT_PERIOD_START;
+    const end = start + MAX_PERIOD_MS + 1;
+    const rec = buildSignedV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      metrics: { cpu_seconds: 0, ram_gb_hours: 0, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 0 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("PERIOD_INVALID");
+  });
+
+  test("period_end_ms == now + 60s accepted (rule 2 boundary)", () => {
+    const now = 1_700_000_000_000;
+    const end = now + FUTURE_SKEW_MS;
+    const rec = buildSignedV2({
+      period_start_ms: end - 3_600_000,
+      period_end_ms: end,
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: now });
+    expect(r.ok).toBe(true);
+  });
+
+  test("period_end_ms > now + 60s rejected (rule 2)", () => {
+    const now = 1_700_000_000_000;
+    const end = now + FUTURE_SKEW_MS + 1;
+    const rec = buildSignedV2({
+      period_start_ms: end - 3_600_000,
+      period_end_ms: end,
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: now });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("PERIOD_INVALID");
+      expect(r.field).toBe("period_end_ms");
+    }
+  });
+
+  test("period_end_ms <= period_start_ms rejected", () => {
+    const rec = buildSignedV2({
+      period_start_ms: DEFAULT_PERIOD_START,
+      period_end_ms: DEFAULT_PERIOD_START,
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: DEFAULT_PERIOD_START + 1000 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("PERIOD_INVALID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Metric values >= 0 (rule 3)
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — metric values >= 0 (rule 3)", () => {
+  for (const metric of [
+    "cpu_seconds",
+    "ram_gb_hours",
+    "disk_gb_hours",
+    "net_bytes_in",
+    "net_bytes_out",
+    "gpu_seconds",
+  ] as const) {
+    test(`negative ${metric} rejected`, () => {
+      const rec = buildSignedV2();
+      // cast to mutate the metrics map directly
+      (rec.metrics as Record<string, number>)[metric] = -1;
+      const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.code).toBe("NEGATIVE_VALUE");
+        expect(r.field).toBe(`metrics.${metric}`);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 10. cpu_seconds bound (rule 4)
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — cpu_seconds bound (rule 4)", () => {
+  test("cpu_seconds at exactly the 1.05× cap accepted", () => {
+    const start = DEFAULT_PERIOD_START;
+    const end = start + 3_600_000; // 3600s
+    const cores = 4;
+    const cap = cores * 3_600 * JITTER_FACTOR; // 15120 exact
+    const rec = buildSignedV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      hardware_spec: { cpu_cores: cores },
+      metrics: { cpu_seconds: cap, ram_gb_hours: 0, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 0 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: end + 1 });
+    expect(r.ok).toBe(true);
+  });
+
+  test("cpu_seconds just over the 1.05× cap rejected", () => {
+    const start = DEFAULT_PERIOD_START;
+    const end = start + 3_600_000;
+    const cores = 4;
+    const cap = cores * 3_600 * JITTER_FACTOR;
+    const rec = buildSignedV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      hardware_spec: { cpu_cores: cores },
+      metrics: { cpu_seconds: cap + 0.01, ram_gb_hours: 0, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 0 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("BOUND_EXCEEDED");
+      expect(r.field).toBe("metrics.cpu_seconds");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. ram_gb_hours bound (rule 5)
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — ram_gb_hours bound (rule 5)", () => {
+  test("ram_gb_hours at exactly cap accepted", () => {
+    const start = DEFAULT_PERIOD_START;
+    const end = start + 3_600_000; // 1h
+    const ram = 16;
+    const cap = ram * 1.0 * JITTER_FACTOR;
+    const rec = buildSignedV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      hardware_spec: { ram_gb: ram },
+      metrics: { cpu_seconds: 0, ram_gb_hours: cap, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 0 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: end + 1 });
+    expect(r.ok).toBe(true);
+  });
+
+  test("ram_gb_hours just over cap rejected", () => {
+    const start = DEFAULT_PERIOD_START;
+    const end = start + 3_600_000;
+    const ram = 16;
+    const cap = ram * 1.0 * JITTER_FACTOR;
+    const rec = buildSignedV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      hardware_spec: { ram_gb: ram },
+      metrics: { cpu_seconds: 0, ram_gb_hours: cap + 0.001, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 0 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: end + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("BOUND_EXCEEDED");
+      expect(r.field).toBe("metrics.ram_gb_hours");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. gpu_seconds rule (rule 6)
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — gpu_seconds when no GPU (rule 6)", () => {
+  test("gpu_type=none AND gpu_seconds>0 → GPU_COUNT_MISMATCH", () => {
+    const rec = buildSignedV2({
+      hardware_spec: { gpu_type: "none", gpu_count: 0 },
+      metrics: { cpu_seconds: 0, ram_gb_hours: 0, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 1 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("GPU_COUNT_MISMATCH");
+      expect(r.field).toBe("metrics.gpu_seconds");
+    }
+  });
+
+  test("gpu_count=0 (any gpu_type) AND gpu_seconds>0 → GPU_COUNT_MISMATCH", () => {
+    const rec = buildSignedV2({
+      hardware_spec: { gpu_type: "nvidia-h100", gpu_count: 0 },
+      metrics: { cpu_seconds: 0, ram_gb_hours: 0, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 1 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("GPU_COUNT_MISMATCH");
+  });
+
+  test("gpu_type=none AND gpu_seconds=0 → ok", () => {
+    const rec = buildSignedV2({
+      hardware_spec: { gpu_type: "none", gpu_count: 0 },
+      metrics: { cpu_seconds: 0, ram_gb_hours: 0, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 0 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(true);
+  });
+
+  test("gpu_type=h100 AND gpu_count>0 AND gpu_seconds>0 → ok", () => {
+    const rec = buildSignedV2({
+      hardware_spec: { gpu_type: "nvidia-h100", gpu_count: 2 },
+      metrics: { cpu_seconds: 0, ram_gb_hours: 0, disk_gb_hours: 0,
+        net_bytes_in: 0, net_bytes_out: 0, gpu_seconds: 100 },
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. Hardware spec bounds (gpu_type whitelist + numeric ranges)
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — hardware_spec bounds", () => {
+  test("gpu_type not in whitelist rejected", () => {
+    const rec = buildSignedV2();
+    (rec.hardware_spec as Record<string, unknown>).gpu_type = "intel-xe";
+    // Re-sign to keep signature valid for the (corrupt-shape) body, so we
+    // cleanly assert GPU_TYPE_INVALID rather than SIG_INVALID.
+    const r = validateComputeMeteringV2(rec, {
+      now_ms: rec.period_end_ms + 1,
+      verify_signatures: false,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("GPU_TYPE_INVALID");
+      expect(r.field).toBe("hardware_spec.gpu_type");
+    }
+  });
+
+  test("cpu_cores below MIN_CPU_CORES rejected", () => {
+    const rec = buildSignedV2();
+    (rec.hardware_spec as Record<string, unknown>).cpu_cores = 0;
+    const r = validateComputeMeteringV2(rec, {
+      now_ms: rec.period_end_ms + 1,
+      verify_signatures: false,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("HARDWARE_BOUND");
+  });
+
+  test("cpu_cores above MAX_CPU_CORES rejected", () => {
+    const rec = buildSignedV2();
+    (rec.hardware_spec as Record<string, unknown>).cpu_cores = 1025;
+    const r = validateComputeMeteringV2(rec, {
+      now_ms: rec.period_end_ms + 1,
+      verify_signatures: false,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("HARDWARE_BOUND");
+  });
+
+  test("ram_gb above MAX_RAM_GB rejected", () => {
+    const rec = buildSignedV2();
+    (rec.hardware_spec as Record<string, unknown>).ram_gb = 16385;
+    const r = validateComputeMeteringV2(rec, {
+      now_ms: rec.period_end_ms + 1,
+      verify_signatures: false,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("HARDWARE_BOUND");
+  });
+
+  test("gpu_count above MAX_GPU_COUNT rejected", () => {
+    const rec = buildSignedV2();
+    (rec.hardware_spec as Record<string, unknown>).gpu_count = 17;
+    const r = validateComputeMeteringV2(rec, {
+      now_ms: rec.period_end_ms + 1,
+      verify_signatures: false,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("HARDWARE_BOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. Hex format
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — hex format", () => {
+  test("worker_pubkey wrong length rejected", () => {
+    const rec = buildSignedV2({ override_worker_pubkey: "ab".repeat(31) });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("HEX_FORMAT");
+      expect(r.field).toBe("worker_pubkey");
+    }
+  });
+
+  test("worker_pubkey uppercase rejected", () => {
+    const rec = buildSignedV2({ override_worker_pubkey: "AB".repeat(32) });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("HEX_FORMAT");
+  });
+
+  test("fleet_operator_signature wrong length rejected", () => {
+    const rec = buildSignedV2({ override_fleet_signature: "cd".repeat(63) });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("HEX_FORMAT");
+      expect(r.field).toBe("hardware_spec.fleet_operator_signature");
+    }
+  });
+
+  test("observer_pubkey wrong length rejected", () => {
+    const rec = buildSignedV2({
+      observer_uri: "//Observer0",
+      override_observer_pubkey: "ab".repeat(31),
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("HEX_FORMAT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 15. Signature verification (rules 7, 8, 9)
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — fleet_op signature (rule 7)", () => {
+  test("corrupt fleet_op signature → FLEET_OP_SIGNATURE_INVALID", () => {
+    const rec = buildSignedV2({ override_fleet_signature: "00".repeat(64) });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("FLEET_OP_SIGNATURE_INVALID");
+      expect(r.field).toBe("hardware_spec.fleet_operator_signature");
+    }
+  });
+
+  test("fleet_op pubkey swapped (different fleet) → FLEET_OP_SIGNATURE_INVALID", () => {
+    // Sign with FleetOperator0 but claim FleetOperator1's pubkey.
+    const otherFleet = keyring.addFromUri("//FleetOperator1");
+    const rec = buildSignedV2();
+    rec.hardware_spec = {
+      ...rec.hardware_spec,
+      fleet_operator_pubkey: u8aToHex(otherFleet.publicKey, undefined, false),
+    };
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("FLEET_OP_SIGNATURE_INVALID");
+  });
+
+  test("hardware_spec field tampered after fleet sign → FLEET_OP_SIGNATURE_INVALID", () => {
+    const rec = buildSignedV2();
+    // Bump cpu_cores from 4 to 8 — within the legal bound, but breaks the
+    // fleet-op pre-image. Keep the fleet signature unchanged.
+    rec.hardware_spec = { ...rec.hardware_spec, cpu_cores: 8 };
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("FLEET_OP_SIGNATURE_INVALID");
+  });
+});
+
+describe("validateComputeMeteringV2 — worker signature (rule 8)", () => {
+  test("corrupt worker signature → WORKER_SIGNATURE_INVALID", () => {
+    const rec = buildSignedV2({ override_worker_signature: "00".repeat(64) });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("WORKER_SIGNATURE_INVALID");
+      expect(r.field).toBe("worker_signature");
+    }
+  });
+
+  test("metrics tampered after worker sign → WORKER_SIGNATURE_INVALID", () => {
+    const rec = buildSignedV2();
+    rec.metrics = { ...rec.metrics, cpu_seconds: rec.metrics.cpu_seconds + 1 };
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WORKER_SIGNATURE_INVALID");
+  });
+
+  test("worker pubkey swapped → WORKER_SIGNATURE_INVALID", () => {
+    const other = keyring.addFromUri("//ComputeWorker1");
+    const rec = buildSignedV2();
+    rec.worker_pubkey = u8aToHex(other.publicKey, undefined, false);
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WORKER_SIGNATURE_INVALID");
+  });
+});
+
+describe("validateComputeMeteringV2 — observer signature (rule 9)", () => {
+  test("observer signs the WORKER pre-image, not its own", () => {
+    // The worker pair signs the worker pre-image; the observer pair signs
+    // the SAME bytes. Verify the validator accepts this and ALSO rejects
+    // an observer signature over different bytes.
+    const rec = buildSignedV2({ observer_uri: "//Observer0" });
+    const ok = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(ok.ok).toBe(true);
+  });
+
+  test("corrupt observer signature → OBSERVER_SIGNATURE_INVALID", () => {
+    const rec = buildSignedV2({
+      observer_uri: "//Observer0",
+      override_observer_signature: "00".repeat(64),
+    });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("OBSERVER_SIGNATURE_INVALID");
+      expect(r.field).toBe("observer.observer_signature");
+    }
+  });
+
+  test("observer pubkey swapped to wrong observer → OBSERVER_SIGNATURE_INVALID", () => {
+    const rec = buildSignedV2({ observer_uri: "//Observer0" });
+    // Replace observer_pubkey with a different observer's key. The signature
+    // is still over the same bytes but signed by Observer0, so verifying
+    // against Observer1's key fails.
+    const other = keyring.addFromUri("//Observer1");
+    if (rec.observer) {
+      rec.observer = {
+        ...rec.observer,
+        observer_pubkey: u8aToHex(other.publicKey, undefined, false),
+      };
+    }
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("OBSERVER_SIGNATURE_INVALID");
+  });
+
+  test("observer signing OWN bytes (not worker pre-image) → OBSERVER_SIGNATURE_INVALID", () => {
+    // Construct a record where observer signed something else (e.g. an empty
+    // buffer). Must fail.
+    const observerPair = keyring.addFromUri("//Observer0");
+    const wrongSig = u8aToHex(observerPair.sign(new Uint8Array([0xde, 0xad])), undefined, false);
+    const rec = buildSignedV2({ observer_uri: "//Observer0", override_observer_signature: wrongSig });
+    const r = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("OBSERVER_SIGNATURE_INVALID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 16. Monotonic period_start_ms (per worker_id)
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — monotonic period_start_ms", () => {
+  test("period_start_ms < last_period_start_ms rejected", () => {
+    const rec = buildSignedV2();
+    const r = validateComputeMeteringV2(rec, {
+      now_ms: rec.period_end_ms + 1,
+      last_period_start_ms: rec.period_start_ms + 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("MONOTONIC_VIOLATION");
+      expect(r.field).toBe("period_start_ms");
+    }
+  });
+
+  test("period_start_ms == last accepted (non-decreasing)", () => {
+    const rec = buildSignedV2();
+    const r = validateComputeMeteringV2(rec, {
+      now_ms: rec.period_end_ms + 1,
+      last_period_start_ms: rec.period_start_ms,
+    });
+    expect(r.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 17. Replay = same content_hash (validator stateless re: replay)
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — stateless replay determinism", () => {
+  test("same record validates twice with same content_hash", () => {
+    const rec = buildSignedV2();
+    const a = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    const b = validateComputeMeteringV2(rec, { now_ms: rec.period_end_ms + 1 });
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    if (a.ok && b.ok) expect(a.content_hash).toBe(b.content_hash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 18. verify_signatures=false short-circuit
+// ---------------------------------------------------------------------------
+
+describe("validateComputeMeteringV2 — verify_signatures=false", () => {
+  test("structural-only validation skips all sig checks", () => {
+    const rec = buildSignedV2({
+      override_fleet_signature: "11".repeat(64),
+      override_worker_signature: "22".repeat(64),
+    });
+    const r = validateComputeMeteringV2(rec, {
+      now_ms: rec.period_end_ms + 1,
+      verify_signatures: false,
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/services/blob-gateway/src/schemas/compute_metering_v2.ts
+++ b/services/blob-gateway/src/schemas/compute_metering_v2.ts
@@ -1,0 +1,1091 @@
+/**
+ * `compute_metering_v2` — Wave 1+2 hardware-bounded + observer-co-signed schema.
+ *
+ * v1 (still supported in parallel) is worker-signed-only with a flat body. v2
+ * adds two trust layers on top:
+ *
+ *   - `hardware_spec` — the worker's claimed CPU cores / RAM / GPU type, signed
+ *     OFFLINE by the FPS-registered fleet operator. Lets the gateway reject
+ *     "100 CPU-hours/hour from a 4-core node" claims at the validator.
+ *   - `observer` (optional, Wave 2) — independent co-signature over the EXACT
+ *     SAME bytes as the worker signature, to prove a second party witnessed
+ *     this record.
+ *
+ * Trust framing: M-of-N committee attested, same standard Cardano itself uses.
+ * Wave 1+2 is the BASELINE trust layer, not a stopgap. (TEE attestation lands
+ * in Wave 3 as defense-in-depth.) See `project_compute_portal_trust_roadmap.md`.
+ *
+ * --- Why CBOR (and a hand-rolled encoder) ---
+ *
+ * The signature MUST be verifiable byte-for-byte across worker SDKs in TS,
+ * Python, and (eventually) Rust. JSON is non-canonical (spacing, key order,
+ * number formatting all vary). RFC 8949 §4.2.1 canonical CBOR pins one
+ * deterministic byte string per logical record.
+ *
+ * We hand-roll the encoder rather than pull in `cbor`, `cbor-x`, or Python's
+ * `cbor2(canonical=True)` — because those libraries silently SHORTEN floats
+ * (1.5 becomes a 3-byte float16, not a 9-byte float64). A cross-language
+ * verifier that uses two libraries with different shortening rules will
+ * disagree on bytes for half the field values. v2's encoder always emits
+ * 8-byte float64 (major type 7, additional info 27), with no shortening,
+ * matching v1's pattern.
+ *
+ * --- Wire format vs canonical pre-image ---
+ *
+ * The HTTP wire format is JSON: pubkeys/signatures are 64/128-char lowercase
+ * hex strings, byte fields are ints, etc. The CANONICAL CBOR pre-image used
+ * for signing/verifying uses RAW BYTES (CBOR major type 2) for pubkeys and
+ * signatures — that's what `sr25519::verify` actually consumes, and using
+ * bytes (not 64-char hex) keeps the pre-image short and unambiguous.
+ *
+ * --- Canonical CBOR rules (RFC 8949 §4.2.1, distilled to what we use) ---
+ *
+ *   - Definite-length encoding only (no indefinite-length items).
+ *   - Shortest possible integer head per RFC 8949 §3.1.
+ *   - Floats: ALWAYS IEEE-754 binary64 (major 7, additional 27, 8-byte BE).
+ *     Never shortened to f32/f16. NaN/Infinity rejected at validation time.
+ *   - Map keys sorted by encoded-byte lexicographic order. Our keys are all
+ *     short ASCII so this reduces to a string lex sort.
+ *   - Strings: UTF-8 bytes, major type 3.
+ *   - Byte strings: major type 2 (used for pubkeys/signatures in pre-images).
+ *   - Arrays: major type 4 (used for the fixed-position pre-image tuples).
+ *   - Maps: major type 5.
+ *
+ * --- Signature pre-images (PINNED — coordinated with Python encoder) ---
+ *
+ * `fleet_operator_signature` signs canonical CBOR of the array:
+ *   ["fleet_op_attestation_v1", worker_id, hardware_spec_no_sig, issued_ms]
+ *   where `hardware_spec_no_sig` = hardware_spec map MINUS
+ *   `fleet_operator_signature` (everything else stays, including pubkey).
+ *
+ * `worker_signature` signs canonical CBOR of the array:
+ *   ["compute_metering_v2", worker_id, tenant_id,
+ *    period_start_ms, period_end_ms, metrics_map, hardware_spec_full_map,
+ *    worker_pubkey_bytes]
+ *   `hardware_spec_full_map` INCLUDES `fleet_operator_signature` so any
+ *   tampering with the operator-signed portion breaks the worker pre-image
+ *   too.
+ *
+ * `observer_signature` (when present) signs the EXACT SAME BYTES as
+ * `worker_signature`. Verifier reconstructs the worker pre-image once and
+ * runs sr25519::verify against `observer_pubkey` separately.
+ */
+
+import { createHash } from "crypto";
+import { signatureVerify, encodeAddress } from "@polkadot/util-crypto";
+import { hexToU8a, u8aToHex } from "@polkadot/util";
+
+/** Exact schema version string. Anything else = reject. */
+export const SCHEMA_VERSION = "compute_metering_v2";
+
+/** sha256 of the schema-version string — used as `schema_hash` upstream. */
+export const SCHEMA_HASH_HEX = createHash("sha256")
+  .update(SCHEMA_VERSION, "utf-8")
+  .digest("hex");
+
+/** Tag string used as the array head of the fleet-op attestation pre-image. */
+export const FLEET_OP_TAG = "fleet_op_attestation_v1";
+
+/** ID-format regex shared by `worker_id` and `tenant_id`. */
+const ID_REGEX = /^[a-z0-9-]{4,64}$/;
+
+/**
+ * `worker_id` accepts anything UTF-8 in [1..128] without spaces or commas.
+ * (Spec is intentionally looser than `tenant_id` — workers identify themselves
+ * with hostnames / pod-names which can include underscores, dots, etc.)
+ */
+const WORKER_ID_REGEX = /^[^\s,]{1,128}$/;
+
+/** Period upper bound: 24 h. */
+export const MAX_PERIOD_MS = 86_400_000;
+
+/** Future-dated `period_end_ms` tolerance: 60 s of clock skew. */
+export const FUTURE_SKEW_MS = 60_000;
+
+/**
+ * Hardware-jitter factor. CPU/RAM bounds allow up to 5% over the strict
+ * `cores × seconds` limit to absorb measurement jitter (tickless kernels,
+ * cgroup accounting overshoots, etc.). PINNED — do not change without
+ * coordinating Wave 1+2 teams 1/2/3 simultaneously.
+ */
+export const JITTER_FACTOR = 1.05;
+
+/** JS-safe int max (`Number.MAX_SAFE_INTEGER` = 2^53 - 1). */
+export const JS_SAFE_INT = Number.MAX_SAFE_INTEGER;
+
+/** Hex regex for 32-byte pubkey (64 chars) and 64-byte signature (128 chars). */
+const HEX64 = /^[0-9a-f]{64}$/;
+const HEX128 = /^[0-9a-f]{128}$/;
+
+/**
+ * Permitted `gpu_type` values. Closed set so future workers can't claim
+ * imaginary silicon. `"none"` (no GPU) and `"custom"` (escape hatch for
+ * audited custom hardware) are the bookends.
+ */
+export const GPU_TYPES = [
+  "none",
+  "nvidia-h100",
+  "nvidia-h200",
+  "nvidia-b100",
+  "nvidia-a100",
+  "amd-mi300",
+  "custom",
+] as const;
+export type GpuType = (typeof GPU_TYPES)[number];
+
+const GPU_TYPE_SET: ReadonlySet<string> = new Set<string>(GPU_TYPES);
+
+/** Hardware-spec bounds. */
+export const MIN_CPU_CORES = 1;
+export const MAX_CPU_CORES = 1024;
+export const MIN_RAM_GB = 1;
+export const MAX_RAM_GB = 16384;
+export const MIN_GPU_COUNT = 0;
+export const MAX_GPU_COUNT = 16;
+
+// ---------------------------------------------------------------------------
+// Type definitions for the wire format (JSON over HTTP).
+// ---------------------------------------------------------------------------
+
+/** Per-record resource metrics. All values >= 0. */
+export interface MetricsV2 {
+  cpu_seconds: number;
+  ram_gb_hours: number;
+  disk_gb_hours: number;
+  net_bytes_in: number;
+  net_bytes_out: number;
+  gpu_seconds: number;
+}
+
+/** Hardware spec, signed offline by the fleet operator. */
+export interface HardwareSpecV2 {
+  cpu_cores: number;
+  ram_gb: number;
+  gpu_type: GpuType;
+  gpu_count: number;
+  /** 64-char lowercase hex (no `0x` prefix). */
+  fleet_operator_pubkey: string;
+  /** 128-char lowercase hex (no `0x` prefix). */
+  fleet_operator_signature: string;
+  /** UNIX millis when the fleet operator signed this spec. */
+  issued_ms: number;
+}
+
+/** Optional independent observer co-signature over the worker pre-image. */
+export interface ObserverV2 {
+  /** 64-char lowercase hex. */
+  observer_pubkey: string;
+  /** 128-char lowercase hex. */
+  observer_signature: string;
+}
+
+/** Decoded v2 record (post-validation). */
+export interface ComputeMeteringV2 {
+  schema_version: typeof SCHEMA_VERSION;
+  worker_id: string;
+  tenant_id: string;
+  period_start_ms: number;
+  period_end_ms: number;
+  metrics: MetricsV2;
+  hardware_spec: HardwareSpecV2;
+  /** 64-char lowercase hex. */
+  worker_pubkey: string;
+  /** 128-char lowercase hex. */
+  worker_signature: string;
+  /** Optional Wave 2 co-signature. Absent => key not in record. */
+  observer?: ObserverV2;
+}
+
+// ---------------------------------------------------------------------------
+// Validation result types.
+// ---------------------------------------------------------------------------
+
+export type ValidateErrorCode =
+  | "INVALID_JSON"
+  | "MISSING_FIELD"
+  | "WRONG_TYPE"
+  | "WRONG_SCHEMA_VERSION"
+  | "ID_FORMAT"
+  | "PERIOD_INVALID"
+  | "NEGATIVE_VALUE"
+  | "BOUND_EXCEEDED"
+  | "INT_OVERFLOW"
+  | "HEX_FORMAT"
+  | "GPU_TYPE_INVALID"
+  | "GPU_COUNT_MISMATCH"
+  | "HARDWARE_BOUND"
+  | "FLEET_OP_SIGNATURE_INVALID"
+  | "WORKER_SIGNATURE_INVALID"
+  | "OBSERVER_SIGNATURE_INVALID"
+  | "MONOTONIC_VIOLATION";
+
+export interface ValidateOk {
+  ok: true;
+  record: ComputeMeteringV2;
+  /** SHA-256 hex of the worker-signature pre-image. */
+  content_hash: string;
+  /** SHA-256 hex of the schema-version string. */
+  schema_hash: string;
+  /** The worker-signature pre-image bytes (canonical CBOR). */
+  worker_pre_image: Uint8Array;
+  /** The fleet-op-signature pre-image bytes (canonical CBOR). */
+  fleet_op_pre_image: Uint8Array;
+}
+
+export interface ValidateErr {
+  ok: false;
+  code: ValidateErrorCode;
+  message: string;
+  field?: string;
+}
+
+export type ValidateResult = ValidateOk | ValidateErr;
+
+export interface ValidateOptions {
+  /**
+   * Greatest `period_start_ms` previously observed for this `worker_id`. The
+   * incoming record's `period_start_ms` MUST be `>=` this value. Pass `0`
+   * (or omit) for the first-ever record from a worker.
+   */
+  last_period_start_ms?: number;
+  /** Override `Date.now()` in tests. Production callers omit this. */
+  now_ms?: number;
+  /**
+   * When true (default), verify all sr25519 signatures. The schemas-as-types
+   * use case may pass `false` to use the validator as a pure shape checker,
+   * but the gateway always sets this true.
+   */
+  verify_signatures?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical CBOR encoder — RFC 8949 §4.2.1.
+//
+// Restricted to the types we use:
+//   - Unsigned ints (major 0)
+//   - Signed ints   (major 1)
+//   - Byte strings  (major 2)  — pubkeys/signatures in pre-images
+//   - Text strings  (major 3)
+//   - Arrays        (major 4)  — pre-image tuples
+//   - Maps          (major 5)
+//   - Floats        (major 7, additional 27 = 8-byte float64 BE)
+//
+// All other CBOR features (tags, bignums, simple values) are intentionally
+// NOT supported — pass an unsupported value and you get a TypeError, by
+// design. Keeps the cross-language verifier surface tiny.
+// ---------------------------------------------------------------------------
+
+function encodeUint(major: number, n: number): Uint8Array {
+  if (n < 0 || !Number.isFinite(n)) {
+    throw new TypeError(`encodeUint: out of range: ${n}`);
+  }
+  if (n <= 23) return Uint8Array.of((major << 5) | n);
+  if (n <= 0xff) return Uint8Array.of((major << 5) | 24, n);
+  if (n <= 0xffff) {
+    return Uint8Array.of((major << 5) | 25, (n >> 8) & 0xff, n & 0xff);
+  }
+  if (n <= 0xffffffff) {
+    return Uint8Array.of(
+      (major << 5) | 26,
+      (n >>> 24) & 0xff,
+      (n >>> 16) & 0xff,
+      (n >>> 8) & 0xff,
+      n & 0xff,
+    );
+  }
+  if (n > JS_SAFE_INT) {
+    throw new TypeError(`encodeUint: exceeds JS-safe int: ${n}`);
+  }
+  const bn = BigInt(n);
+  const out = new Uint8Array(9);
+  out[0] = (major << 5) | 27;
+  for (let i = 0; i < 8; i++) {
+    out[8 - i] = Number((bn >> BigInt(i * 8)) & 0xffn);
+  }
+  return out;
+}
+
+function encodeInt(n: number): Uint8Array {
+  if (!Number.isInteger(n)) {
+    throw new TypeError(`encodeInt: not an integer: ${n}`);
+  }
+  if (n >= 0) return encodeUint(0, n);
+  return encodeUint(1, -1 - n);
+}
+
+function encodeFloat64(n: number): Uint8Array {
+  if (!Number.isFinite(n)) {
+    throw new TypeError(`encodeFloat64: not finite: ${n}`);
+  }
+  const buf = new ArrayBuffer(9);
+  const view = new DataView(buf);
+  view.setUint8(0, (7 << 5) | 27);
+  view.setFloat64(1, n, /* littleEndian = */ false);
+  return new Uint8Array(buf);
+}
+
+function encodeText(s: string): Uint8Array {
+  const bytes = new TextEncoder().encode(s);
+  const head = encodeUint(3, bytes.length);
+  const out = new Uint8Array(head.length + bytes.length);
+  out.set(head, 0);
+  out.set(bytes, head.length);
+  return out;
+}
+
+function encodeBytes(b: Uint8Array): Uint8Array {
+  const head = encodeUint(2, b.length);
+  const out = new Uint8Array(head.length + b.length);
+  out.set(head, 0);
+  out.set(b, head.length);
+  return out;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+function cmpBytes(a: Uint8Array, b: Uint8Array): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const av = a[i] as number;
+    const bv = b[i] as number;
+    if (av !== bv) return av - bv;
+  }
+  return a.length - b.length;
+}
+
+/**
+ * Discriminator type for canonical-CBOR values. Closed dispatch — every value
+ * placed into a map or array must be one of these wrapped variants. Wrapping
+ * ints/floats explicitly avoids the JS quirk where `Number.isInteger(0.0)`
+ * is `true`, which would silently route a float zero to the integer encoding
+ * path and produce different bytes than the Python encoder.
+ */
+export type CborValue =
+  | { type: "int"; v: number }
+  | { type: "float"; v: number }
+  | { type: "text"; v: string }
+  | { type: "bytes"; v: Uint8Array }
+  | { type: "array"; v: CborValue[] }
+  | { type: "map"; v: Array<[string, CborValue]> };
+
+/** Encode a tagged CBOR value into canonical bytes. */
+export function encodeCbor(val: CborValue): Uint8Array {
+  switch (val.type) {
+    case "int":
+      return encodeInt(val.v);
+    case "float":
+      return encodeFloat64(val.v);
+    case "text":
+      return encodeText(val.v);
+    case "bytes":
+      return encodeBytes(val.v);
+    case "array": {
+      const head = encodeUint(4, val.v.length);
+      const parts: Uint8Array[] = [head];
+      for (const item of val.v) parts.push(encodeCbor(item));
+      return concat(parts);
+    }
+    case "map": {
+      const encoded = val.v.map(([k, v]) => ({
+        keyBytes: encodeText(k),
+        valueBytes: encodeCbor(v),
+      }));
+      // RFC 8949 §4.2.1: sort by encoded-key bytes. All-ASCII keys reduce
+      // this to a JS string lex sort, but we sort on the actual encoded
+      // bytes for correctness.
+      encoded.sort((a, b) => cmpBytes(a.keyBytes, b.keyBytes));
+      const head = encodeUint(5, encoded.length);
+      const parts: Uint8Array[] = [head];
+      for (const { keyBytes, valueBytes } of encoded) {
+        parts.push(keyBytes, valueBytes);
+      }
+      return concat(parts);
+    }
+  }
+}
+
+/** Convenience: build an int CBOR value. */
+export const cborInt = (v: number): CborValue => ({ type: "int", v });
+/** Convenience: build a float CBOR value (always 8-byte float64). */
+export const cborFloat = (v: number): CborValue => ({ type: "float", v });
+/** Convenience: build a text CBOR value. */
+export const cborText = (v: string): CborValue => ({ type: "text", v });
+/** Convenience: build a byte-string CBOR value. */
+export const cborBytes = (v: Uint8Array): CborValue => ({ type: "bytes", v });
+/** Convenience: build an array CBOR value. */
+export const cborArray = (v: CborValue[]): CborValue => ({ type: "array", v });
+/** Convenience: build a map CBOR value (key insertion order is irrelevant — sorted on encode). */
+export const cborMap = (v: Array<[string, CborValue]>): CborValue => ({
+  type: "map",
+  v,
+});
+
+// ---------------------------------------------------------------------------
+// Pre-image builders.
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical CBOR for the `metrics` sub-map. Field-by-field: ints stay ints,
+ * floats stay floats. The JS quirk `Number.isInteger(0.0) === true` is dodged
+ * because we tag each value's type explicitly here based on the schema.
+ *
+ * `cpu_seconds`, `ram_gb_hours`, `disk_gb_hours`, `gpu_seconds` are FLOATS in
+ * the schema. `net_bytes_in` / `net_bytes_out` are INTS. We always emit the
+ * declared CBOR type, regardless of the runtime value's JS type.
+ */
+function metricsToCbor(m: MetricsV2): CborValue {
+  return cborMap([
+    ["cpu_seconds", cborFloat(m.cpu_seconds)],
+    ["disk_gb_hours", cborFloat(m.disk_gb_hours)],
+    ["gpu_seconds", cborFloat(m.gpu_seconds)],
+    ["net_bytes_in", cborInt(m.net_bytes_in)],
+    ["net_bytes_out", cborInt(m.net_bytes_out)],
+    ["ram_gb_hours", cborFloat(m.ram_gb_hours)],
+  ]);
+}
+
+/**
+ * `hardware_spec` minus the `fleet_operator_signature` field. Used as the
+ * 3rd element of the fleet-op pre-image array. Pubkey is encoded as raw
+ * bytes (32) in the CBOR pre-image — `cborHexBytes` strips the hex layer.
+ */
+function hardwareSpecNoSigToCbor(spec: HardwareSpecV2): CborValue {
+  return cborMap([
+    ["cpu_cores", cborInt(spec.cpu_cores)],
+    ["fleet_operator_pubkey", cborBytes(hexToU8a("0x" + spec.fleet_operator_pubkey))],
+    ["gpu_count", cborInt(spec.gpu_count)],
+    ["gpu_type", cborText(spec.gpu_type)],
+    ["issued_ms", cborInt(spec.issued_ms)],
+    ["ram_gb", cborInt(spec.ram_gb)],
+  ]);
+}
+
+/**
+ * Full `hardware_spec` (including signature) for embedding in the worker
+ * pre-image. The fleet-op signature itself is bytes (64). Including it
+ * means tampering with the operator-signed portion breaks the worker
+ * pre-image too — defence in depth.
+ */
+function hardwareSpecFullToCbor(spec: HardwareSpecV2): CborValue {
+  return cborMap([
+    ["cpu_cores", cborInt(spec.cpu_cores)],
+    ["fleet_operator_pubkey", cborBytes(hexToU8a("0x" + spec.fleet_operator_pubkey))],
+    ["fleet_operator_signature", cborBytes(hexToU8a("0x" + spec.fleet_operator_signature))],
+    ["gpu_count", cborInt(spec.gpu_count)],
+    ["gpu_type", cborText(spec.gpu_type)],
+    ["issued_ms", cborInt(spec.issued_ms)],
+    ["ram_gb", cborInt(spec.ram_gb)],
+  ]);
+}
+
+/**
+ * Build the canonical CBOR bytes for the fleet-op-attestation pre-image.
+ *
+ *   [ "fleet_op_attestation_v1", worker_id, hardware_spec_no_sig, issued_ms ]
+ *
+ * Exported so worker SDKs (TS-side) can construct the bytes the fleet
+ * operator signs offline.
+ */
+export function canonicalCborForFleetOpSig(
+  workerId: string,
+  hardwareSpec: HardwareSpecV2,
+): Uint8Array {
+  return encodeCbor(
+    cborArray([
+      cborText(FLEET_OP_TAG),
+      cborText(workerId),
+      hardwareSpecNoSigToCbor(hardwareSpec),
+      cborInt(hardwareSpec.issued_ms),
+    ]),
+  );
+}
+
+/**
+ * Build the canonical CBOR bytes for the worker-signature pre-image.
+ *
+ *   [ "compute_metering_v2", worker_id, tenant_id, period_start_ms,
+ *     period_end_ms, metrics, hardware_spec_full, worker_pubkey_bytes ]
+ *
+ * The observer signature (when present) signs THESE EXACT BYTES under the
+ * observer pubkey.
+ */
+export function canonicalCborForWorkerSig(
+  rec: Omit<ComputeMeteringV2, "worker_signature" | "observer">,
+): Uint8Array {
+  return encodeCbor(
+    cborArray([
+      cborText(SCHEMA_VERSION),
+      cborText(rec.worker_id),
+      cborText(rec.tenant_id),
+      cborInt(rec.period_start_ms),
+      cborInt(rec.period_end_ms),
+      metricsToCbor(rec.metrics),
+      hardwareSpecFullToCbor(rec.hardware_spec),
+      cborBytes(hexToU8a("0x" + rec.worker_pubkey)),
+    ]),
+  );
+}
+
+/**
+ * SHA-256 hex of the worker-signature pre-image. This is the upstream
+ * `content_hash` that the sponsored-receipt pipeline anchors to Cardano.
+ */
+export function canonicalContentHash(
+  rec: Omit<ComputeMeteringV2, "worker_signature" | "observer">,
+): string {
+  return createHash("sha256")
+    .update(canonicalCborForWorkerSig(rec))
+    .digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+function err(
+  code: ValidateErrorCode,
+  message: string,
+  field?: string,
+): ValidateErr {
+  return field !== undefined
+    ? { ok: false, code, message, field }
+    : { ok: false, code, message };
+}
+
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  return x !== null && typeof x === "object" && !Array.isArray(x);
+}
+
+interface NumericFieldSpec {
+  key: string;
+  kind: "int" | "float";
+}
+
+const METRIC_FIELDS: readonly NumericFieldSpec[] = [
+  { key: "cpu_seconds", kind: "float" },
+  { key: "ram_gb_hours", kind: "float" },
+  { key: "disk_gb_hours", kind: "float" },
+  { key: "net_bytes_in", kind: "int" },
+  { key: "net_bytes_out", kind: "int" },
+  { key: "gpu_seconds", kind: "float" },
+];
+
+/** Validate the `metrics` sub-object, returning a typed copy or an err. */
+function validateMetrics(
+  raw: unknown,
+): { ok: true; value: MetricsV2 } | ValidateErr {
+  if (!isPlainObject(raw)) {
+    return err("WRONG_TYPE", "metrics must be a JSON object", "metrics");
+  }
+  const out: Partial<MetricsV2> = {};
+  for (const { key, kind } of METRIC_FIELDS) {
+    if (!(key in raw)) {
+      return err("MISSING_FIELD", `metrics.${key} is required`, `metrics.${key}`);
+    }
+    const v = raw[key];
+    if (typeof v !== "number" || !Number.isFinite(v)) {
+      return err("WRONG_TYPE", `metrics.${key} must be a finite number`, `metrics.${key}`);
+    }
+    if (kind === "int" && !Number.isInteger(v)) {
+      return err("WRONG_TYPE", `metrics.${key} must be an integer`, `metrics.${key}`);
+    }
+    if (v < 0) {
+      return err("NEGATIVE_VALUE", `metrics.${key} must be >= 0, got ${v}`, `metrics.${key}`);
+    }
+    if (kind === "int" && v > JS_SAFE_INT) {
+      return err("INT_OVERFLOW", `metrics.${key} must be <= 2^53-1`, `metrics.${key}`);
+    }
+    (out as Record<string, number>)[key] = v;
+  }
+  return { ok: true, value: out as MetricsV2 };
+}
+
+/** Validate the `hardware_spec` sub-object. */
+function validateHardwareSpec(
+  raw: unknown,
+): { ok: true; value: HardwareSpecV2 } | ValidateErr {
+  if (!isPlainObject(raw)) {
+    return err("WRONG_TYPE", "hardware_spec must be a JSON object", "hardware_spec");
+  }
+
+  // cpu_cores
+  if (!("cpu_cores" in raw)) {
+    return err("MISSING_FIELD", "hardware_spec.cpu_cores is required", "hardware_spec.cpu_cores");
+  }
+  const cpu_cores = raw.cpu_cores;
+  if (typeof cpu_cores !== "number" || !Number.isInteger(cpu_cores)) {
+    return err("WRONG_TYPE", "hardware_spec.cpu_cores must be an integer", "hardware_spec.cpu_cores");
+  }
+  if (cpu_cores < MIN_CPU_CORES || cpu_cores > MAX_CPU_CORES) {
+    return err(
+      "HARDWARE_BOUND",
+      `hardware_spec.cpu_cores must be in [${MIN_CPU_CORES}, ${MAX_CPU_CORES}], got ${cpu_cores}`,
+      "hardware_spec.cpu_cores",
+    );
+  }
+
+  // ram_gb
+  if (!("ram_gb" in raw)) {
+    return err("MISSING_FIELD", "hardware_spec.ram_gb is required", "hardware_spec.ram_gb");
+  }
+  const ram_gb = raw.ram_gb;
+  if (typeof ram_gb !== "number" || !Number.isInteger(ram_gb)) {
+    return err("WRONG_TYPE", "hardware_spec.ram_gb must be an integer", "hardware_spec.ram_gb");
+  }
+  if (ram_gb < MIN_RAM_GB || ram_gb > MAX_RAM_GB) {
+    return err(
+      "HARDWARE_BOUND",
+      `hardware_spec.ram_gb must be in [${MIN_RAM_GB}, ${MAX_RAM_GB}], got ${ram_gb}`,
+      "hardware_spec.ram_gb",
+    );
+  }
+
+  // gpu_type
+  if (!("gpu_type" in raw)) {
+    return err("MISSING_FIELD", "hardware_spec.gpu_type is required", "hardware_spec.gpu_type");
+  }
+  const gpu_type = raw.gpu_type;
+  if (typeof gpu_type !== "string") {
+    return err("WRONG_TYPE", "hardware_spec.gpu_type must be a string", "hardware_spec.gpu_type");
+  }
+  if (!GPU_TYPE_SET.has(gpu_type)) {
+    return err(
+      "GPU_TYPE_INVALID",
+      `hardware_spec.gpu_type must be one of [${GPU_TYPES.join(", ")}], got "${gpu_type}"`,
+      "hardware_spec.gpu_type",
+    );
+  }
+
+  // gpu_count
+  if (!("gpu_count" in raw)) {
+    return err("MISSING_FIELD", "hardware_spec.gpu_count is required", "hardware_spec.gpu_count");
+  }
+  const gpu_count = raw.gpu_count;
+  if (typeof gpu_count !== "number" || !Number.isInteger(gpu_count)) {
+    return err("WRONG_TYPE", "hardware_spec.gpu_count must be an integer", "hardware_spec.gpu_count");
+  }
+  if (gpu_count < MIN_GPU_COUNT || gpu_count > MAX_GPU_COUNT) {
+    return err(
+      "HARDWARE_BOUND",
+      `hardware_spec.gpu_count must be in [${MIN_GPU_COUNT}, ${MAX_GPU_COUNT}], got ${gpu_count}`,
+      "hardware_spec.gpu_count",
+    );
+  }
+
+  // fleet_operator_pubkey + fleet_operator_signature (hex check)
+  for (const [k, re, len] of [
+    ["fleet_operator_pubkey", HEX64, 64],
+    ["fleet_operator_signature", HEX128, 128],
+  ] as const) {
+    const fk = `hardware_spec.${k}`;
+    if (!(k in raw)) {
+      return err("MISSING_FIELD", `${fk} is required`, fk);
+    }
+    const v = raw[k];
+    if (typeof v !== "string") {
+      return err("WRONG_TYPE", `${fk} must be a string`, fk);
+    }
+    if (!re.test(v)) {
+      return err(
+        "HEX_FORMAT",
+        `${fk} must be exactly ${len} lowercase hex chars, got length ${v.length}`,
+        fk,
+      );
+    }
+  }
+
+  // issued_ms
+  if (!("issued_ms" in raw)) {
+    return err("MISSING_FIELD", "hardware_spec.issued_ms is required", "hardware_spec.issued_ms");
+  }
+  const issued_ms = raw.issued_ms;
+  if (typeof issued_ms !== "number" || !Number.isInteger(issued_ms)) {
+    return err("WRONG_TYPE", "hardware_spec.issued_ms must be an integer", "hardware_spec.issued_ms");
+  }
+  if (issued_ms <= 0) {
+    return err("PERIOD_INVALID", "hardware_spec.issued_ms must be > 0", "hardware_spec.issued_ms");
+  }
+
+  return {
+    ok: true,
+    value: {
+      cpu_cores,
+      ram_gb,
+      gpu_type: gpu_type as GpuType,
+      gpu_count,
+      fleet_operator_pubkey: raw.fleet_operator_pubkey as string,
+      fleet_operator_signature: raw.fleet_operator_signature as string,
+      issued_ms,
+    },
+  };
+}
+
+/** Validate the optional `observer` sub-object. */
+function validateObserver(
+  raw: unknown,
+): { ok: true; value: ObserverV2 } | ValidateErr {
+  if (!isPlainObject(raw)) {
+    return err("WRONG_TYPE", "observer must be a JSON object", "observer");
+  }
+  if (!("observer_pubkey" in raw)) {
+    return err("MISSING_FIELD", "observer.observer_pubkey is required", "observer.observer_pubkey");
+  }
+  if (!("observer_signature" in raw)) {
+    return err("MISSING_FIELD", "observer.observer_signature is required", "observer.observer_signature");
+  }
+  const pk = raw.observer_pubkey;
+  const sg = raw.observer_signature;
+  if (typeof pk !== "string") {
+    return err("WRONG_TYPE", "observer.observer_pubkey must be a string", "observer.observer_pubkey");
+  }
+  if (typeof sg !== "string") {
+    return err("WRONG_TYPE", "observer.observer_signature must be a string", "observer.observer_signature");
+  }
+  if (!HEX64.test(pk)) {
+    return err(
+      "HEX_FORMAT",
+      `observer.observer_pubkey must be exactly 64 lowercase hex chars, got length ${pk.length}`,
+      "observer.observer_pubkey",
+    );
+  }
+  if (!HEX128.test(sg)) {
+    return err(
+      "HEX_FORMAT",
+      `observer.observer_signature must be exactly 128 lowercase hex chars, got length ${sg.length}`,
+      "observer.observer_signature",
+    );
+  }
+  return { ok: true, value: { observer_pubkey: pk, observer_signature: sg } };
+}
+
+/**
+ * Verify a single sr25519 signature. Returns true on valid; false on either
+ * verify-failed or any thrown error from the underlying util-crypto helper
+ * (malformed pubkey/sig is the most common throw).
+ */
+function verifySr25519(
+  message: Uint8Array,
+  signatureHex: string,
+  pubkeyHex: string,
+): boolean {
+  try {
+    const result = signatureVerify(
+      message,
+      hexToU8a("0x" + signatureHex),
+      u8aToHex(hexToU8a("0x" + pubkeyHex)),
+    );
+    return result.isValid;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate a parsed JSON object against the `compute_metering_v2` schema.
+ *
+ * Returns `{ ok: true, record, content_hash, schema_hash, worker_pre_image,
+ * fleet_op_pre_image }` on success or `{ ok: false, code, message, field? }`
+ * on failure. The validator never throws on input shape — every failure mode
+ * is captured as a `ValidateErr`.
+ */
+export function validateComputeMeteringV2(
+  raw: unknown,
+  opts: ValidateOptions = {},
+): ValidateResult {
+  const nowMs = opts.now_ms ?? Date.now();
+  const lastPeriodStartMs = opts.last_period_start_ms ?? 0;
+  const verifySigs = opts.verify_signatures ?? true;
+
+  if (!isPlainObject(raw)) {
+    return err("WRONG_TYPE", "expected JSON object at root");
+  }
+  const r = raw;
+
+  // --- schema_version ---
+  if (!("schema_version" in r)) {
+    return err("MISSING_FIELD", "schema_version is required", "schema_version");
+  }
+  if (typeof r.schema_version !== "string") {
+    return err("WRONG_TYPE", "schema_version must be a string", "schema_version");
+  }
+  if (r.schema_version !== SCHEMA_VERSION) {
+    return err(
+      "WRONG_SCHEMA_VERSION",
+      `schema_version must be exactly "${SCHEMA_VERSION}", got "${r.schema_version}"`,
+      "schema_version",
+    );
+  }
+
+  // --- worker_id (looser regex than tenant_id) ---
+  if (!("worker_id" in r)) {
+    return err("MISSING_FIELD", "worker_id is required", "worker_id");
+  }
+  if (typeof r.worker_id !== "string") {
+    return err("WRONG_TYPE", "worker_id must be a string", "worker_id");
+  }
+  if (!WORKER_ID_REGEX.test(r.worker_id)) {
+    return err(
+      "ID_FORMAT",
+      "worker_id must be 1-128 UTF-8 chars with no spaces or commas",
+      "worker_id",
+    );
+  }
+  const workerId = r.worker_id;
+
+  // --- tenant_id (strict regex) ---
+  if (!("tenant_id" in r)) {
+    return err("MISSING_FIELD", "tenant_id is required", "tenant_id");
+  }
+  if (typeof r.tenant_id !== "string") {
+    return err("WRONG_TYPE", "tenant_id must be a string", "tenant_id");
+  }
+  if (!ID_REGEX.test(r.tenant_id)) {
+    return err(
+      "ID_FORMAT",
+      `tenant_id must match [a-z0-9-]{4,64}, got "${r.tenant_id}"`,
+      "tenant_id",
+    );
+  }
+  const tenantId = r.tenant_id;
+
+  // --- period_start_ms ---
+  if (!("period_start_ms" in r)) {
+    return err("MISSING_FIELD", "period_start_ms is required", "period_start_ms");
+  }
+  if (typeof r.period_start_ms !== "number" || !Number.isInteger(r.period_start_ms)) {
+    return err("WRONG_TYPE", "period_start_ms must be an integer", "period_start_ms");
+  }
+  if (r.period_start_ms <= 0) {
+    return err("PERIOD_INVALID", "period_start_ms must be > 0", "period_start_ms");
+  }
+  const periodStartMs = r.period_start_ms;
+
+  // --- period_end_ms ---
+  if (!("period_end_ms" in r)) {
+    return err("MISSING_FIELD", "period_end_ms is required", "period_end_ms");
+  }
+  if (typeof r.period_end_ms !== "number" || !Number.isInteger(r.period_end_ms)) {
+    return err("WRONG_TYPE", "period_end_ms must be an integer", "period_end_ms");
+  }
+  const periodEndMs = r.period_end_ms;
+  if (periodEndMs <= periodStartMs) {
+    return err("PERIOD_INVALID", "period_end_ms must be > period_start_ms", "period_end_ms");
+  }
+  if (periodEndMs - periodStartMs > MAX_PERIOD_MS) {
+    return err(
+      "PERIOD_INVALID",
+      `period (period_end_ms - period_start_ms) must be <= ${MAX_PERIOD_MS} ms (24 h)`,
+      "period_end_ms",
+    );
+  }
+  if (periodEndMs > nowMs + FUTURE_SKEW_MS) {
+    return err(
+      "PERIOD_INVALID",
+      `period_end_ms is too far in the future (skew > ${FUTURE_SKEW_MS} ms)`,
+      "period_end_ms",
+    );
+  }
+
+  // --- monotonic per-worker ---
+  if (periodStartMs < lastPeriodStartMs) {
+    return err(
+      "MONOTONIC_VIOLATION",
+      `period_start_ms ${periodStartMs} < last observed ${lastPeriodStartMs} for ${workerId}`,
+      "period_start_ms",
+    );
+  }
+
+  // --- metrics ---
+  if (!("metrics" in r)) {
+    return err("MISSING_FIELD", "metrics is required", "metrics");
+  }
+  const mRes = validateMetrics(r.metrics);
+  if (!mRes.ok) return mRes;
+  const metrics = mRes.value;
+
+  // --- hardware_spec ---
+  if (!("hardware_spec" in r)) {
+    return err("MISSING_FIELD", "hardware_spec is required", "hardware_spec");
+  }
+  const hsRes = validateHardwareSpec(r.hardware_spec);
+  if (!hsRes.ok) return hsRes;
+  const hardwareSpec = hsRes.value;
+
+  // --- worker_pubkey / worker_signature (hex) ---
+  for (const [k, re, len] of [
+    ["worker_pubkey", HEX64, 64],
+    ["worker_signature", HEX128, 128],
+  ] as const) {
+    if (!(k in r)) {
+      return err("MISSING_FIELD", `${k} is required`, k);
+    }
+    const v = r[k];
+    if (typeof v !== "string") {
+      return err("WRONG_TYPE", `${k} must be a string`, k);
+    }
+    if (!re.test(v)) {
+      return err(
+        "HEX_FORMAT",
+        `${k} must be exactly ${len} lowercase hex chars, got length ${v.length}`,
+        k,
+      );
+    }
+  }
+  const workerPubkey = r.worker_pubkey as string;
+  const workerSignature = r.worker_signature as string;
+
+  // --- observer (optional) ---
+  let observer: ObserverV2 | undefined;
+  if ("observer" in r && r.observer !== undefined && r.observer !== null) {
+    const obRes = validateObserver(r.observer);
+    if (!obRes.ok) return obRes;
+    observer = obRes.value;
+  }
+
+  // --- bound checks (rules 4, 5, 6) ---
+  // Rule 4: cpu_seconds <= cpu_cores × period_seconds × JITTER
+  // Rule 5: ram_gb_hours <= ram_gb × period_hours × JITTER
+  // Rule 6: gpu_seconds = 0 if gpu_type == "none" OR gpu_count == 0
+  // (Per-period jitter is computed in float64; the numeric stability of these
+  // multiplications is fine for the realistic input range.)
+  const periodSec = (periodEndMs - periodStartMs) / 1000;
+  const periodHr = (periodEndMs - periodStartMs) / 3_600_000;
+  const cpuCap = hardwareSpec.cpu_cores * periodSec * JITTER_FACTOR;
+  const ramCap = hardwareSpec.ram_gb * periodHr * JITTER_FACTOR;
+  if (metrics.cpu_seconds > cpuCap) {
+    return err(
+      "BOUND_EXCEEDED",
+      `metrics.cpu_seconds ${metrics.cpu_seconds} exceeds hardware cap ${cpuCap} (${hardwareSpec.cpu_cores} cores × ${periodSec}s × ${JITTER_FACTOR})`,
+      "metrics.cpu_seconds",
+    );
+  }
+  if (metrics.ram_gb_hours > ramCap) {
+    return err(
+      "BOUND_EXCEEDED",
+      `metrics.ram_gb_hours ${metrics.ram_gb_hours} exceeds hardware cap ${ramCap} (${hardwareSpec.ram_gb} GB × ${periodHr}h × ${JITTER_FACTOR})`,
+      "metrics.ram_gb_hours",
+    );
+  }
+  if (
+    (hardwareSpec.gpu_type === "none" || hardwareSpec.gpu_count === 0) &&
+    metrics.gpu_seconds !== 0
+  ) {
+    return err(
+      "GPU_COUNT_MISMATCH",
+      `metrics.gpu_seconds must be 0 when gpu_type="${hardwareSpec.gpu_type}" or gpu_count=${hardwareSpec.gpu_count}`,
+      "metrics.gpu_seconds",
+    );
+  }
+
+  // --- assemble typed record ---
+  const record: ComputeMeteringV2 = observer
+    ? {
+        schema_version: SCHEMA_VERSION,
+        worker_id: workerId,
+        tenant_id: tenantId,
+        period_start_ms: periodStartMs,
+        period_end_ms: periodEndMs,
+        metrics,
+        hardware_spec: hardwareSpec,
+        worker_pubkey: workerPubkey,
+        worker_signature: workerSignature,
+        observer,
+      }
+    : {
+        schema_version: SCHEMA_VERSION,
+        worker_id: workerId,
+        tenant_id: tenantId,
+        period_start_ms: periodStartMs,
+        period_end_ms: periodEndMs,
+        metrics,
+        hardware_spec: hardwareSpec,
+        worker_pubkey: workerPubkey,
+        worker_signature: workerSignature,
+      };
+
+  // --- canonical pre-images ---
+  const fleetOpPreImage = canonicalCborForFleetOpSig(workerId, hardwareSpec);
+  const workerPreImage = canonicalCborForWorkerSig({
+    schema_version: SCHEMA_VERSION,
+    worker_id: workerId,
+    tenant_id: tenantId,
+    period_start_ms: periodStartMs,
+    period_end_ms: periodEndMs,
+    metrics,
+    hardware_spec: hardwareSpec,
+    worker_pubkey: workerPubkey,
+  });
+
+  // --- signature verifications (rules 7, 8, 9) ---
+  if (verifySigs) {
+    if (
+      !verifySr25519(
+        fleetOpPreImage,
+        hardwareSpec.fleet_operator_signature,
+        hardwareSpec.fleet_operator_pubkey,
+      )
+    ) {
+      return err(
+        "FLEET_OP_SIGNATURE_INVALID",
+        "fleet_operator_signature does not verify against fleet_operator_pubkey",
+        "hardware_spec.fleet_operator_signature",
+      );
+    }
+    if (!verifySr25519(workerPreImage, workerSignature, workerPubkey)) {
+      return err(
+        "WORKER_SIGNATURE_INVALID",
+        "worker_signature does not verify against worker_pubkey",
+        "worker_signature",
+      );
+    }
+    if (observer) {
+      if (
+        !verifySr25519(
+          workerPreImage,
+          observer.observer_signature,
+          observer.observer_pubkey,
+        )
+      ) {
+        return err(
+          "OBSERVER_SIGNATURE_INVALID",
+          "observer_signature does not verify against observer_pubkey over the worker pre-image",
+          "observer.observer_signature",
+        );
+      }
+    }
+  }
+
+  const contentHash = createHash("sha256").update(workerPreImage).digest("hex");
+  return {
+    ok: true,
+    record,
+    content_hash: contentHash,
+    schema_hash: SCHEMA_HASH_HEX,
+    worker_pre_image: workerPreImage,
+    fleet_op_pre_image: fleetOpPreImage,
+  };
+}
+
+/**
+ * Convenience: derive an SS58 address (Substrate generic, prefix 42 by
+ * default) from a 64-char lowercase hex sr25519 pubkey. Used by the gateway
+ * route to attribute the upstream sponsored-receipt to the worker's account.
+ */
+export function workerPubkeyToSs58(workerPubkey: string, prefix = 42): string {
+  if (!HEX64.test(workerPubkey)) {
+    throw new TypeError(
+      `workerPubkeyToSs58: expected 64 lowercase hex, got "${workerPubkey}"`,
+    );
+  }
+  return encodeAddress(hexToU8a("0x" + workerPubkey), prefix);
+}


### PR DESCRIPTION
Wave 1+2 Team 1 of 3: `compute_metering_v2` schema + TS validator + Python encoder + cross-language byte-pinning tests. Adds mandatory `hardware_spec` (fleet-operator-signed) and optional `observer` co-signature. v1 untouched.

**Trust framing:** M-of-N committee attested = same standard Cardano runs on. Wave 1+2 is the BASELINE, not a stopgap.

**Files:** 6 files, +3266 LoC. `schema_hash_v2 = 2aa950df31d7f9efa570f39e1fce597e287d30b2d22e223428d155261573d732`.

**Tests:** TS 74 + Python 82 (incl. 21 cross-language byte-pinning vectors) all passing. v1 + metering_route regressions: 64 + 12 still pass. `pnpm tsc --noEmit` clean. AST clean. 0 TODO/FIXME.

**Notable findings:** `cbor2(canonical=True)` shortens floats to float16 — would silently break cross-language byte equality; v2 dodges with hand-rolled Python encoder mirroring TS byte-for-byte. `Number.isInteger(0.0) === true` worked around in BOTH encoders. `Python True is 1` rejected via isinstance(v, bool).

**Judgment calls (documented in source):** bytes-not-hex in pre-image (raw CBOR byte strings, not double-encoded hex); `worker_id` regex `[^\s,]{1,128}` permits hostnames + UTF-8.

**Trace:** `03121164-f5d3-43e4-99ae-c01af42dee86`

Coordinated with Team 2 (gateway validator) and Team 3 (worker SDK). Lockstep schema = the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)