### PR TITLE
feat(blob-gateway): compute_metering_v2 + fleet_operators/observers registries (Wave 1+2 Team 2)

### DIFF
--- a/services/blob-gateway/src/__tests__/fleet_operators.test.ts
+++ b/services/blob-gateway/src/__tests__/fleet_operators.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Unit tests for fleet_operators.ts (compute_metering_v2 trust registry).
+ *
+ * Per `feedback_pr_review_ast_check.md` and the Wave 1+2 TDD bar, these tests
+ * MUST exercise a real on-disk SQLite migration in addition to the in-memory
+ * fast path. The CONCURRENT-STARTUP race test opens the same on-disk file
+ * with two handles simultaneously and verifies the schema lands intact.
+ *
+ * Test categories:
+ *   1. Migration (idempotent in-memory + real on-disk fresh + on-disk pre-v2 survives)
+ *   2. CRUD (register / get / revoke / list)
+ *   3. Pubkey normalisation (0x-prefix, mixed case)
+ *   4. Edge cases (duplicate, unknown, revoked-then-revoke)
+ *   5. Concurrent-startup race (two handles, same file)
+ */
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  initFleetOperatorsDb,
+  setFleetOperatorsDbForTests,
+  getFleetOperatorsDb,
+  registerFleetOperator,
+  revokeFleetOperator,
+  getFleetOperator,
+  isFleetOperatorActive,
+  listFleetOperators,
+} from "../fleet_operators.js";
+
+const PUB_A = "a".repeat(64);
+const PUB_B = "b".repeat(64);
+const PUB_C = "c".repeat(64);
+
+function makeMemDb(): Database.Database {
+  const db = new Database(":memory:");
+  initFleetOperatorsDb(db);
+  setFleetOperatorsDbForTests(db);
+  return db;
+}
+
+describe("fleet_operators: in-memory migration", () => {
+  test("initFleetOperatorsDb_creates_table_idempotently", () => {
+    const db = new Database(":memory:");
+    initFleetOperatorsDb(db);
+    initFleetOperatorsDb(db); // second call must be a no-op
+    initFleetOperatorsDb(db); // third also fine
+    const cols = db.prepare("PRAGMA table_info(fleet_operators)").all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual([
+      "id",
+      "label",
+      "notes",
+      "pubkey_hex",
+      "registered_at",
+      "revoked_at",
+    ]);
+  });
+
+  test("indexes_created_for_pubkey_lookup_and_active_filter", () => {
+    const db = new Database(":memory:");
+    initFleetOperatorsDb(db);
+    const idxs = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='fleet_operators'")
+      .all() as Array<{ name: string }>;
+    const idxNames = idxs.map((i) => i.name).sort();
+    expect(idxNames).toContain("idx_fleet_operators_pubkey");
+    expect(idxNames).toContain("idx_fleet_operators_active");
+  });
+});
+
+describe("fleet_operators: real on-disk SQLite migration", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "fleet-ops-disk-"));
+    dbPath = join(tmpDir, "fleet_operators.db");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("fresh_on_disk_file_gets_full_schema_after_first_init", () => {
+    expect(existsSync(dbPath)).toBe(false);
+    const db = new Database(dbPath);
+    initFleetOperatorsDb(db);
+    db.close();
+
+    expect(existsSync(dbPath)).toBe(true);
+
+    const reopened = new Database(dbPath);
+    const cols = reopened
+      .prepare("PRAGMA table_info(fleet_operators)")
+      .all() as Array<{ name: string }>;
+    expect(cols.map((c) => c.name).sort()).toEqual([
+      "id",
+      "label",
+      "notes",
+      "pubkey_hex",
+      "registered_at",
+      "revoked_at",
+    ]);
+    reopened.close();
+  });
+
+  test("rows_inserted_in_first_session_survive_second_init", () => {
+    // Session 1: write a row.
+    const db1 = new Database(dbPath);
+    initFleetOperatorsDb(db1);
+    setFleetOperatorsDbForTests(db1);
+    const row = registerFleetOperator({
+      pubkey: PUB_A,
+      label: "session-1",
+      now: 1_000_000,
+    });
+    expect(row.pubkey_hex).toBe(PUB_A);
+    db1.close();
+
+    // Session 2: re-open same file, run init AGAIN — pre-existing row must survive.
+    const db2 = new Database(dbPath);
+    initFleetOperatorsDb(db2);
+    setFleetOperatorsDbForTests(db2);
+    const persisted = getFleetOperator(PUB_A);
+    expect(persisted).not.toBeNull();
+    expect(persisted!.label).toBe("session-1");
+    expect(persisted!.registered_at).toBe(1_000_000);
+    expect(persisted!.revoked_at).toBeNull();
+    db2.close();
+  });
+
+  test("concurrent_startup_two_handles_one_file_both_succeed", () => {
+    // Simulate two boot processes (e.g., a docker-compose race) opening the
+    // same file in parallel. Both should run init OK. Per
+    // `feedback_pr_review_ast_check.md`, this is the kind of race a pure mock
+    // test would NEVER catch — both handles really write to the same on-disk
+    // file here.
+    const db1 = new Database(dbPath);
+    const db2 = new Database(dbPath);
+    expect(() => initFleetOperatorsDb(db1)).not.toThrow();
+    expect(() => initFleetOperatorsDb(db2)).not.toThrow();
+
+    // Use db1 to insert; db2 should see it after a fresh read.
+    setFleetOperatorsDbForTests(db1);
+    registerFleetOperator({ pubkey: PUB_B, label: "concurrent" });
+    const cols = db2
+      .prepare("PRAGMA table_info(fleet_operators)")
+      .all() as Array<{ name: string }>;
+    expect(cols.length).toBe(6);
+    db1.close();
+    db2.close();
+  });
+
+  test("legacy_rows_pre_existing_pubkey_survive_re_init", () => {
+    // Session 1: write a single row directly via raw SQL (simulating data
+    // written by an older binary that used the same schema).
+    const db1 = new Database(dbPath);
+    db1.exec(`
+      CREATE TABLE IF NOT EXISTS fleet_operators (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        pubkey_hex TEXT UNIQUE NOT NULL,
+        label TEXT,
+        registered_at INTEGER NOT NULL,
+        revoked_at INTEGER,
+        notes TEXT
+      );
+    `);
+    db1.prepare(
+      `INSERT INTO fleet_operators (pubkey_hex, label, registered_at, notes)
+       VALUES (?, ?, ?, ?)`,
+    ).run(PUB_C, "legacy", 999_999, "old-row");
+    db1.close();
+
+    // Session 2: run init() on the existing file. Row must survive.
+    const db2 = new Database(dbPath);
+    initFleetOperatorsDb(db2);
+    setFleetOperatorsDbForTests(db2);
+    const row = getFleetOperator(PUB_C);
+    expect(row).not.toBeNull();
+    expect(row!.label).toBe("legacy");
+    expect(row!.notes).toBe("old-row");
+    db2.close();
+  });
+});
+
+describe("fleet_operators: register", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeMemDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  test("register_returns_row_with_pubkey_label_registered_at", () => {
+    const row = registerFleetOperator({
+      pubkey: PUB_A,
+      label: "fleet-acme",
+      notes: "primary fleet",
+      now: 1_700_000_000,
+    });
+    expect(row.pubkey_hex).toBe(PUB_A);
+    expect(row.label).toBe("fleet-acme");
+    expect(row.notes).toBe("primary fleet");
+    expect(row.registered_at).toBe(1_700_000_000);
+    expect(row.revoked_at).toBeNull();
+    expect(row.id).toBeGreaterThan(0);
+  });
+
+  test("register_normalises_0x_prefix_and_uppercase", () => {
+    const row = registerFleetOperator({
+      pubkey: "0X" + "F".repeat(64),
+      label: "norm",
+    });
+    expect(row.pubkey_hex).toBe("f".repeat(64));
+  });
+
+  test("register_throws_on_invalid_hex_length", () => {
+    expect(() => registerFleetOperator({ pubkey: "abcd" })).toThrow(/64 chars/);
+  });
+
+  test("register_throws_on_invalid_hex_chars", () => {
+    expect(() =>
+      registerFleetOperator({ pubkey: "g".repeat(64) }),
+    ).toThrow(/64 chars/);
+  });
+
+  test("register_throws_on_duplicate_pubkey", () => {
+    registerFleetOperator({ pubkey: PUB_A, label: "first" });
+    expect(() =>
+      registerFleetOperator({ pubkey: PUB_A, label: "second" }),
+    ).toThrow(/UNIQUE/i);
+  });
+
+  test("register_truncates_label_at_256_chars", () => {
+    const longLabel = "x".repeat(500);
+    const row = registerFleetOperator({ pubkey: PUB_A, label: longLabel });
+    expect(row.label!.length).toBe(256);
+  });
+
+  test("register_truncates_notes_at_1024_chars", () => {
+    const longNotes = "n".repeat(2000);
+    const row = registerFleetOperator({ pubkey: PUB_A, notes: longNotes });
+    expect(row.notes!.length).toBe(1024);
+  });
+
+  test("register_accepts_null_label_and_notes", () => {
+    const row = registerFleetOperator({ pubkey: PUB_A });
+    expect(row.label).toBeNull();
+    expect(row.notes).toBeNull();
+  });
+});
+
+describe("fleet_operators: get + isActive", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeMemDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  test("get_returns_null_for_unknown_pubkey", () => {
+    expect(getFleetOperator(PUB_A)).toBeNull();
+  });
+
+  test("get_returns_row_for_registered_pubkey", () => {
+    registerFleetOperator({ pubkey: PUB_A, label: "test" });
+    const row = getFleetOperator(PUB_A);
+    expect(row).not.toBeNull();
+    expect(row!.pubkey_hex).toBe(PUB_A);
+  });
+
+  test("get_normalises_lookup_key", () => {
+    registerFleetOperator({ pubkey: PUB_A });
+    expect(getFleetOperator("0x" + PUB_A.toUpperCase())).not.toBeNull();
+  });
+
+  test("isActive_true_for_registered_not_revoked", () => {
+    registerFleetOperator({ pubkey: PUB_A });
+    expect(isFleetOperatorActive(PUB_A)).toBe(true);
+  });
+
+  test("isActive_false_for_unknown_pubkey", () => {
+    expect(isFleetOperatorActive(PUB_A)).toBe(false);
+  });
+
+  test("isActive_false_after_revocation", () => {
+    registerFleetOperator({ pubkey: PUB_A });
+    revokeFleetOperator(PUB_A);
+    expect(isFleetOperatorActive(PUB_A)).toBe(false);
+  });
+
+  test("isActive_returns_false_when_db_uninitialised_defensive", () => {
+    setFleetOperatorsDbForTests(undefined as unknown as Database.Database);
+    expect(isFleetOperatorActive(PUB_A)).toBe(false);
+  });
+});
+
+describe("fleet_operators: revoke", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeMemDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  test("revoke_returns_true_on_first_call", () => {
+    registerFleetOperator({ pubkey: PUB_A });
+    expect(revokeFleetOperator(PUB_A)).toBe(true);
+  });
+
+  test("revoke_returns_false_for_unknown_pubkey", () => {
+    expect(revokeFleetOperator(PUB_A)).toBe(false);
+  });
+
+  test("revoke_is_idempotent_returns_false_on_second_call", () => {
+    registerFleetOperator({ pubkey: PUB_A });
+    expect(revokeFleetOperator(PUB_A, { now: 1000 })).toBe(true);
+    expect(revokeFleetOperator(PUB_A, { now: 2000 })).toBe(false);
+    const row = getFleetOperator(PUB_A);
+    expect(row!.revoked_at).toBe(1000);
+  });
+
+  test("revoke_marks_revoked_at_with_supplied_now", () => {
+    registerFleetOperator({ pubkey: PUB_A });
+    revokeFleetOperator(PUB_A, { now: 12345 });
+    const row = getFleetOperator(PUB_A);
+    expect(row!.revoked_at).toBe(12345);
+  });
+
+  test("revoke_normalises_input_pubkey", () => {
+    registerFleetOperator({ pubkey: PUB_A });
+    expect(revokeFleetOperator("0X" + PUB_A.toUpperCase())).toBe(true);
+  });
+});
+
+describe("fleet_operators: list", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeMemDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  test("list_returns_empty_array_for_fresh_db", () => {
+    expect(listFleetOperators()).toEqual([]);
+    expect(listFleetOperators({ active: true })).toEqual([]);
+  });
+
+  test("list_returns_all_rows_in_registered_at_desc_order", () => {
+    registerFleetOperator({ pubkey: PUB_A, now: 100 });
+    registerFleetOperator({ pubkey: PUB_B, now: 200 });
+    registerFleetOperator({ pubkey: PUB_C, now: 150 });
+    const all = listFleetOperators();
+    expect(all).toHaveLength(3);
+    expect(all.map((r) => r.pubkey_hex)).toEqual([PUB_B, PUB_C, PUB_A]);
+  });
+
+  test("list_active_filters_revoked_rows", () => {
+    registerFleetOperator({ pubkey: PUB_A, now: 100 });
+    registerFleetOperator({ pubkey: PUB_B, now: 200 });
+    revokeFleetOperator(PUB_A);
+
+    const all = listFleetOperators();
+    expect(all).toHaveLength(2);
+
+    const active = listFleetOperators({ active: true });
+    expect(active).toHaveLength(1);
+    expect(active[0]!.pubkey_hex).toBe(PUB_B);
+  });
+
+  test("list_includes_revoked_rows_when_active_unset_or_false", () => {
+    registerFleetOperator({ pubkey: PUB_A });
+    revokeFleetOperator(PUB_A);
+    const allDefault = listFleetOperators();
+    expect(allDefault).toHaveLength(1);
+    expect(allDefault[0]!.revoked_at).not.toBeNull();
+    const allFalse = listFleetOperators({ active: false });
+    expect(allFalse).toHaveLength(1);
+  });
+});
+
+describe("fleet_operators: getFleetOperatorsDb test hook", () => {
+  test("throws_before_init", () => {
+    setFleetOperatorsDbForTests(undefined as unknown as Database.Database);
+    expect(() => getFleetOperatorsDb()).toThrow(/not initialised/);
+  });
+
+  test("returns_handle_after_setForTests", () => {
+    const db = makeMemDb();
+    expect(getFleetOperatorsDb()).toBe(db);
+    db.close();
+  });
+});

--- a/services/blob-gateway/src/__tests__/metering_v2_admin.test.ts
+++ b/services/blob-gateway/src/__tests__/metering_v2_admin.test.ts
@@ -1,0 +1,518 @@
+/**
+ * Integration tests for the admin endpoints that manage the
+ * fleet_operators + observers registries used by compute_metering_v2.
+ *
+ * Real express server, real in-memory SQLite, real adminGuard. We test:
+ *   - 401 when no/invalid x-admin-token
+ *   - 200 + persisted row on POST
+ *   - 409 on duplicate POST
+ *   - 200 on DELETE happy path
+ *   - 200 already-revoked on second DELETE (idempotent)
+ *   - 404 on DELETE for unknown pubkey
+ *   - 200 list with shape assertions
+ *   - active=1 query filter
+ *   - 503 when DAEMON_NOTIFY_TOKEN unset (route mounted but unconfigured)
+ */
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+
+import { config } from "../config.js";
+import {
+  initFleetOperatorsDb,
+  setFleetOperatorsDbForTests,
+} from "../fleet_operators.js";
+import {
+  initObserversDb,
+  setObserversDbForTests,
+} from "../observers.js";
+import { registerFleetOperatorRoutes } from "../routes/fleet_operators.js";
+import { registerObserverRoutes } from "../routes/observers.js";
+
+const ADMIN_TOKEN = "admin-test-token-deadbeef";
+const PUB_A = "a".repeat(64);
+const PUB_B = "b".repeat(64);
+const PUB_C = "c".repeat(64);
+
+interface Ctx {
+  app: express.Express;
+  fleetDb: Database.Database;
+  observersDb: Database.Database;
+  prevToken: string;
+}
+
+function setupApp(opts: { withToken?: boolean } = {}): Ctx {
+  const fleetDb = new Database(":memory:");
+  initFleetOperatorsDb(fleetDb);
+  setFleetOperatorsDbForTests(fleetDb);
+
+  const observersDb = new Database(":memory:");
+  initObserversDb(observersDb);
+  setObserversDbForTests(observersDb);
+
+  const prevToken = config.daemonNotifyToken;
+  config.daemonNotifyToken = opts.withToken === false ? "" : ADMIN_TOKEN;
+
+  const app = express();
+  app.use(express.json({ limit: "1mb" }));
+  registerFleetOperatorRoutes(app);
+  registerObserverRoutes(app);
+
+  return { app, fleetDb, observersDb, prevToken };
+}
+
+function teardown(ctx: Ctx): void {
+  config.daemonNotifyToken = ctx.prevToken;
+  ctx.fleetDb.close();
+  ctx.observersDb.close();
+}
+
+async function callApp(
+  app: express.Express,
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: {
+          "content-type": "application/json",
+          ...(opts.headers ?? {}),
+        },
+      };
+      if (opts.body !== undefined) {
+        init.body = JSON.stringify(opts.body);
+      }
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+// ===========================================================================
+// fleet operators
+// ===========================================================================
+
+describe("/admin/fleet-operators — auth gating", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp();
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("POST_without_token_returns_401", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      body: { pubkey: PUB_A },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("POST_with_wrong_token_returns_401", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      headers: { "x-admin-token": "wrong" },
+      body: { pubkey: PUB_A },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("DELETE_without_token_returns_401", async () => {
+    const res = await callApp(ctx.app, "DELETE", `/admin/fleet-operators/${PUB_A}`);
+    expect(res.status).toBe(401);
+  });
+
+  test("GET_without_token_returns_401", async () => {
+    const res = await callApp(ctx.app, "GET", "/admin/fleet-operators");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("/admin/fleet-operators — POST register", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp();
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("POST_with_valid_pubkey_returns_200_with_persisted_row", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A, label: "fleet-acme" },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as Record<string, unknown>;
+    expect(body.status).toBe("created");
+    const op = body.operator as Record<string, unknown>;
+    expect(op.pubkey_hex).toBe(PUB_A);
+    expect(op.label).toBe("fleet-acme");
+    expect(op.revoked_at).toBeNull();
+  });
+
+  test("POST_with_0x_prefixed_pubkey_normalises", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: "0x" + PUB_A.toUpperCase() },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { operator: { pubkey_hex: string } };
+    expect(body.operator.pubkey_hex).toBe(PUB_A);
+  });
+
+  test("POST_with_missing_pubkey_returns_400", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { label: "no-key" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("POST_with_short_pubkey_returns_400", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: "abcd" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("POST_duplicate_pubkey_returns_409", async () => {
+    const r1 = await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A, label: "first" },
+    });
+    expect(r1.status).toBe(200);
+    const r2 = await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A, label: "second" },
+    });
+    expect(r2.status).toBe(409);
+    const body2 = r2.body as Record<string, unknown>;
+    expect(body2.error).toMatch(/already registered/);
+    expect(body2.existing).toBeDefined();
+  });
+});
+
+describe("/admin/fleet-operators — DELETE revoke", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp();
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("DELETE_unknown_pubkey_returns_404", async () => {
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/fleet-operators/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("DELETE_active_returns_200_with_revoked_at_set", async () => {
+    await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A, label: "to-revoke" },
+    });
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/fleet-operators/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { status: string; operator: { revoked_at: number | null } };
+    expect(body.status).toBe("revoked");
+    expect(body.operator.revoked_at).not.toBeNull();
+  });
+
+  test("DELETE_already_revoked_returns_200_already_revoked", async () => {
+    await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A },
+    });
+    await callApp(ctx.app, "DELETE", `/admin/fleet-operators/${PUB_A}`, {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/fleet-operators/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { status: string }).status).toBe("already-revoked");
+  });
+
+  test("DELETE_invalid_pubkey_format_returns_400", async () => {
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      "/admin/fleet-operators/not-hex",
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("/admin/fleet-operators — GET list", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp();
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("GET_returns_empty_array_for_fresh_db", async () => {
+    const res = await callApp(ctx.app, "GET", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    expect(res.status).toBe(200);
+    expect((res.body as { operators: unknown[] }).operators).toEqual([]);
+  });
+
+  test("GET_returns_all_rows_including_revoked", async () => {
+    for (const p of [PUB_A, PUB_B, PUB_C]) {
+      await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+        headers: { "x-admin-token": ADMIN_TOKEN },
+        body: { pubkey: p },
+      });
+    }
+    await callApp(ctx.app, "DELETE", `/admin/fleet-operators/${PUB_A}`, {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    const res = await callApp(ctx.app, "GET", "/admin/fleet-operators", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    expect(res.status).toBe(200);
+    const ops = (res.body as { operators: Array<{ pubkey_hex: string; revoked_at: number | null }> }).operators;
+    expect(ops).toHaveLength(3);
+  });
+
+  test("GET_active_query_filters_revoked", async () => {
+    for (const p of [PUB_A, PUB_B]) {
+      await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+        headers: { "x-admin-token": ADMIN_TOKEN },
+        body: { pubkey: p },
+      });
+    }
+    await callApp(ctx.app, "DELETE", `/admin/fleet-operators/${PUB_A}`, {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    const res = await callApp(ctx.app, "GET", "/admin/fleet-operators?active=1", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    expect(res.status).toBe(200);
+    const ops = (res.body as { operators: Array<{ pubkey_hex: string }> }).operators;
+    expect(ops).toHaveLength(1);
+    expect(ops[0]!.pubkey_hex).toBe(PUB_B);
+  });
+});
+
+describe("/admin/fleet-operators — unconfigured (no admin token env)", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp({ withToken: false });
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("POST_returns_503_when_admin_token_unset", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/fleet-operators", {
+      body: { pubkey: PUB_A },
+    });
+    expect(res.status).toBe(503);
+  });
+
+  test("DELETE_returns_503_when_admin_token_unset", async () => {
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/fleet-operators/${PUB_A}`,
+    );
+    expect(res.status).toBe(503);
+  });
+
+  test("GET_returns_503_when_admin_token_unset", async () => {
+    const res = await callApp(ctx.app, "GET", "/admin/fleet-operators");
+    expect(res.status).toBe(503);
+  });
+});
+
+// ===========================================================================
+// observers — same coverage shape
+// ===========================================================================
+
+describe("/admin/observers — auth gating", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp();
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("POST_without_token_returns_401", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/observers", {
+      body: { pubkey: PUB_A },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("DELETE_without_token_returns_401", async () => {
+    const res = await callApp(ctx.app, "DELETE", `/admin/observers/${PUB_A}`);
+    expect(res.status).toBe(401);
+  });
+
+  test("GET_without_token_returns_401", async () => {
+    const res = await callApp(ctx.app, "GET", "/admin/observers");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("/admin/observers — POST + DELETE + GET", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp();
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("POST_register_returns_200", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/observers", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A, label: "watch-1" },
+    });
+    expect(res.status).toBe(200);
+    expect(((res.body as { observer: { pubkey_hex: string } }).observer.pubkey_hex)).toBe(PUB_A);
+  });
+
+  test("POST_duplicate_returns_409", async () => {
+    await callApp(ctx.app, "POST", "/admin/observers", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A },
+    });
+    const res = await callApp(ctx.app, "POST", "/admin/observers", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A },
+    });
+    expect(res.status).toBe(409);
+  });
+
+  test("POST_with_invalid_pubkey_returns_400", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/observers", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: "not-hex" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("DELETE_unknown_returns_404", async () => {
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/observers/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("DELETE_active_returns_200_revoked", async () => {
+    await callApp(ctx.app, "POST", "/admin/observers", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A },
+    });
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/observers/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { status: string }).status).toBe("revoked");
+  });
+
+  test("DELETE_idempotent_returns_already_revoked", async () => {
+    await callApp(ctx.app, "POST", "/admin/observers", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+      body: { pubkey: PUB_A },
+    });
+    await callApp(ctx.app, "DELETE", `/admin/observers/${PUB_A}`, {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/observers/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { status: string }).status).toBe("already-revoked");
+  });
+
+  test("GET_lists_active_filtered_correctly", async () => {
+    for (const p of [PUB_A, PUB_B]) {
+      await callApp(ctx.app, "POST", "/admin/observers", {
+        headers: { "x-admin-token": ADMIN_TOKEN },
+        body: { pubkey: p },
+      });
+    }
+    await callApp(ctx.app, "DELETE", `/admin/observers/${PUB_A}`, {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    const res = await callApp(ctx.app, "GET", "/admin/observers?active=true", {
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    expect(res.status).toBe(200);
+    const obs = (res.body as { observers: Array<{ pubkey_hex: string }> }).observers;
+    expect(obs).toHaveLength(1);
+    expect(obs[0]!.pubkey_hex).toBe(PUB_B);
+  });
+});
+
+describe("/admin/observers — unconfigured", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp({ withToken: false });
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("POST_returns_503_when_admin_token_unset", async () => {
+    const res = await callApp(ctx.app, "POST", "/admin/observers", {
+      body: { pubkey: PUB_A },
+    });
+    expect(res.status).toBe(503);
+  });
+});

--- a/services/blob-gateway/src/__tests__/metering_v2_live_preprod.test.ts
+++ b/services/blob-gateway/src/__tests__/metering_v2_live_preprod.test.ts
@@ -1,0 +1,379 @@
+/**
+ * LIVE PREPROD integration test for `POST /metering/submit` with
+ * `schema_version = "compute_metering_v2"`.
+ *
+ * Mirrors the existing v1 live preprod test:
+ *   1. Spin up local express app pointed at preprod RPC.
+ *   2. Build a v2 record with //Alice as the fleet operator (and pre-register
+ *      Alice's pubkey in the in-memory fleet_operators DB).
+ *   3. POST to local /metering/submit. Expect 200 + content_hash.
+ *   4. Submit submit_receipt extrinsic on-chain with //Alice + the schema_hash
+ *      = sha256("compute_metering_v2"). This proves end-to-end that the
+ *      gateway-derived schema_hash matches what an on-chain submitter would
+ *      pin.
+ *   5. Poll orinq_getReceipt until the receipt appears or deadline.
+ *
+ * Gating: LIVE_PREPROD=1. Skipped on CI by default. Run locally with:
+ *
+ *   LIVE_PREPROD=1 npx vitest run \
+ *     services/blob-gateway/src/__tests__/metering_v2_live_preprod.test.ts
+ */
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { ApiPromise, Keyring, WsProvider } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+import { createHash } from "crypto";
+
+import { config } from "../config.js";
+import { meteringRouter } from "../routes/metering.js";
+import {
+  initWorkerBoundsDb,
+  setWorkerBoundsDbForTests,
+} from "../worker_bounds.js";
+import {
+  initFleetOperatorsDb,
+  setFleetOperatorsDbForTests,
+  registerFleetOperator,
+} from "../fleet_operators.js";
+import {
+  initObserversDb,
+  setObserversDbForTests,
+} from "../observers.js";
+import {
+  canonicalCborForFleetOpSig,
+  canonicalCborForWorkerSig,
+  SCHEMA_HASH_HEX,
+  SCHEMA_VERSION,
+  type ComputeMeteringV2,
+} from "../schemas/compute_metering_v2.js";
+
+const PREPROD_WSS = "wss://materios.fluxpointstudios.com/preprod-rpc";
+const LIVE = process.env.LIVE_PREPROD === "1";
+
+const RECEIPT_APPEAR_DEADLINE_MS = 60_000;
+
+interface FakeSubmitter {
+  server: Server;
+  port: number;
+  captured: Array<{ body: string }>;
+  stop(): Promise<void>;
+}
+
+async function startFakeSubmitter(): Promise<FakeSubmitter> {
+  const captured: FakeSubmitter["captured"] = [];
+  const server = createServer((req: IncomingMessage, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      captured.push({ body: Buffer.concat(chunks).toString("utf-8") });
+      res.statusCode = 202;
+      res.setHeader("content-type", "application/json");
+      res.end('{"accepted":true}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    server,
+    port,
+    captured,
+    async stop() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+interface AppCtx {
+  app: express.Express;
+  storage: string;
+  prevStorage: string;
+  prevSubmitterUrl: string;
+  fake: FakeSubmitter;
+  workerBoundsDb: Database.Database;
+  fleetDb: Database.Database;
+  observersDb: Database.Database;
+}
+
+async function setupApp(fleetPubkeyHex: string): Promise<AppCtx> {
+  const storage = mkdtempSync(join(tmpdir(), "metering-v2-live-test-"));
+  const prevStorage = config.storagePath;
+  config.storagePath = storage;
+
+  const workerBoundsDb = new Database(":memory:");
+  initWorkerBoundsDb(workerBoundsDb);
+  setWorkerBoundsDbForTests(workerBoundsDb);
+
+  const fleetDb = new Database(":memory:");
+  initFleetOperatorsDb(fleetDb);
+  setFleetOperatorsDbForTests(fleetDb);
+  // Pre-register the fleet operator we'll be using as Alice.
+  registerFleetOperator({
+    pubkey: fleetPubkeyHex,
+    label: "live-preprod-test-fleet",
+  });
+
+  const observersDb = new Database(":memory:");
+  initObserversDb(observersDb);
+  setObserversDbForTests(observersDb);
+
+  const fake = await startFakeSubmitter();
+  const prevSubmitterUrl = config.sponsoredReceiptSubmitterUrl;
+  config.sponsoredReceiptSubmitterUrl = `http://127.0.0.1:${fake.port}/submit`;
+
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.use(meteringRouter);
+
+  return {
+    app,
+    storage,
+    prevStorage,
+    prevSubmitterUrl,
+    fake,
+    workerBoundsDb,
+    fleetDb,
+    observersDb,
+  };
+}
+
+async function teardown(ctx: AppCtx): Promise<void> {
+  config.storagePath = ctx.prevStorage;
+  config.sponsoredReceiptSubmitterUrl = ctx.prevSubmitterUrl;
+  await ctx.fake.stop();
+  rmSync(ctx.storage, { recursive: true, force: true });
+  ctx.workerBoundsDb.close();
+  ctx.fleetDb.close();
+  ctx.observersDb.close();
+}
+
+async function postJson(
+  app: express.Express,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${(addr as AddressInfo).port}${path}`;
+      fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+async function pollUntil<T>(
+  fn: () => Promise<T | undefined>,
+  opts: { deadlineMs: number; intervalMs?: number; what: string },
+): Promise<T> {
+  const deadline = Date.now() + opts.deadlineMs;
+  const interval = opts.intervalMs ?? 2000;
+  while (Date.now() < deadline) {
+    const v = await fn();
+    if (v !== undefined && v !== null) return v;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`pollUntil timeout after ${opts.deadlineMs}ms: ${opts.what}`);
+}
+
+function computeReceiptId(contentHashHex: string): string {
+  return (
+    "0x" +
+    createHash("sha256")
+      .update(Buffer.from(contentHashHex, "hex"))
+      .digest("hex")
+  );
+}
+
+const describeMaybe = LIVE ? describe : describe.skip;
+
+describeMaybe("POST /metering/submit v2 — LIVE preprod end-to-end", () => {
+  let appCtx: AppCtx;
+  let api: ApiPromise;
+  let alicePubkeyHex: string;
+
+  beforeAll(async () => {
+    await cryptoWaitReady();
+    const keyring = new Keyring({ type: "sr25519" });
+    const alice = keyring.addFromUri("//Alice");
+    alicePubkeyHex = u8aToHex(alice.publicKey, undefined, false);
+
+    appCtx = await setupApp(alicePubkeyHex);
+    const provider = new WsProvider(PREPROD_WSS, 5000);
+    api = await ApiPromise.create({ provider, noInitWarn: true });
+    const chain = (await api.rpc.system.chain()).toString();
+    if (!/preprod/i.test(chain)) {
+      throw new Error(
+        `LIVE_PREPROD pointed at unexpected chain "${chain}" — refusing to run`,
+      );
+    }
+    // eslint-disable-next-line no-console
+    console.log(`[live-preprod-v2] connected to "${chain}" via ${PREPROD_WSS}`);
+  }, 60_000);
+
+  afterAll(async () => {
+    if (api) await api.disconnect();
+    if (appCtx) await teardown(appCtx);
+  });
+
+  test(
+    "valid v2 record with //Alice fleet → 200 → on-chain receipt appears",
+    async () => {
+      const keyring = new Keyring({ type: "sr25519" });
+      const alice = keyring.addFromUri("//Alice");
+      const workerPair = keyring.addFromUri("//ComputeWorkerLiveV2" + Date.now());
+
+      const period_end_ms = Date.now() - 30_000;
+      const period_start_ms = period_end_ms - 5 * 60_000;
+      const issued_ms = period_start_ms - 60_000;
+
+      const hardware_spec_no_sig = {
+        cpu_cores: 4,
+        ram_gb: 16,
+        gpu_type: "none",
+        gpu_count: 0,
+        fleet_operator_pubkey: alicePubkeyHex,
+        issued_ms,
+      };
+
+      const fleetPreimage = canonicalCborForFleetOpSig(
+        "wkr-live-v2-" + Date.now().toString(36),
+        {
+          ...hardware_spec_no_sig,
+          fleet_operator_signature: "00".repeat(64),
+        },
+      );
+      const fleetSig = u8aToHex(alice.sign(fleetPreimage), undefined, false);
+
+      const hardware_spec = {
+        ...hardware_spec_no_sig,
+        fleet_operator_signature: fleetSig,
+      };
+
+      const recordNoSig = {
+        schema_version: SCHEMA_VERSION,
+        worker_id: "wkr-live-v2-" + Date.now().toString(36),
+        tenant_id: "ten-live-v2-" + Date.now().toString(36),
+        period_start_ms,
+        period_end_ms,
+        metrics: {
+          cpu_seconds: 12,
+          ram_gb_hours: 0.1,
+          disk_gb_hours: 0.05,
+          net_bytes_in: 4096,
+          net_bytes_out: 2048,
+          gpu_seconds: 0,
+        },
+        hardware_spec,
+        worker_pubkey: u8aToHex(workerPair.publicKey, undefined, false),
+      } as const;
+
+      const workerPreimage = canonicalCborForWorkerSig(recordNoSig);
+      const workerSig = u8aToHex(workerPair.sign(workerPreimage), undefined, false);
+      const record: ComputeMeteringV2 = {
+        ...recordNoSig,
+        worker_signature: workerSig,
+      };
+
+      // 1. POST to local /metering/submit
+      const res = await postJson(appCtx.app, "/metering/submit", record);
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        ok: true;
+        status: string;
+        content_hash: string;
+        schema_hash: string;
+        operator: string;
+        observer_present: boolean;
+      };
+      expect(body.ok).toBe(true);
+      expect(body.status).toBe("accepted");
+      expect(body.content_hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(body.schema_hash).toBe(SCHEMA_HASH_HEX);
+      expect(body.observer_present).toBe(false);
+
+      // 2. Submit on-chain via //Alice (no live submitter accessible from test).
+      const contentHashHex = body.content_hash;
+      const receiptId = computeReceiptId(contentHashHex);
+      const tx = (
+        api.tx as unknown as Record<
+          string,
+          Record<string, (...args: unknown[]) => unknown>
+        >
+      ).orinqReceipts.submitReceipt(
+        receiptId,
+        "0x" + contentHashHex,
+        "0x" + contentHashHex,
+        null,
+        null,
+        "0x" + contentHashHex,
+        "0x" + "00".repeat(32),
+        "0x" + "00".repeat(32),
+        "0x" + "00".repeat(32),
+        "0x" + "00".repeat(32),
+        "0x" + body.schema_hash,
+      );
+
+      const txHash = await new Promise<string>((resolve, reject) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (tx as any)
+          .signAndSend(alice, ({ status, dispatchError }: { status: { isInBlock: boolean; asInBlock: { toHex(): string } }; dispatchError?: unknown }) => {
+            if (dispatchError) {
+              reject(new Error(`submit_receipt dispatchError: ${String(dispatchError)}`));
+              return;
+            }
+            if (status.isInBlock) {
+              resolve(status.asInBlock.toHex());
+            }
+          })
+          .catch(reject);
+      });
+      expect(txHash).toMatch(/^0x[0-9a-f]{64}$/);
+
+      // 3. Poll for receipt appearance.
+      const receipt = await pollUntil(
+        async () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const r = await (api.rpc as any).orinq.getReceipt(receiptId);
+          if (!r || r.isNone) return undefined;
+          return r;
+        },
+        {
+          deadlineMs: RECEIPT_APPEAR_DEADLINE_MS,
+          what: "receipt to appear via orinq_getReceipt",
+        },
+      );
+      expect(receipt).toBeDefined();
+    },
+    180_000,
+  );
+});

--- a/services/blob-gateway/src/__tests__/metering_v2_route.test.ts
+++ b/services/blob-gateway/src/__tests__/metering_v2_route.test.ts
@@ -436,12 +436,16 @@ describe("POST /metering/submit v2 — Rule 1 structural", () => {
     expect((res.body as { field: string }).field).toBe("hardware_spec");
   });
 
-  test("worker_id_with_uppercase_returns_400", async () => {
+  test("tenant_id_with_uppercase_returns_400_ID_FORMAT", async () => {
+    // tenant_id has the strict regex `[a-z0-9-]{4,64}` (worker_id is
+    // intentionally looser to permit hostnames/pod-names with dots, mixed
+    // case, etc., per Team 1's schema rationale).
     const rec = buildV2();
-    (rec as unknown as Record<string, unknown>).worker_id = "Worker-001";
+    (rec as unknown as Record<string, unknown>).tenant_id = "Tenant-Acme-1";
     const res = await postJson(ctx.app, "/metering/submit", rec);
     expect(res.status).toBe(400);
     expect((res.body as { code: string }).code).toBe("ID_FORMAT");
+    expect((res.body as { field: string }).field).toBe("tenant_id");
   });
 
   test("hardware_spec_missing_cpu_cores_returns_400", async () => {
@@ -473,7 +477,7 @@ describe("POST /metering/submit v2 — Rule 2 period bounds", () => {
     expect(res.status).toBe(200);
   });
 
-  test("period_24h_plus_1ms_returns_400", async () => {
+  test("period_24h_plus_1ms_returns_400_PERIOD_INVALID", async () => {
     const end = Date.now() - 5_000;
     const start = end - 86_400_001;
     // Increase cpu_cores so we don't blow the cpu cap on this >24h period.
@@ -485,7 +489,12 @@ describe("POST /metering/submit v2 — Rule 2 period bounds", () => {
     });
     const res = await postJson(ctx.app, "/metering/submit", rec);
     expect(res.status).toBe(400);
-    expect((res.body as { code: string }).code).toBe("PERIOD_TOO_LONG");
+    // Team 1's structural validator emits a single PERIOD_INVALID code for
+    // every period anomaly (>24h, end<=start, end>now+skew). The test asserts
+    // the code + the field; the message string carries the reason ("must be
+    // <= 86_400_000 ms (24 h)") for callers who want to surface specifics.
+    expect((res.body as { code: string }).code).toBe("PERIOD_INVALID");
+    expect((res.body as { field: string }).field).toBe("period_end_ms");
   });
 });
 
@@ -502,13 +511,16 @@ describe("POST /metering/submit v2 — Rule 3 clock skew", () => {
     await teardown(ctx);
   });
 
-  test("period_end_in_far_future_returns_400_PERIOD_FUTURE_SKEW", async () => {
+  test("period_end_in_far_future_returns_400_PERIOD_INVALID", async () => {
     const end = Date.now() + 5 * 60 * 1000; // 5 minutes ahead
     const start = end - 60_000;
     const rec = buildV2({ period_start_ms: start, period_end_ms: end });
     const res = await postJson(ctx.app, "/metering/submit", rec);
     expect(res.status).toBe(400);
-    expect((res.body as { code: string }).code).toBe("PERIOD_FUTURE_SKEW");
+    // Same union code as period_24h_plus_1ms; differentiation is in `message`.
+    expect((res.body as { code: string }).code).toBe("PERIOD_INVALID");
+    expect((res.body as { field: string }).field).toBe("period_end_ms");
+    expect((res.body as { message: string }).message).toMatch(/skew/i);
   });
 
   test("period_end_within_60s_skew_passes", async () => {
@@ -578,7 +590,7 @@ describe("POST /metering/submit v2 — Rules 5/6 hardware caps", () => {
     expect(res.status).toBe(200);
   });
 
-  test("cpu_seconds_just_over_cap_returns_422_CPU_OVER_HARDWARE", async () => {
+  test("cpu_seconds_just_over_cap_returns_422_BOUND_EXCEEDED", async () => {
     const cpuCores = 1;
     const periodMs = 3_600_000;
     const end = Date.now() - 5_000;
@@ -592,7 +604,11 @@ describe("POST /metering/submit v2 — Rules 5/6 hardware caps", () => {
     });
     const res = await postJson(ctx.app, "/metering/submit", rec);
     expect(res.status).toBe(422);
-    expect((res.body as { code: string }).code).toBe("CPU_OVER_HARDWARE");
+    // Team 1's structural validator emits the union code BOUND_EXCEEDED for
+    // every cpu/ram cap overshoot (rules 5 and 6 in the spec); the field
+    // disambiguates `metrics.cpu_seconds` from `metrics.ram_gb_hours`.
+    expect((res.body as { code: string }).code).toBe("BOUND_EXCEEDED");
+    expect((res.body as { field: string }).field).toBe("metrics.cpu_seconds");
   });
 
   test("ram_gb_hours_at_exactly_1_05x_cap_passes", async () => {
@@ -611,7 +627,7 @@ describe("POST /metering/submit v2 — Rules 5/6 hardware caps", () => {
     expect(res.status).toBe(200);
   });
 
-  test("ram_gb_hours_just_over_cap_returns_422_RAM_OVER_HARDWARE", async () => {
+  test("ram_gb_hours_just_over_cap_returns_422_BOUND_EXCEEDED", async () => {
     const ramGb = 4;
     const periodHr = 1;
     const end = Date.now() - 5_000;
@@ -625,7 +641,8 @@ describe("POST /metering/submit v2 — Rules 5/6 hardware caps", () => {
     });
     const res = await postJson(ctx.app, "/metering/submit", rec);
     expect(res.status).toBe(422);
-    expect((res.body as { code: string }).code).toBe("RAM_OVER_HARDWARE");
+    expect((res.body as { code: string }).code).toBe("BOUND_EXCEEDED");
+    expect((res.body as { field: string }).field).toBe("metrics.ram_gb_hours");
   });
 });
 
@@ -642,8 +659,13 @@ describe("POST /metering/submit v2 — Rule 7 gpu consistency", () => {
     await teardown(ctx);
   });
 
+  // Team 1's GPU_TYPES enum is the closed set
+  // ["none","nvidia-h100","nvidia-h200","nvidia-b100","nvidia-a100",
+  //  "amd-mi300","custom"]. Plain "h100" / "a100" are NOT in the set, so
+  // we use the fully-prefixed names below. (Earlier Team-2 stubs used the
+  // short form; the canonical schema requires the vendor prefix.)
   test("gpu_seconds_nonzero_with_gpu_count_zero_returns_422", async () => {
-    const rec = buildV2({ gpu_type: "h100", gpu_count: 0, gpu_seconds: 100 });
+    const rec = buildV2({ gpu_type: "nvidia-h100", gpu_count: 0, gpu_seconds: 100 });
     const res = await postJson(ctx.app, "/metering/submit", rec);
     expect(res.status).toBe(422);
     expect((res.body as { code: string }).code).toBe("GPU_COUNT_MISMATCH");
@@ -664,9 +686,19 @@ describe("POST /metering/submit v2 — Rule 7 gpu consistency", () => {
 
   test("gpu_seconds_nonzero_with_real_gpu_passes", async () => {
     // 1 GPU × 3600s × 1.05 = 3780s budget
-    const rec = buildV2({ gpu_type: "a100", gpu_count: 1, gpu_seconds: 3000 });
+    const rec = buildV2({ gpu_type: "nvidia-a100", gpu_count: 1, gpu_seconds: 3000 });
     const res = await postJson(ctx.app, "/metering/submit", rec);
     expect(res.status).toBe(200);
+  });
+
+  test("gpu_type_short_form_h100_returns_400_GPU_TYPE_INVALID", async () => {
+    // Belt-and-suspenders: documents that the GPU_TYPES set is closed and
+    // that historical short-form aliases ("h100", "a100") are rejected at
+    // the gateway. Surfaces a regression if someone re-loosens the enum.
+    const rec = buildV2({ gpu_type: "h100", gpu_count: 1, gpu_seconds: 0 });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("GPU_TYPE_INVALID");
   });
 });
 

--- a/services/blob-gateway/src/__tests__/metering_v2_route.test.ts
+++ b/services/blob-gateway/src/__tests__/metering_v2_route.test.ts
@@ -1,0 +1,996 @@
+/**
+ * End-to-end integration tests for `POST /metering/submit` with
+ * `schema_version = "compute_metering_v2"`.
+ *
+ * Real express server. Real schema validator. Real on-disk SQLite for the
+ * metering_submissions billing table; real in-memory SQLite for the trust
+ * registries (fleet_operators, observers). Real Polkadot crypto for sr25519
+ * signatures (no mocked verifies). Real fake HTTP server for the sponsored-
+ * receipt-submitter to verify outbound notify shape.
+ *
+ * Coverage matrix — 11 rules from the spec, positive + negative + edge:
+ *
+ *   Rule 1 (schema): malformed JSON, missing field, wrong type, wrong version
+ *   Rule 2 (period bounds): exactly 24h OK, 24h+1ms reject
+ *   Rule 3 (clock skew): now+60s OK, now+61s reject
+ *   Rule 4 (non-negative metrics): negative cpu_seconds rejected
+ *   Rule 5 (cpu hardware bound): exactly 1.05× OK, just over reject
+ *   Rule 6 (ram hardware bound): exactly 1.05× OK, just over reject
+ *   Rule 7 (gpu consistency): gpu_count=0 + gpu_seconds>0 rejected
+ *   Rule 8 (fleet operator known): unknown rejected, revoked rejected
+ *   Rule 9 (fleet operator sig): tampered sig rejected
+ *   Rule 10 (worker sig): tampered sig rejected
+ *   Rule 11 (observer): missing observer OK, present+valid OK,
+ *                        unknown observer pubkey rejected, revoked rejected,
+ *                        present+invalid sig rejected
+ *
+ *   Replay: same content_hash → 200 status:replay, no second notify
+ *   Monotonic: earlier period_start_ms → 409
+ *
+ *   v1 backward-compat: a v1 record still flows through the v1 path
+ */
+import { describe, test, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { Keyring } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+
+import { config } from "../config.js";
+import { meteringRouter } from "../routes/metering.js";
+import {
+  initWorkerBoundsDb,
+  setWorkerBoundsDbForTests,
+} from "../worker_bounds.js";
+import {
+  initFleetOperatorsDb,
+  setFleetOperatorsDbForTests,
+  registerFleetOperator,
+  revokeFleetOperator,
+} from "../fleet_operators.js";
+import {
+  initObserversDb,
+  setObserversDbForTests,
+  registerObserver,
+  revokeObserver,
+} from "../observers.js";
+import {
+  canonicalCborForFleetOpSig,
+  canonicalCborForWorkerSig,
+  SCHEMA_HASH_HEX,
+  SCHEMA_VERSION,
+  type ComputeMeteringV2,
+} from "../schemas/compute_metering_v2.js";
+import {
+  canonicalBody as canonicalBodyV1,
+  SCHEMA_VERSION as SCHEMA_VERSION_V1,
+} from "../schemas/compute_metering_v1.js";
+
+let keyring: Keyring;
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+  keyring = new Keyring({ type: "sr25519" });
+});
+
+interface FakeSubmitter {
+  server: Server;
+  port: number;
+  captured: Array<{ method: string; url: string; body: string }>;
+  stop(): Promise<void>;
+}
+
+async function startFakeSubmitter(): Promise<FakeSubmitter> {
+  const captured: FakeSubmitter["captured"] = [];
+  const server = createServer((req: IncomingMessage, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      captured.push({
+        method: req.method || "",
+        url: req.url || "",
+        body: Buffer.concat(chunks).toString("utf-8"),
+      });
+      res.statusCode = 202;
+      res.setHeader("content-type", "application/json");
+      res.end('{"accepted":true}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    server,
+    port,
+    captured,
+    async stop() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+interface BuildOpts {
+  workerUri?: string;
+  fleetUri?: string;
+  observerUri?: string;
+  withObserver?: boolean;
+  worker_id?: string;
+  tenant_id?: string;
+  period_start_ms?: number;
+  period_end_ms?: number;
+  cpu_seconds?: number;
+  ram_gb_hours?: number;
+  disk_gb_hours?: number;
+  net_bytes_in?: number;
+  net_bytes_out?: number;
+  gpu_seconds?: number;
+  cpu_cores?: number;
+  ram_gb?: number;
+  gpu_type?: string;
+  gpu_count?: number;
+  issued_ms?: number;
+}
+
+/**
+ * Build a fully-signed valid v2 record. Override any field via opts. Default
+ * fleet operator URI is `//FleetOp0`; override via fleetUri. Observer present
+ * iff withObserver=true (defaults to false).
+ */
+function buildV2(opts: BuildOpts = {}): ComputeMeteringV2 {
+  const workerPair = keyring.addFromUri(opts.workerUri ?? "//ComputeWorker0");
+  const fleetPair = keyring.addFromUri(opts.fleetUri ?? "//FleetOp0");
+  const now = Date.now();
+  const period_end_ms = opts.period_end_ms ?? now - 5_000;
+  const period_start_ms = opts.period_start_ms ?? period_end_ms - 3_600_000;
+
+  const hardware_spec_no_sig = {
+    cpu_cores: opts.cpu_cores ?? 8,
+    ram_gb: opts.ram_gb ?? 32,
+    gpu_type: opts.gpu_type ?? "none",
+    gpu_count: opts.gpu_count ?? 0,
+    fleet_operator_pubkey: u8aToHex(fleetPair.publicKey, undefined, false),
+    issued_ms: opts.issued_ms ?? period_start_ms - 60_000,
+  };
+
+  const fleetPreimage = canonicalCborForFleetOpSig(
+    opts.worker_id ?? "worker-v2-001",
+    {
+      ...hardware_spec_no_sig,
+      // signature absent — encoder uses _no_sig form internally
+      fleet_operator_signature: "00".repeat(64),
+    },
+  );
+  const fleetSig = u8aToHex(fleetPair.sign(fleetPreimage), undefined, false);
+
+  const hardware_spec = {
+    ...hardware_spec_no_sig,
+    fleet_operator_signature: fleetSig,
+  };
+
+  const metrics = {
+    cpu_seconds: opts.cpu_seconds ?? 30,
+    ram_gb_hours: opts.ram_gb_hours ?? 0.5,
+    disk_gb_hours: opts.disk_gb_hours ?? 1,
+    net_bytes_in: opts.net_bytes_in ?? 1024,
+    net_bytes_out: opts.net_bytes_out ?? 512,
+    gpu_seconds: opts.gpu_seconds ?? 0,
+  };
+
+  const recordNoSig = {
+    schema_version: SCHEMA_VERSION,
+    worker_id: opts.worker_id ?? "worker-v2-001",
+    tenant_id: opts.tenant_id ?? "tenant-acme-1",
+    period_start_ms,
+    period_end_ms,
+    metrics,
+    hardware_spec,
+    worker_pubkey: u8aToHex(workerPair.publicKey, undefined, false),
+  } as const;
+
+  const workerPreimage = canonicalCborForWorkerSig(recordNoSig);
+  const workerSig = u8aToHex(workerPair.sign(workerPreimage), undefined, false);
+
+  let observer: ComputeMeteringV2["observer"];
+  if (opts.withObserver) {
+    const observerPair = keyring.addFromUri(opts.observerUri ?? "//Observer0");
+    const observerSig = u8aToHex(observerPair.sign(workerPreimage), undefined, false);
+    observer = {
+      observer_pubkey: u8aToHex(observerPair.publicKey, undefined, false),
+      observer_signature: observerSig,
+    };
+  }
+
+  return {
+    ...recordNoSig,
+    worker_signature: workerSig,
+    ...(observer ? { observer } : {}),
+  };
+}
+
+interface Ctx {
+  app: express.Express;
+  storage: string;
+  prevStorage: string;
+  prevSubmitterUrl: string;
+  prevSubmitterTimeout: number;
+  fake: FakeSubmitter;
+  workerBoundsDb: Database.Database;
+  fleetDb: Database.Database;
+  observersDb: Database.Database;
+}
+
+async function setupApp(): Promise<Ctx> {
+  const storage = mkdtempSync(join(tmpdir(), "metering-v2-test-"));
+  const prevStorage = config.storagePath;
+  config.storagePath = storage;
+
+  const workerBoundsDb = new Database(":memory:");
+  initWorkerBoundsDb(workerBoundsDb);
+  setWorkerBoundsDbForTests(workerBoundsDb);
+
+  const fleetDb = new Database(":memory:");
+  initFleetOperatorsDb(fleetDb);
+  setFleetOperatorsDbForTests(fleetDb);
+
+  const observersDb = new Database(":memory:");
+  initObserversDb(observersDb);
+  setObserversDbForTests(observersDb);
+
+  const fake = await startFakeSubmitter();
+  const prevSubmitterUrl = config.sponsoredReceiptSubmitterUrl;
+  const prevSubmitterTimeout = config.sponsoredReceiptNotifyTimeoutMs;
+  config.sponsoredReceiptSubmitterUrl = `http://127.0.0.1:${fake.port}/submit`;
+  config.sponsoredReceiptNotifyTimeoutMs = 5000;
+
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.use(meteringRouter);
+
+  // Pre-register the default fleet operator used by buildV2().
+  const defaultFleet = keyring.addFromUri("//FleetOp0");
+  registerFleetOperator({
+    pubkey: u8aToHex(defaultFleet.publicKey, undefined, false),
+    label: "default-test-fleet",
+  });
+
+  return {
+    app,
+    storage,
+    prevStorage,
+    prevSubmitterUrl,
+    prevSubmitterTimeout,
+    fake,
+    workerBoundsDb,
+    fleetDb,
+    observersDb,
+  };
+}
+
+async function teardown(ctx: Ctx): Promise<void> {
+  config.storagePath = ctx.prevStorage;
+  config.sponsoredReceiptSubmitterUrl = ctx.prevSubmitterUrl;
+  config.sponsoredReceiptNotifyTimeoutMs = ctx.prevSubmitterTimeout;
+  await ctx.fake.stop();
+  rmSync(ctx.storage, { recursive: true, force: true });
+  ctx.workerBoundsDb.close();
+  ctx.fleetDb.close();
+  ctx.observersDb.close();
+}
+
+async function postJson(
+  app: express.Express,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  opts: { deadlineMs: number; what: string },
+): Promise<void> {
+  const deadline = Date.now() + opts.deadlineMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`waitFor timeout after ${opts.deadlineMs}ms: ${opts.what}`);
+}
+
+// ===========================================================================
+// Happy path — bare record (no observer)
+// ===========================================================================
+
+describe("POST /metering/submit v2 — happy path", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("valid_v2_record_returns_200_accepted", async () => {
+    const rec = buildV2();
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+    const body = res.body as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.status).toBe("accepted");
+    expect(body.schema_hash).toBe(SCHEMA_HASH_HEX);
+    expect(body.worker_id).toBe(rec.worker_id);
+    expect(body.observer_present).toBe(false);
+    expect(body.content_hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("manifest_persisted_with_v2_schema_marker", async () => {
+    const rec = buildV2({ worker_id: "worker-manifest-test" });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+    const ch = (res.body as { content_hash: string }).content_hash;
+    const manifestPath = join(ctx.storage, "receipts", ch, "manifest.json");
+    expect(existsSync(manifestPath)).toBe(true);
+    const stored = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+      schema: string;
+      record: ComputeMeteringV2;
+      rootHash: string;
+    };
+    expect(stored.schema).toBe(SCHEMA_VERSION);
+    expect(stored.record.worker_id).toBe("worker-manifest-test");
+    expect(stored.rootHash).toBe(ch);
+  });
+
+  test("submitter_notified_with_v2_schemaHash_and_source", async () => {
+    const rec = buildV2({ worker_id: "worker-notify-test" });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+    await waitFor(() => ctx.fake.captured.length === 1, {
+      deadlineMs: 2000,
+      what: "submitter notify",
+    });
+    const captured = ctx.fake.captured[0]!;
+    const body = JSON.parse(captured.body) as Record<string, unknown>;
+    expect(body.schemaHash).toBe(SCHEMA_HASH_HEX);
+    expect(body.source).toBe("compute-metering-v2");
+    expect(body.contentHash).toBe((res.body as { content_hash: string }).content_hash);
+  });
+
+  test("valid_v2_record_with_observer_returns_200_observer_present_true", async () => {
+    const rec = buildV2({
+      worker_id: "worker-observer-test",
+      withObserver: true,
+    });
+    // Pre-register observer
+    registerObserver({
+      pubkey: rec.observer!.observer_pubkey,
+      label: "test-obs",
+    });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+    const body = res.body as Record<string, unknown>;
+    expect(body.status).toBe("accepted");
+    expect(body.observer_present).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Rule 1 — structural validation
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rule 1 structural", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("missing_metrics_returns_400_with_field_metrics", async () => {
+    const rec = buildV2() as Record<string, unknown>;
+    delete rec.metrics;
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string; field: string }).field).toBe("metrics");
+  });
+
+  test("missing_hardware_spec_returns_400", async () => {
+    const rec = buildV2() as Record<string, unknown>;
+    delete rec.hardware_spec;
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(400);
+    expect((res.body as { field: string }).field).toBe("hardware_spec");
+  });
+
+  test("worker_id_with_uppercase_returns_400", async () => {
+    const rec = buildV2();
+    (rec as unknown as Record<string, unknown>).worker_id = "Worker-001";
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("ID_FORMAT");
+  });
+
+  test("hardware_spec_missing_cpu_cores_returns_400", async () => {
+    const rec = buildV2();
+    delete (rec.hardware_spec as Record<string, unknown>).cpu_cores;
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ===========================================================================
+// Rule 2 — period_end_ms - period_start_ms <= 86_400_000 (24h)
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rule 2 period bounds", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("period_exactly_24h_passes", async () => {
+    const end = Date.now() - 5_000;
+    const start = end - 86_400_000;
+    const rec = buildV2({ period_start_ms: start, period_end_ms: end });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+  });
+
+  test("period_24h_plus_1ms_returns_400", async () => {
+    const end = Date.now() - 5_000;
+    const start = end - 86_400_001;
+    // Increase cpu_cores so we don't blow the cpu cap on this >24h period.
+    const rec = buildV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      cpu_cores: 1,
+      cpu_seconds: 0,
+    });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("PERIOD_TOO_LONG");
+  });
+});
+
+// ===========================================================================
+// Rule 3 — period_end_ms <= now + 60_000
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rule 3 clock skew", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("period_end_in_far_future_returns_400_PERIOD_FUTURE_SKEW", async () => {
+    const end = Date.now() + 5 * 60 * 1000; // 5 minutes ahead
+    const start = end - 60_000;
+    const rec = buildV2({ period_start_ms: start, period_end_ms: end });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("PERIOD_FUTURE_SKEW");
+  });
+
+  test("period_end_within_60s_skew_passes", async () => {
+    const end = Date.now() + 30_000; // within 60s tolerance
+    const start = end - 60_000;
+    const rec = buildV2({ period_start_ms: start, period_end_ms: end });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+  });
+});
+
+// ===========================================================================
+// Rule 4 — non-negative metrics
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rule 4 non-negative", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("negative_cpu_seconds_returns_422", async () => {
+    const rec = buildV2();
+    (rec.metrics as Record<string, unknown>).cpu_seconds = -1;
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(422);
+    expect((res.body as { code: string }).code).toBe("NEGATIVE_VALUE");
+  });
+
+  test("negative_ram_gb_hours_returns_422", async () => {
+    const rec = buildV2();
+    (rec.metrics as Record<string, unknown>).ram_gb_hours = -0.001;
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(422);
+  });
+});
+
+// ===========================================================================
+// Rules 5 + 6 — hardware caps with 5% tolerance
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rules 5/6 hardware caps", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("cpu_seconds_at_exactly_1_05x_cap_passes", async () => {
+    const cpuCores = 1;
+    const periodMs = 3_600_000;
+    const end = Date.now() - 5_000;
+    const start = end - periodMs;
+    const cap = (cpuCores * periodMs * 1.05) / 1000; // = 3780 with 5% tolerance
+    const rec = buildV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      cpu_cores: cpuCores,
+      cpu_seconds: Math.floor(cap), // floor to keep int for u64 metric
+    });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+  });
+
+  test("cpu_seconds_just_over_cap_returns_422_CPU_OVER_HARDWARE", async () => {
+    const cpuCores = 1;
+    const periodMs = 3_600_000;
+    const end = Date.now() - 5_000;
+    const start = end - periodMs;
+    const cap = (cpuCores * periodMs * 1.05) / 1000; // 3780
+    const rec = buildV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      cpu_cores: cpuCores,
+      cpu_seconds: Math.ceil(cap) + 1,
+    });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(422);
+    expect((res.body as { code: string }).code).toBe("CPU_OVER_HARDWARE");
+  });
+
+  test("ram_gb_hours_at_exactly_1_05x_cap_passes", async () => {
+    const ramGb = 4;
+    const periodHr = 1; // 1h
+    const end = Date.now() - 5_000;
+    const start = end - 3_600_000;
+    const cap = ramGb * periodHr * 1.05;
+    const rec = buildV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      ram_gb: ramGb,
+      ram_gb_hours: cap, // exactly 4.2
+    });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+  });
+
+  test("ram_gb_hours_just_over_cap_returns_422_RAM_OVER_HARDWARE", async () => {
+    const ramGb = 4;
+    const periodHr = 1;
+    const end = Date.now() - 5_000;
+    const start = end - 3_600_000;
+    const cap = ramGb * periodHr * 1.05;
+    const rec = buildV2({
+      period_start_ms: start,
+      period_end_ms: end,
+      ram_gb: ramGb,
+      ram_gb_hours: cap + 0.01,
+    });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(422);
+    expect((res.body as { code: string }).code).toBe("RAM_OVER_HARDWARE");
+  });
+});
+
+// ===========================================================================
+// Rule 7 — GPU consistency
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rule 7 gpu consistency", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("gpu_seconds_nonzero_with_gpu_count_zero_returns_422", async () => {
+    const rec = buildV2({ gpu_type: "h100", gpu_count: 0, gpu_seconds: 100 });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(422);
+    expect((res.body as { code: string }).code).toBe("GPU_COUNT_MISMATCH");
+  });
+
+  test("gpu_seconds_nonzero_with_gpu_type_none_returns_422", async () => {
+    const rec = buildV2({ gpu_type: "none", gpu_count: 4, gpu_seconds: 100 });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(422);
+    expect((res.body as { code: string }).code).toBe("GPU_COUNT_MISMATCH");
+  });
+
+  test("gpu_seconds_zero_with_gpu_type_none_passes", async () => {
+    const rec = buildV2({ gpu_type: "none", gpu_count: 0, gpu_seconds: 0 });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+  });
+
+  test("gpu_seconds_nonzero_with_real_gpu_passes", async () => {
+    // 1 GPU × 3600s × 1.05 = 3780s budget
+    const rec = buildV2({ gpu_type: "a100", gpu_count: 1, gpu_seconds: 3000 });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+  });
+});
+
+// ===========================================================================
+// Rule 8 — fleet operator must be registered + not revoked
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rule 8 fleet operator known", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("unknown_fleet_operator_returns_403", async () => {
+    const rec = buildV2({ fleetUri: "//UnregisteredFleet" });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(403);
+    expect((res.body as { code: string }).code).toBe("FLEET_OPERATOR_UNKNOWN");
+  });
+
+  test("revoked_fleet_operator_returns_403", async () => {
+    const rec = buildV2();
+    revokeFleetOperator(rec.hardware_spec.fleet_operator_pubkey);
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(403);
+    expect((res.body as { code: string }).code).toBe("FLEET_OPERATOR_UNKNOWN");
+  });
+});
+
+// ===========================================================================
+// Rule 9 — fleet operator signature must verify
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rule 9 fleet sig", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("tampered_fleet_operator_signature_returns_401", async () => {
+    const rec = buildV2();
+    // Flip last byte of fleet_operator_signature
+    const orig = rec.hardware_spec.fleet_operator_signature;
+    rec.hardware_spec.fleet_operator_signature =
+      orig.slice(0, -2) + (orig.endsWith("ff") ? "00" : "ff");
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(401);
+    expect((res.body as { code: string }).code).toBe("FLEET_OPERATOR_SIG_INVALID");
+  });
+
+  test("fleet_signature_signed_by_different_key_returns_401", async () => {
+    const rec = buildV2();
+    // Re-sign the fleet preimage with a DIFFERENT key — the sig is well-formed
+    // but not by the declared fleet_operator_pubkey.
+    const wrong = keyring.addFromUri("//Eve");
+    const fleetPreimage = canonicalCborForFleetOpSig(rec.worker_id, rec.hardware_spec);
+    rec.hardware_spec.fleet_operator_signature = u8aToHex(
+      wrong.sign(fleetPreimage),
+      undefined,
+      false,
+    );
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(401);
+    expect((res.body as { code: string }).code).toBe("FLEET_OPERATOR_SIG_INVALID");
+  });
+});
+
+// ===========================================================================
+// Rule 10 — worker signature must verify
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rule 10 worker sig", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("tampered_worker_signature_returns_401", async () => {
+    const rec = buildV2();
+    rec.worker_signature = rec.worker_signature.slice(0, -2) +
+      (rec.worker_signature.endsWith("ff") ? "00" : "ff");
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(401);
+    expect((res.body as { code: string }).code).toBe("WORKER_SIG_INVALID");
+  });
+
+  test("tampered_metrics_after_signing_returns_worker_sig_invalid", async () => {
+    const rec = buildV2();
+    // Bump cpu_seconds AFTER worker signed → worker sig no longer covers this body.
+    rec.metrics.cpu_seconds = 99;
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(401);
+    expect((res.body as { code: string }).code).toBe("WORKER_SIG_INVALID");
+  });
+});
+
+// ===========================================================================
+// Rule 11 — observer behaviour
+// ===========================================================================
+
+describe("POST /metering/submit v2 — Rule 11 observer", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("observer_pubkey_unknown_returns_403", async () => {
+    const rec = buildV2({ withObserver: true, observerUri: "//UnknownObs" });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(403);
+    expect((res.body as { code: string }).code).toBe("OBSERVER_UNKNOWN");
+  });
+
+  test("observer_revoked_returns_403", async () => {
+    const rec = buildV2({ withObserver: true });
+    registerObserver({ pubkey: rec.observer!.observer_pubkey });
+    revokeObserver(rec.observer!.observer_pubkey);
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(403);
+    expect((res.body as { code: string }).code).toBe("OBSERVER_UNKNOWN");
+  });
+
+  test("observer_present_with_invalid_sig_returns_401", async () => {
+    const rec = buildV2({ withObserver: true });
+    registerObserver({ pubkey: rec.observer!.observer_pubkey });
+    rec.observer!.observer_signature =
+      rec.observer!.observer_signature.slice(0, -2) +
+      (rec.observer!.observer_signature.endsWith("ff") ? "00" : "ff");
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(401);
+    expect((res.body as { code: string }).code).toBe("OBSERVER_SIG_INVALID");
+  });
+
+  test("observer_present_with_wrong_key_returns_401", async () => {
+    // Observer pubkey claims to be A but signature is by B
+    const rec = buildV2({ withObserver: true });
+    registerObserver({ pubkey: rec.observer!.observer_pubkey });
+    const wrong = keyring.addFromUri("//Eve");
+    // Re-sign the worker preimage with a different key, but keep declared pubkey.
+    const wp = canonicalCborForWorkerSig(rec);
+    rec.observer!.observer_signature = u8aToHex(wrong.sign(wp), undefined, false);
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(401);
+    expect((res.body as { code: string }).code).toBe("OBSERVER_SIG_INVALID");
+  });
+
+  test("observer_omitted_from_record_passes", async () => {
+    const rec = buildV2({ withObserver: false });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+    expect((res.body as { observer_present: boolean }).observer_present).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Replay + monotonic
+// ===========================================================================
+
+describe("POST /metering/submit v2 — replay + monotonic", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("identical_record_resubmitted_returns_200_status_replay_no_double_notify", async () => {
+    const rec = buildV2({ worker_id: "worker-replay" });
+    const r1 = await postJson(ctx.app, "/metering/submit", rec);
+    expect(r1.status).toBe(200);
+    expect((r1.body as { status: string }).status).toBe("accepted");
+    await waitFor(() => ctx.fake.captured.length === 1, {
+      deadlineMs: 2000,
+      what: "first notify",
+    });
+
+    const r2 = await postJson(ctx.app, "/metering/submit", rec);
+    expect(r2.status).toBe(200);
+    expect((r2.body as { status: string }).status).toBe("replay");
+    // Must NOT double-notify.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(ctx.fake.captured).toHaveLength(1);
+  });
+
+  test("monotonic_violation_earlier_period_start_returns_409", async () => {
+    const baseEnd = Date.now() - 5_000;
+    const baseStart = baseEnd - 3_600_000;
+    const first = buildV2({
+      worker_id: "worker-mono",
+      period_start_ms: baseStart,
+      period_end_ms: baseEnd,
+    });
+    const r1 = await postJson(ctx.app, "/metering/submit", first);
+    expect(r1.status).toBe(200);
+
+    const earlier = buildV2({
+      worker_id: "worker-mono",
+      period_start_ms: baseStart - 60_000,
+      period_end_ms: baseStart - 1000,
+    });
+    const r2 = await postJson(ctx.app, "/metering/submit", earlier);
+    expect(r2.status).toBe(409);
+    expect((r2.body as { code: string }).code).toBe("MONOTONIC_VIOLATION");
+  });
+});
+
+// ===========================================================================
+// Backward compat: v1 records still flow through v1 path
+// ===========================================================================
+
+describe("POST /metering/submit v2 dispatcher — v1 backward compat", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("v1_record_with_v1_schema_version_uses_v1_path_unchanged", async () => {
+    const pair = keyring.addFromUri("//ComputeWorkerLegacy");
+    const now = Date.now();
+    const period_end = now - 5_000;
+    const period_start = period_end - 3_600_000;
+    const v1Body = {
+      schema_version: SCHEMA_VERSION_V1,
+      worker_id: "v1-worker-001",
+      tenant_id: "v1-tenant",
+      period_start,
+      period_end,
+      cpu_seconds: 30,
+      ram_gb_hours: 0.5,
+      disk_gb_hours: 1,
+      net_bytes_in: 1024,
+      net_bytes_out: 512,
+      gpu_seconds: 0,
+      worker_pubkey: u8aToHex(pair.publicKey, undefined, false),
+    };
+    const sig = u8aToHex(pair.sign(canonicalBodyV1(v1Body)), undefined, false);
+    const v1Record = { ...v1Body, worker_signature: sig };
+    const res = await postJson(ctx.app, "/metering/submit", v1Record);
+    expect(res.status).toBe(200);
+    const body = res.body as Record<string, unknown>;
+    // v1 path returns `accepted`, with a content_hash and worker_id, but NOT
+    // an `observer_present` field (v2-only).
+    expect(body.status).toBe("accepted");
+    expect("observer_present" in body).toBe(false);
+  });
+
+  test("unknown_schema_version_falls_through_to_v1_validator_for_clear_error", async () => {
+    const rec = { schema_version: "compute_metering_vfuture", foo: "bar" };
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(422);
+    expect((res.body as { code: string }).code).toBe("WRONG_SCHEMA_VERSION");
+  });
+});
+
+// ===========================================================================
+// Audit logs
+// ===========================================================================
+
+describe("POST /metering/submit v2 — audit logs", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("auth_fail_for_revoked_fleet_emits_metering_v2_auth_fail_log", async () => {
+    const warnSpy = (() => {
+      const captured: string[] = [];
+      const orig = console.warn;
+      console.warn = (msg?: unknown) => captured.push(String(msg));
+      return {
+        captured,
+        restore: () => { console.warn = orig; },
+      };
+    })();
+    try {
+      const rec = buildV2();
+      revokeFleetOperator(rec.hardware_spec.fleet_operator_pubkey);
+      await postJson(ctx.app, "/metering/submit", rec);
+      const found = warnSpy.captured.find((line) =>
+        line.includes("metering_v2_auth_fail") &&
+        line.includes("fleet_operator_unknown_or_revoked"),
+      );
+      expect(found).toBeDefined();
+      // Must NOT include the full pubkey (only first 16 hex chars).
+      const fullPub = rec.hardware_spec.fleet_operator_pubkey;
+      expect(found!.includes(fullPub)).toBe(false);
+      expect(found).toContain(fullPub.slice(0, 16));
+    } finally {
+      warnSpy.restore();
+    }
+  });
+
+  test("auth_fail_log_does_not_include_signature_bytes", async () => {
+    const captured: string[] = [];
+    const orig = console.warn;
+    console.warn = (msg?: unknown) => captured.push(String(msg));
+    try {
+      const rec = buildV2();
+      rec.worker_signature = rec.worker_signature.slice(0, -2) + "00";
+      await postJson(ctx.app, "/metering/submit", rec);
+      const all = captured.join("\n");
+      // Signature is 128 hex chars; if any 64+ chunk of it appears we've leaked.
+      expect(all.includes(rec.worker_signature.slice(0, 64))).toBe(false);
+    } finally {
+      console.warn = orig;
+    }
+  });
+});

--- a/services/blob-gateway/src/__tests__/observers.test.ts
+++ b/services/blob-gateway/src/__tests__/observers.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Unit tests for observers.ts (compute_metering_v2 optional observer registry).
+ *
+ * Mirrors fleet_operators.test.ts in shape — same migration pattern, same CRUD
+ * surface, same on-disk SQLite verification. Kept as a separate test file
+ * (not parameterised) so a regression in one registry's wire-up doesn't get
+ * masked by the other passing.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  initObserversDb,
+  setObserversDbForTests,
+  getObserversDb,
+  registerObserver,
+  revokeObserver,
+  getObserver,
+  isObserverActive,
+  listObservers,
+} from "../observers.js";
+
+const PUB_A = "1".repeat(64);
+const PUB_B = "2".repeat(64);
+const PUB_C = "3".repeat(64);
+
+function makeMemDb(): Database.Database {
+  const db = new Database(":memory:");
+  initObserversDb(db);
+  setObserversDbForTests(db);
+  return db;
+}
+
+describe("observers: in-memory migration", () => {
+  test("initObserversDb_creates_table_idempotently", () => {
+    const db = new Database(":memory:");
+    initObserversDb(db);
+    initObserversDb(db);
+    initObserversDb(db);
+    const cols = db.prepare("PRAGMA table_info(observers)").all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual([
+      "id",
+      "label",
+      "notes",
+      "pubkey_hex",
+      "registered_at",
+      "revoked_at",
+    ]);
+  });
+
+  test("indexes_created_for_pubkey_lookup_and_active_filter", () => {
+    const db = new Database(":memory:");
+    initObserversDb(db);
+    const idxs = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='observers'")
+      .all() as Array<{ name: string }>;
+    const idxNames = idxs.map((i) => i.name).sort();
+    expect(idxNames).toContain("idx_observers_pubkey");
+    expect(idxNames).toContain("idx_observers_active");
+  });
+});
+
+describe("observers: real on-disk SQLite migration", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "observers-disk-"));
+    dbPath = join(tmpDir, "observers.db");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("fresh_on_disk_file_gets_full_schema_after_first_init", () => {
+    expect(existsSync(dbPath)).toBe(false);
+    const db = new Database(dbPath);
+    initObserversDb(db);
+    db.close();
+
+    expect(existsSync(dbPath)).toBe(true);
+
+    const reopened = new Database(dbPath);
+    const cols = reopened
+      .prepare("PRAGMA table_info(observers)")
+      .all() as Array<{ name: string }>;
+    expect(cols.map((c) => c.name).sort()).toEqual([
+      "id",
+      "label",
+      "notes",
+      "pubkey_hex",
+      "registered_at",
+      "revoked_at",
+    ]);
+    reopened.close();
+  });
+
+  test("rows_inserted_in_first_session_survive_second_init", () => {
+    const db1 = new Database(dbPath);
+    initObserversDb(db1);
+    setObserversDbForTests(db1);
+    registerObserver({ pubkey: PUB_A, label: "session-1", now: 555_555 });
+    db1.close();
+
+    const db2 = new Database(dbPath);
+    initObserversDb(db2);
+    setObserversDbForTests(db2);
+    const persisted = getObserver(PUB_A);
+    expect(persisted).not.toBeNull();
+    expect(persisted!.label).toBe("session-1");
+    expect(persisted!.registered_at).toBe(555_555);
+    db2.close();
+  });
+
+  test("concurrent_startup_two_handles_one_file_both_succeed", () => {
+    const db1 = new Database(dbPath);
+    const db2 = new Database(dbPath);
+    expect(() => initObserversDb(db1)).not.toThrow();
+    expect(() => initObserversDb(db2)).not.toThrow();
+
+    setObserversDbForTests(db1);
+    registerObserver({ pubkey: PUB_B, label: "concurrent" });
+    const cols = db2.prepare("PRAGMA table_info(observers)").all() as Array<{ name: string }>;
+    expect(cols.length).toBe(6);
+    db1.close();
+    db2.close();
+  });
+});
+
+describe("observers: register", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeMemDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  test("register_returns_row_with_pubkey_label_registered_at", () => {
+    const row = registerObserver({
+      pubkey: PUB_A,
+      label: "watchtower-1",
+      notes: "third-party witness",
+      now: 1_700_000_000,
+    });
+    expect(row.pubkey_hex).toBe(PUB_A);
+    expect(row.label).toBe("watchtower-1");
+    expect(row.notes).toBe("third-party witness");
+    expect(row.registered_at).toBe(1_700_000_000);
+    expect(row.revoked_at).toBeNull();
+    expect(row.id).toBeGreaterThan(0);
+  });
+
+  test("register_normalises_0x_prefix_and_uppercase", () => {
+    const row = registerObserver({
+      pubkey: "0X" + "F".repeat(64),
+      label: "norm",
+    });
+    expect(row.pubkey_hex).toBe("f".repeat(64));
+  });
+
+  test("register_throws_on_invalid_hex_length", () => {
+    expect(() => registerObserver({ pubkey: "abcd" })).toThrow(/64 chars/);
+  });
+
+  test("register_throws_on_duplicate_pubkey", () => {
+    registerObserver({ pubkey: PUB_A });
+    expect(() => registerObserver({ pubkey: PUB_A })).toThrow(/UNIQUE/i);
+  });
+});
+
+describe("observers: get + isActive", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeMemDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  test("get_returns_null_for_unknown_pubkey", () => {
+    expect(getObserver(PUB_A)).toBeNull();
+  });
+
+  test("get_returns_row_for_registered_pubkey", () => {
+    registerObserver({ pubkey: PUB_A });
+    const row = getObserver(PUB_A);
+    expect(row).not.toBeNull();
+    expect(row!.pubkey_hex).toBe(PUB_A);
+  });
+
+  test("isActive_true_for_registered_not_revoked", () => {
+    registerObserver({ pubkey: PUB_A });
+    expect(isObserverActive(PUB_A)).toBe(true);
+  });
+
+  test("isActive_false_for_unknown_pubkey", () => {
+    expect(isObserverActive(PUB_A)).toBe(false);
+  });
+
+  test("isActive_false_after_revocation", () => {
+    registerObserver({ pubkey: PUB_A });
+    revokeObserver(PUB_A);
+    expect(isObserverActive(PUB_A)).toBe(false);
+  });
+
+  test("isActive_returns_false_when_db_uninitialised_defensive", () => {
+    setObserversDbForTests(undefined as unknown as Database.Database);
+    expect(isObserverActive(PUB_A)).toBe(false);
+  });
+});
+
+describe("observers: revoke", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeMemDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  test("revoke_returns_true_on_first_call", () => {
+    registerObserver({ pubkey: PUB_A });
+    expect(revokeObserver(PUB_A)).toBe(true);
+  });
+
+  test("revoke_returns_false_for_unknown_pubkey", () => {
+    expect(revokeObserver(PUB_A)).toBe(false);
+  });
+
+  test("revoke_is_idempotent_returns_false_on_second_call", () => {
+    registerObserver({ pubkey: PUB_A });
+    expect(revokeObserver(PUB_A, { now: 5000 })).toBe(true);
+    expect(revokeObserver(PUB_A, { now: 6000 })).toBe(false);
+    const row = getObserver(PUB_A);
+    expect(row!.revoked_at).toBe(5000);
+  });
+});
+
+describe("observers: list", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeMemDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  test("list_returns_empty_array_for_fresh_db", () => {
+    expect(listObservers()).toEqual([]);
+  });
+
+  test("list_returns_all_rows_desc_order_and_active_filters_revoked", () => {
+    registerObserver({ pubkey: PUB_A, now: 100 });
+    registerObserver({ pubkey: PUB_B, now: 300 });
+    registerObserver({ pubkey: PUB_C, now: 200 });
+    revokeObserver(PUB_A);
+
+    const all = listObservers();
+    expect(all.map((r) => r.pubkey_hex)).toEqual([PUB_B, PUB_C, PUB_A]);
+
+    const active = listObservers({ active: true });
+    expect(active.map((r) => r.pubkey_hex)).toEqual([PUB_B, PUB_C]);
+  });
+});
+
+describe("observers: getObserversDb test hook", () => {
+  test("throws_before_init", () => {
+    setObserversDbForTests(undefined as unknown as Database.Database);
+    expect(() => getObserversDb()).toThrow(/not initialised/);
+  });
+
+  test("returns_handle_after_setForTests", () => {
+    const db = makeMemDb();
+    expect(getObserversDb()).toBe(db);
+    db.close();
+  });
+});

--- a/services/blob-gateway/src/fleet_operators.ts
+++ b/services/blob-gateway/src/fleet_operators.ts
@@ -1,0 +1,224 @@
+/**
+ * SQLite-backed registry of FLEET OPERATORS — third parties that attest to
+ * the hardware specification of compute workers.
+ *
+ * In `compute_metering_v2`, every record carries a `hardware_spec` sub-object
+ * with a `fleet_operator_pubkey` + `fleet_operator_signature`. The fleet
+ * operator is the only party allowed to declare what hardware a worker is
+ * running on (so a worker can't unilaterally inflate its own capacity in
+ * order to over-bill). Only fleet operators in this registry — and not
+ * revoked — pass the gateway's check.
+ *
+ * Trust framing: this registry implements rule (8) in the v2 validator,
+ * "fleet_operator_pubkey exists in fleet_operators table AND is not revoked."
+ * Mutation is admin-only (see routes/fleet_operators.ts).
+ *
+ * Why a separate db/file from operators/api_tokens?
+ *   - Different access pattern (admin-only writes; gateway-frequent reads).
+ *   - Different lifecycle (operators are validators that join/leave the chain;
+ *     fleet operators are organizations that vouch for hardware fleets).
+ *   - Different on-disk file means a fleet-operators schema migration can
+ *     never collide with an api-tokens migration (per
+ *     `feedback_orynq_gateway_migration_gaps.md`'s "audit every wire-up"
+ *     lesson).
+ */
+
+import Database from "better-sqlite3";
+import { join } from "path";
+import { config } from "./config.js";
+
+let db: Database.Database | null = null;
+
+/** Test hook: inject a handle (typically `:memory:` for unit tests). */
+export function setFleetOperatorsDbForTests(injected: Database.Database): void {
+  db = injected;
+}
+
+/** Test/debug helper — returns the current handle or throws if uninitialised. */
+export function getFleetOperatorsDb(): Database.Database {
+  if (!db) {
+    throw new Error(
+      "fleet_operators db not initialised — call initFleetOperatorsDb() first",
+    );
+  }
+  return db;
+}
+
+/**
+ * Initialise the fleet_operators table on a SQLite handle.
+ *
+ * Idempotent: safe to call repeatedly. CREATE IF NOT EXISTS is the workhorse;
+ * column additions (when we add them) go through migrate*Columns() helpers
+ * with the same try/swallow-duplicate-name pattern api-tokens.ts uses for
+ * parallel-startup races.
+ *
+ * If `database` is omitted, opens (or creates) `fleet_operators.db` at the
+ * canonical storage path. Tests should pass an in-memory handle.
+ */
+export function initFleetOperatorsDb(
+  database?: Database.Database,
+): Database.Database {
+  const handle =
+    database ?? new Database(join(config.storagePath, "fleet_operators.db"));
+  handle.pragma("journal_mode = WAL");
+  handle.pragma("busy_timeout = 5000");
+  handle.exec(`
+    CREATE TABLE IF NOT EXISTS fleet_operators (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      pubkey_hex TEXT UNIQUE NOT NULL,
+      label TEXT,
+      registered_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      notes TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_fleet_operators_pubkey
+      ON fleet_operators(pubkey_hex);
+    CREATE INDEX IF NOT EXISTS idx_fleet_operators_active
+      ON fleet_operators(pubkey_hex) WHERE revoked_at IS NULL;
+  `);
+  if (!db) db = handle;
+  return handle;
+}
+
+export interface FleetOperatorRow {
+  id: number;
+  pubkey_hex: string;
+  label: string | null;
+  registered_at: number;
+  revoked_at: number | null;
+  notes: string | null;
+}
+
+/** Hex regex for 32-byte sr25519 pubkey (64 lowercase hex chars). */
+const HEX64 = /^[0-9a-f]{64}$/;
+
+function normalizePubkey(input: string): string {
+  // Accept inputs with or without 0x prefix; canonicalise to lowercase no-prefix.
+  const stripped = input.startsWith("0x") || input.startsWith("0X")
+    ? input.slice(2)
+    : input;
+  return stripped.toLowerCase();
+}
+
+export interface RegisterFleetOperatorInput {
+  pubkey: string;
+  label?: string | null;
+  notes?: string | null;
+  /** Unix seconds override; used in tests for determinism. */
+  now?: number;
+}
+
+/**
+ * Insert a new fleet operator row. Returns the freshly-inserted row.
+ *
+ * Throws if a row with that pubkey already exists (UNIQUE constraint). Caller
+ * (route layer) should catch and translate to 409. We intentionally DO NOT
+ * silently re-register a revoked operator — the admin must explicitly revive
+ * one (a separate, future endpoint), keeping the audit trail intact.
+ */
+export function registerFleetOperator(
+  input: RegisterFleetOperatorInput,
+): FleetOperatorRow {
+  if (!db) throw new Error("fleet_operators db not initialised");
+  const normalized = normalizePubkey(input.pubkey);
+  if (!HEX64.test(normalized)) {
+    throw new TypeError(
+      `registerFleetOperator: pubkey must be 32 bytes hex (64 chars), got "${input.pubkey}"`,
+    );
+  }
+  const label = input.label ? String(input.label).slice(0, 256) : null;
+  const notes = input.notes ? String(input.notes).slice(0, 1024) : null;
+  const registeredAt = input.now ?? Math.floor(Date.now() / 1000);
+
+  const info = db
+    .prepare(
+      `INSERT INTO fleet_operators (pubkey_hex, label, registered_at, notes)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(normalized, label, registeredAt, notes);
+
+  return {
+    id: Number(info.lastInsertRowid),
+    pubkey_hex: normalized,
+    label,
+    registered_at: registeredAt,
+    revoked_at: null,
+    notes,
+  };
+}
+
+/**
+ * Mark a fleet operator as revoked. Idempotent: if already revoked, returns
+ * `false`; if not found, returns `false`; otherwise `true`. Never re-stamps
+ * the original revocation timestamp.
+ */
+export function revokeFleetOperator(
+  pubkey: string,
+  opts: { now?: number } = {},
+): boolean {
+  if (!db) throw new Error("fleet_operators db not initialised");
+  const normalized = normalizePubkey(pubkey);
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  const info = db
+    .prepare(
+      `UPDATE fleet_operators SET revoked_at = ?
+       WHERE pubkey_hex = ? AND revoked_at IS NULL`,
+    )
+    .run(now, normalized);
+  return info.changes > 0;
+}
+
+/** Look up a single row by pubkey (active or revoked). */
+export function getFleetOperator(pubkey: string): FleetOperatorRow | null {
+  if (!db) return null;
+  const normalized = normalizePubkey(pubkey);
+  const row = db
+    .prepare(
+      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes
+       FROM fleet_operators WHERE pubkey_hex = ?`,
+    )
+    .get(normalized) as FleetOperatorRow | undefined;
+  return row ?? null;
+}
+
+/**
+ * Hot-path check used by the v2 validator: returns true iff the pubkey is
+ * registered AND not revoked. Defensively returns false when the registry
+ * isn't initialised (so a misconfigured boot rejects all v2 records loudly
+ * via 403 rather than silently accepting forged hardware claims).
+ */
+export function isFleetOperatorActive(pubkey: string): boolean {
+  if (!db) return false;
+  const normalized = normalizePubkey(pubkey);
+  const row = db
+    .prepare(
+      `SELECT 1 AS one FROM fleet_operators
+       WHERE pubkey_hex = ? AND revoked_at IS NULL`,
+    )
+    .get(normalized) as { one: number } | undefined;
+  return row !== undefined;
+}
+
+export interface ListFleetOperatorsOpts {
+  /** When true, return only active rows. Default false (return all). */
+  active?: boolean;
+}
+
+/**
+ * List rows. Order: registered_at DESC, id DESC (stable within same epoch).
+ */
+export function listFleetOperators(
+  opts: ListFleetOperatorsOpts = {},
+): FleetOperatorRow[] {
+  if (!db) return [];
+  const where = opts.active ? "WHERE revoked_at IS NULL" : "";
+  const rows = db
+    .prepare(
+      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes
+       FROM fleet_operators
+       ${where}
+       ORDER BY registered_at DESC, id DESC`,
+    )
+    .all() as FleetOperatorRow[];
+  return rows;
+}

--- a/services/blob-gateway/src/index.ts
+++ b/services/blob-gateway/src/index.ts
@@ -26,6 +26,10 @@ import { registerAdminKeysRoutes } from "./routes/admin-keys.js";
 import { meteringRouter } from "./routes/metering.js";
 import { billingRouter } from "./routes/billing.js";
 import { initWorkerBoundsDb } from "./worker_bounds.js";
+import { initFleetOperatorsDb } from "./fleet_operators.js";
+import { initObserversDb } from "./observers.js";
+import { registerFleetOperatorRoutes } from "./routes/fleet_operators.js";
+import { registerObserverRoutes } from "./routes/observers.js";
 // initChainInfoPoller is re-exported for consumers that want to pre-warm the
 // cache at startup; we also call it in start() so the first /chain-info hit
 // after cold-start returns 200 instead of 503.
@@ -68,6 +72,8 @@ app.use(meteringRouter);    // Task #109: POST /metering/submit — compute_mete
 app.use(billingRouter);     // Task #112: GET /billing/usage — verifiable compute-metering billing query.
 registerTokenRoutes(app);   // Bearer-token lifecycle (admin-only)
 registerAdminKeysRoutes(app); // Task #94: api_keys.bound_validator_aura get/set/clear (admin-only)
+registerFleetOperatorRoutes(app); // Wave 1+2: compute_metering_v2 hardware-attestor registry (admin-only)
+registerObserverRoutes(app);      // Wave 1+2: compute_metering_v2 optional co-signer registry (admin-only)
 
 async function start(): Promise<void> {
   // Initialize sr25519/ed25519 WASM (required for signatureVerify)
@@ -86,6 +92,11 @@ async function start(): Promise<void> {
   initApiTokensDb(getOperatorsDb());
   // Compute metering v1 — per-worker hardware bounds + monotonic period_start.
   initWorkerBoundsDb();
+  // Compute metering v2 — fleet operator + observer trust registries.
+  // Each lives in its own SQLite file (fleet_operators.db, observers.db) so
+  // schema migrations stay isolated from operators.db / quota.db.
+  initFleetOperatorsDb();
+  initObserversDb();
 
   // Start cleanup timers
   startCleanupTimer();

--- a/services/blob-gateway/src/observers.ts
+++ b/services/blob-gateway/src/observers.ts
@@ -1,0 +1,189 @@
+/**
+ * SQLite-backed registry of OBSERVERS — independent third parties that may
+ * co-sign a `compute_metering_v2` record over the same pre-image as the
+ * worker.
+ *
+ * The observer signature is OPTIONAL on v2 records. When present, the
+ * gateway enforces:
+ *   - observer_pubkey must exist in this registry AND not be revoked
+ *   - observer_signature must verify against the same canonical CBOR pre-image
+ *     as worker_signature
+ *
+ * Schema and shape are intentionally identical to fleet_operators.ts — same
+ * columns, same function signatures, same admin endpoints — to keep cognitive
+ * overhead low. The only difference is the backing file (`observers.db`)
+ * and the table name (`observers`).
+ *
+ * Why not share a generic `attestor_keys` table?
+ *   - Different revocation policies in the future (operators may want to
+ *     globally revoke a fleet operator while still trusting them as an
+ *     observer for some workloads, or vice versa).
+ *   - Different audit/discovery surface for ops tooling. Operators ask
+ *     "who can claim hardware for me?" (fleet operators) and
+ *     "who can co-sign my work?" (observers) as separate questions.
+ *   - Migrations stay isolated.
+ */
+
+import Database from "better-sqlite3";
+import { join } from "path";
+import { config } from "./config.js";
+
+let db: Database.Database | null = null;
+
+export function setObserversDbForTests(injected: Database.Database): void {
+  db = injected;
+}
+
+export function getObserversDb(): Database.Database {
+  if (!db) {
+    throw new Error("observers db not initialised — call initObserversDb() first");
+  }
+  return db;
+}
+
+/**
+ * Initialise the observers table on a SQLite handle. Idempotent.
+ *
+ * If `database` is omitted, opens (or creates) `observers.db` at the canonical
+ * storage path. Tests should pass an in-memory handle.
+ */
+export function initObserversDb(
+  database?: Database.Database,
+): Database.Database {
+  const handle =
+    database ?? new Database(join(config.storagePath, "observers.db"));
+  handle.pragma("journal_mode = WAL");
+  handle.pragma("busy_timeout = 5000");
+  handle.exec(`
+    CREATE TABLE IF NOT EXISTS observers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      pubkey_hex TEXT UNIQUE NOT NULL,
+      label TEXT,
+      registered_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      notes TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_observers_pubkey
+      ON observers(pubkey_hex);
+    CREATE INDEX IF NOT EXISTS idx_observers_active
+      ON observers(pubkey_hex) WHERE revoked_at IS NULL;
+  `);
+  if (!db) db = handle;
+  return handle;
+}
+
+export interface ObserverRow {
+  id: number;
+  pubkey_hex: string;
+  label: string | null;
+  registered_at: number;
+  revoked_at: number | null;
+  notes: string | null;
+}
+
+const HEX64 = /^[0-9a-f]{64}$/;
+
+function normalizePubkey(input: string): string {
+  const stripped = input.startsWith("0x") || input.startsWith("0X")
+    ? input.slice(2)
+    : input;
+  return stripped.toLowerCase();
+}
+
+export interface RegisterObserverInput {
+  pubkey: string;
+  label?: string | null;
+  notes?: string | null;
+  now?: number;
+}
+
+export function registerObserver(
+  input: RegisterObserverInput,
+): ObserverRow {
+  if (!db) throw new Error("observers db not initialised");
+  const normalized = normalizePubkey(input.pubkey);
+  if (!HEX64.test(normalized)) {
+    throw new TypeError(
+      `registerObserver: pubkey must be 32 bytes hex (64 chars), got "${input.pubkey}"`,
+    );
+  }
+  const label = input.label ? String(input.label).slice(0, 256) : null;
+  const notes = input.notes ? String(input.notes).slice(0, 1024) : null;
+  const registeredAt = input.now ?? Math.floor(Date.now() / 1000);
+
+  const info = db
+    .prepare(
+      `INSERT INTO observers (pubkey_hex, label, registered_at, notes)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(normalized, label, registeredAt, notes);
+
+  return {
+    id: Number(info.lastInsertRowid),
+    pubkey_hex: normalized,
+    label,
+    registered_at: registeredAt,
+    revoked_at: null,
+    notes,
+  };
+}
+
+export function revokeObserver(
+  pubkey: string,
+  opts: { now?: number } = {},
+): boolean {
+  if (!db) throw new Error("observers db not initialised");
+  const normalized = normalizePubkey(pubkey);
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  const info = db
+    .prepare(
+      `UPDATE observers SET revoked_at = ?
+       WHERE pubkey_hex = ? AND revoked_at IS NULL`,
+    )
+    .run(now, normalized);
+  return info.changes > 0;
+}
+
+export function getObserver(pubkey: string): ObserverRow | null {
+  if (!db) return null;
+  const normalized = normalizePubkey(pubkey);
+  const row = db
+    .prepare(
+      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes
+       FROM observers WHERE pubkey_hex = ?`,
+    )
+    .get(normalized) as ObserverRow | undefined;
+  return row ?? null;
+}
+
+export function isObserverActive(pubkey: string): boolean {
+  if (!db) return false;
+  const normalized = normalizePubkey(pubkey);
+  const row = db
+    .prepare(
+      `SELECT 1 AS one FROM observers
+       WHERE pubkey_hex = ? AND revoked_at IS NULL`,
+    )
+    .get(normalized) as { one: number } | undefined;
+  return row !== undefined;
+}
+
+export interface ListObserversOpts {
+  active?: boolean;
+}
+
+export function listObservers(
+  opts: ListObserversOpts = {},
+): ObserverRow[] {
+  if (!db) return [];
+  const where = opts.active ? "WHERE revoked_at IS NULL" : "";
+  const rows = db
+    .prepare(
+      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes
+       FROM observers
+       ${where}
+       ORDER BY registered_at DESC, id DESC`,
+    )
+    .all() as ObserverRow[];
+  return rows;
+}

--- a/services/blob-gateway/src/routes/fleet_operators.ts
+++ b/services/blob-gateway/src/routes/fleet_operators.ts
@@ -1,0 +1,176 @@
+/**
+ * Admin routes for the FLEET OPERATORS registry (compute_metering_v2).
+ *
+ *   POST   /admin/fleet-operators            -- register a new fleet operator
+ *   DELETE /admin/fleet-operators/:pubkey    -- mark a fleet operator revoked
+ *   GET    /admin/fleet-operators            -- list all (active + revoked)
+ *
+ * All endpoints require x-admin-token (same `DAEMON_NOTIFY_TOKEN` env var
+ * used by `routes/tokens.ts`). When the env var is unset the routes mount
+ * but return 503 — surfaces misconfiguration loudly instead of as a 404.
+ */
+
+import type { Express, Request, Response } from "express";
+import { config } from "../config.js";
+import { adminGuard } from "../bearer-auth.js";
+import {
+  registerFleetOperator,
+  revokeFleetOperator,
+  getFleetOperator,
+  listFleetOperators,
+  type FleetOperatorRow,
+} from "../fleet_operators.js";
+
+const HEX64_LOOSE = /^(0x)?[0-9a-fA-F]{64}$/;
+
+export interface RegisterFleetOperatorRoutesOpts {
+  /** Admin shared secret (falls back to config.daemonNotifyToken if empty). */
+  adminToken?: string;
+}
+
+/**
+ * Map a registered row to the JSON shape we expose. Renaming nothing — the
+ * column names are the API surface; if we ever need a wire vs. column rename,
+ * do it in one place here.
+ */
+function rowToJson(row: FleetOperatorRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    pubkey_hex: row.pubkey_hex,
+    label: row.label,
+    registered_at: row.registered_at,
+    revoked_at: row.revoked_at,
+    notes: row.notes,
+  };
+}
+
+export function registerFleetOperatorRoutes(
+  app: Express,
+  opts: RegisterFleetOperatorRoutesOpts = {},
+): void {
+  const adminToken = (opts.adminToken || config.daemonNotifyToken || "").trim();
+  if (!adminToken) {
+    app.post("/admin/fleet-operators", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    app.delete("/admin/fleet-operators/:pubkey", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    app.get("/admin/fleet-operators", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    return;
+  }
+  const guard = adminGuard(adminToken);
+
+  app.post("/admin/fleet-operators", guard, (req: Request, res: Response) => {
+    try {
+      const body = (req.body ?? {}) as {
+        pubkey?: unknown;
+        label?: unknown;
+        notes?: unknown;
+      };
+      if (typeof body.pubkey !== "string" || !HEX64_LOOSE.test(body.pubkey)) {
+        res.status(400).json({
+          error: "pubkey is required and must be 32 bytes hex (64 chars, optional 0x prefix)",
+        });
+        return;
+      }
+      const label =
+        typeof body.label === "string" && body.label.trim()
+          ? body.label.trim()
+          : null;
+      const notes =
+        typeof body.notes === "string" && body.notes.trim()
+          ? body.notes.trim()
+          : null;
+
+      // Pre-check duplicate so we can 409 cleanly instead of bubbling up the
+      // raw SQLite UNIQUE-constraint error string.
+      const existing = getFleetOperator(body.pubkey);
+      if (existing) {
+        res.status(409).json({
+          error: "fleet operator already registered",
+          existing: rowToJson(existing),
+        });
+        return;
+      }
+
+      const row = registerFleetOperator({
+        pubkey: body.pubkey,
+        label,
+        notes,
+      });
+
+      console.log(
+        `[blob-gateway] fleet-operator registered pubkey_prefix=${row.pubkey_hex.slice(0, 16)} label=${label ?? "-"}`,
+      );
+
+      res.status(200).json({
+        status: "created",
+        operator: rowToJson(row),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Defensive: if pre-check missed a race and the UNIQUE constraint
+      // fires anyway, surface as 409 not 500.
+      if (/UNIQUE/i.test(msg)) {
+        res.status(409).json({ error: "fleet operator already registered" });
+        return;
+      }
+      res.status(500).json({ error: msg });
+    }
+  });
+
+  app.delete(
+    "/admin/fleet-operators/:pubkey",
+    guard,
+    (req: Request, res: Response) => {
+      try {
+        const pubkey = String(req.params.pubkey || "");
+        if (!HEX64_LOOSE.test(pubkey)) {
+          res.status(400).json({
+            error: "invalid pubkey (expected 64 hex chars, optional 0x prefix)",
+          });
+          return;
+        }
+        // Pre-check existence so we can return 404 vs. 200/idempotent.
+        const row = getFleetOperator(pubkey);
+        if (!row) {
+          res.status(404).json({ error: "fleet operator not found" });
+          return;
+        }
+        const ok = revokeFleetOperator(pubkey);
+        if (!ok) {
+          // Already revoked — idempotent path.
+          res.status(200).json({
+            status: "already-revoked",
+            operator: rowToJson(getFleetOperator(pubkey)!),
+          });
+          return;
+        }
+        console.log(
+          `[blob-gateway] fleet-operator revoked pubkey_prefix=${row.pubkey_hex.slice(0, 16)}`,
+        );
+        res.status(200).json({
+          status: "revoked",
+          operator: rowToJson(getFleetOperator(pubkey)!),
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        res.status(500).json({ error: msg });
+      }
+    },
+  );
+
+  app.get("/admin/fleet-operators", guard, (req: Request, res: Response) => {
+    try {
+      const active = req.query.active === "1" || req.query.active === "true";
+      const rows = listFleetOperators(active ? { active: true } : {});
+      res.status(200).json({ operators: rows.map(rowToJson) });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: msg });
+    }
+  });
+}

--- a/services/blob-gateway/src/routes/metering.ts
+++ b/services/blob-gateway/src/routes/metering.ts
@@ -39,6 +39,7 @@ import {
   workerPubkeyToSs58,
   SCHEMA_VERSION,
 } from "../schemas/compute_metering_v1.js";
+import { SCHEMA_VERSION as SCHEMA_VERSION_V2 } from "../schemas/compute_metering_v2.js";
 import {
   getWorkerBounds,
   getLastPeriodStart,
@@ -48,6 +49,7 @@ import {
 } from "../worker_bounds.js";
 import { notifySponsoredReceiptSubmitter } from "../sponsored-receipts.js";
 import { saveManifest, updateReceiptMeta } from "../storage.js";
+import { handleV2Submit } from "./metering_v2.js";
 
 export const meteringRouter = Router();
 
@@ -100,6 +102,20 @@ meteringRouter.post(
           code: "INVALID_JSON",
           message: "request body must be a JSON object",
         });
+        return;
+      }
+
+      // Schema-version dispatch. We MUST keep the v1 path byte-for-byte
+      // identical to its pre-v2 behaviour — the v1 worker SDK is in
+      // production. Any record without a recognised schema_version flows
+      // through the v1 validator which will then reject it with the same
+      // WRONG_SCHEMA_VERSION code as before.
+      const schemaVersion =
+        typeof raw === "object" && raw !== null && "schema_version" in raw
+          ? (raw as { schema_version: unknown }).schema_version
+          : undefined;
+      if (schemaVersion === SCHEMA_VERSION_V2) {
+        await handleV2Submit(req, res, raw);
         return;
       }
 

--- a/services/blob-gateway/src/routes/metering_v2.ts
+++ b/services/blob-gateway/src/routes/metering_v2.ts
@@ -1,0 +1,491 @@
+/**
+ * Validator + dispatcher for `compute_metering_v2` records inbound at
+ * `POST /metering/submit`.
+ *
+ * Trust model recap:
+ *   - Worker proves it ran the work by signing the canonical pre-image with
+ *     `worker_pubkey`.
+ *   - Fleet operator (a registered third party) attests to the worker's
+ *     hardware capacity by signing the hardware_spec sub-object with
+ *     `fleet_operator_pubkey`. This prevents a malicious worker from
+ *     unilaterally inflating its capacity to over-bill.
+ *   - Observer (optional, registered third party) co-signs the same pre-image
+ *     as the worker. Adds an independent witness for high-trust workloads.
+ *
+ * 11 validation rules (enforced in this order, fail-fast on first):
+ *
+ *   (1) Schema validates structurally — delegate to validateComputeMeteringV2
+ *   (2) period_end_ms - period_start_ms ≤ 86_400_000 (24 h)
+ *   (3) period_end_ms ≤ now + 60_000 (clock-skew tolerance)
+ *   (4) All metric values ≥ 0 (already enforced by structural validator —
+ *       re-asserted here as belt-and-suspenders)
+ *   (5) cpu_seconds ≤ cpu_cores × period_sec × 1.05
+ *   (6) ram_gb_hours ≤ ram_gb × period_hr × 1.05
+ *   (7) gpu_seconds = 0 if gpu_type=none OR gpu_count=0 (already enforced
+ *       structurally; checked here to keep ALL bound logic in one place)
+ *   (8) fleet_operator_pubkey exists in fleet_operators table AND not revoked
+ *   (9) fleet_operator_signature valid sr25519 over its documented pre-image
+ *  (10) worker_signature valid sr25519 over its documented pre-image
+ *  (11) If observer present: observer_pubkey exists AND not revoked AND sig valid
+ *
+ * On accept:
+ *   - persist receipt manifest under receipts/{contentHash}/manifest.json
+ *   - update worker_state (last_period_start, last_content_hash)
+ *   - append per-record billing snapshot to metering_submissions
+ *   - fire-and-forget notify the sponsored-receipt-submitter with
+ *     schema_hash = SCHEMA_HASH_HEX_V2 + source = "compute-metering-v2"
+ *
+ * HTTP status mapping (mirrors the v1 dispatcher's stable codes):
+ *
+ *   400 — schema malformed (rule 1) or period bounds violated (rules 2, 3)
+ *   422 — metrics out of bounds (rules 4, 5, 6, 7)
+ *   403 — fleet operator unknown or revoked (rule 8)
+ *   401 — fleet operator sig invalid (9), worker sig invalid (10),
+ *         observer sig invalid (11)
+ *   409 — replay (same content_hash) OR monotonic regression on period_start_ms
+ *   500 — unexpected internal error
+ */
+
+import type { Request, Response } from "express";
+import { signatureVerify } from "@polkadot/util-crypto";
+import { hexToU8a } from "@polkadot/util";
+import { config } from "../config.js";
+import {
+  validateComputeMeteringV2,
+  canonicalCborForFleetOpSig,
+  canonicalCborForWorkerSig,
+  SCHEMA_HASH_HEX,
+  SCHEMA_VERSION,
+  MAX_PERIOD_MS,
+  FUTURE_SKEW_MS,
+  JITTER_FACTOR,
+  type ComputeMeteringV2,
+  type ValidateErrorCode,
+} from "../schemas/compute_metering_v2.js";
+import { isFleetOperatorActive } from "../fleet_operators.js";
+import { isObserverActive } from "../observers.js";
+import {
+  getLastPeriodStart,
+  recordWorkerSubmission,
+  recordMeteringSubmission,
+  isReplayedContent,
+} from "../worker_bounds.js";
+import { workerPubkeyToSs58 } from "../schemas/compute_metering_v1.js";
+import { notifySponsoredReceiptSubmitter } from "../sponsored-receipts.js";
+import { saveManifest, updateReceiptMeta } from "../storage.js";
+
+/** Source tag emitted to the sponsored-receipt-submitter for v2 records. */
+export const METERING_V2_SOURCE = "compute-metering-v2" as const;
+
+/**
+ * Stable error codes for v2-specific failures (rules not covered by the
+ * structural validator's own ValidateErrorCode union).
+ */
+export type V2RouteErrorCode =
+  | ValidateErrorCode
+  | "PERIOD_TOO_LONG"
+  | "PERIOD_FUTURE_SKEW"
+  | "CPU_OVER_HARDWARE"
+  | "RAM_OVER_HARDWARE"
+  | "FLEET_OPERATOR_UNKNOWN"
+  | "FLEET_OPERATOR_REVOKED"
+  | "FLEET_OPERATOR_SIG_INVALID"
+  | "WORKER_SIG_INVALID"
+  | "OBSERVER_UNKNOWN"
+  | "OBSERVER_REVOKED"
+  | "OBSERVER_SIG_INVALID"
+  | "REPLAY_CONTENT_HASH"
+  | "MONOTONIC_VIOLATION"
+  | "INTERNAL";
+
+interface V2RejectBody {
+  ok: false;
+  code: V2RouteErrorCode;
+  message: string;
+  field?: string;
+}
+
+function reject(
+  res: Response,
+  status: number,
+  code: V2RouteErrorCode,
+  message: string,
+  field?: string,
+): void {
+  const body: V2RejectBody = field !== undefined
+    ? { ok: false, code, message, field }
+    : { ok: false, code, message };
+  res.status(status).json(body);
+}
+
+/**
+ * Audit-log a single auth-fail line. Format is space-separated key=value so
+ * `| grep metering_v2_auth_fail` gives a clean stream.
+ *
+ * Per the task spec: never log full pubkeys, never log signatures.
+ */
+function logAuthFail(
+  reason: string,
+  pubkeyHexFull: string | undefined,
+): void {
+  const prefix = (pubkeyHexFull ?? "").slice(0, 16);
+  console.warn(
+    `[blob-gateway] event=metering_v2_auth_fail reason=${reason} pubkey_prefix=${prefix}`,
+  );
+}
+
+/**
+ * Verify a sr25519 signature with hex-encoded pubkey + signature against
+ * pre-computed canonical bytes. Returns true on valid, false on any failure
+ * (including malformed key/sig — caught here so the route never throws on a
+ * tampered field).
+ */
+function verifySr25519(
+  preimage: Uint8Array,
+  pubkeyHex: string,
+  sigHex: string,
+): boolean {
+  try {
+    const pub = hexToU8a("0x" + pubkeyHex);
+    const sig = hexToU8a("0x" + sigHex);
+    const r = signatureVerify(preimage, sig, pub);
+    return r.isValid;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Map a structural-validator error code to its v2-route HTTP status.
+ *
+ * Note: the route layer's per-rule failures (PERIOD_TOO_LONG, etc.) are
+ * handled inline in `handleV2Submit`; this mapping only covers the codes the
+ * SCHEMA validator can emit.
+ */
+function statusForStructuralCode(code: ValidateErrorCode): number {
+  switch (code) {
+    case "INVALID_JSON":
+    case "MISSING_FIELD":
+    case "WRONG_TYPE":
+    case "ID_FORMAT":
+    case "PERIOD_INVALID":
+    case "HEX_FORMAT":
+    case "GPU_TYPE_INVALID":
+      return 400;
+    case "WRONG_SCHEMA_VERSION":
+    case "NEGATIVE_VALUE":
+    case "BOUND_EXCEEDED":
+    case "INT_OVERFLOW":
+    case "GPU_COUNT_MISMATCH":
+      return 422;
+    default:
+      return 400;
+  }
+}
+
+/**
+ * The v2 dispatcher. Called from `routes/metering.ts` when the inbound record
+ * carries `schema_version: "compute_metering_v2"`. Splitting it into its own
+ * module keeps the v1 path untouched.
+ */
+export async function handleV2Submit(
+  _req: Request,
+  res: Response,
+  raw: unknown,
+): Promise<void> {
+  const nowMs = Date.now();
+
+  // Rule 1 — structural validation (also pulls workers / metrics / hardware
+  // out of the raw input).
+  const sv = validateComputeMeteringV2(raw);
+  if (!sv.ok) {
+    reject(
+      res,
+      statusForStructuralCode(sv.code),
+      sv.code,
+      sv.message,
+      sv.field,
+    );
+    return;
+  }
+  const { record, content_hash, schema_hash } = sv;
+
+  // Rule 2 — period_end_ms - period_start_ms <= 86_400_000
+  const periodMs = record.period_end_ms - record.period_start_ms;
+  if (periodMs > MAX_PERIOD_MS) {
+    reject(
+      res,
+      400,
+      "PERIOD_TOO_LONG",
+      `period (period_end_ms - period_start_ms) must be <= ${MAX_PERIOD_MS} ms (24 h), got ${periodMs}`,
+      "period_end_ms",
+    );
+    return;
+  }
+
+  // Rule 3 — period_end_ms <= now + 60_000 (clock skew)
+  if (record.period_end_ms > nowMs + FUTURE_SKEW_MS) {
+    reject(
+      res,
+      400,
+      "PERIOD_FUTURE_SKEW",
+      `period_end_ms ${record.period_end_ms} exceeds now+${FUTURE_SKEW_MS}ms`,
+      "period_end_ms",
+    );
+    return;
+  }
+
+  // Rule 4 — non-negative metrics. The structural validator already enforces
+  // this, so this is a sanity-check assertion here. We KEEP this to satisfy
+  // the spec's "rule 4" line and to fail closed if the structural validator
+  // ever loosens.
+  for (const [key, val] of Object.entries(record.metrics) as Array<[string, number]>) {
+    if (val < 0) {
+      reject(res, 422, "NEGATIVE_VALUE", `metric ${key} must be >= 0, got ${val}`, key);
+      return;
+    }
+  }
+
+  // Rules 5 + 6 — hardware-bound CPU / RAM caps with 5% tolerance.
+  const periodSec = periodMs / 1000;
+  const periodHr = periodMs / 3_600_000;
+  const cpuCap = record.hardware_spec.cpu_cores * periodSec * JITTER_FACTOR;
+  if (record.metrics.cpu_seconds > cpuCap) {
+    reject(
+      res,
+      422,
+      "CPU_OVER_HARDWARE",
+      `cpu_seconds ${record.metrics.cpu_seconds} exceeds hardware cap ${cpuCap.toFixed(3)} (cpu_cores=${record.hardware_spec.cpu_cores}, period_sec=${periodSec}, tolerance=${JITTER_FACTOR})`,
+      "cpu_seconds",
+    );
+    return;
+  }
+  const ramCap = record.hardware_spec.ram_gb * periodHr * JITTER_FACTOR;
+  if (record.metrics.ram_gb_hours > ramCap) {
+    reject(
+      res,
+      422,
+      "RAM_OVER_HARDWARE",
+      `ram_gb_hours ${record.metrics.ram_gb_hours} exceeds hardware cap ${ramCap.toFixed(3)} (ram_gb=${record.hardware_spec.ram_gb}, period_hr=${periodHr.toFixed(3)}, tolerance=${JITTER_FACTOR})`,
+      "ram_gb_hours",
+    );
+    return;
+  }
+
+  // Rule 7 — GPU consistency. Structural validator already checks this.
+  // Re-enforced inline so an audit reading just this file sees the rule.
+  if (
+    (record.hardware_spec.gpu_type === "none" ||
+      record.hardware_spec.gpu_count === 0) &&
+    record.metrics.gpu_seconds !== 0
+  ) {
+    reject(
+      res,
+      422,
+      "GPU_COUNT_MISMATCH",
+      `gpu_seconds must be 0 when gpu_type="none" or gpu_count=0`,
+      "gpu_seconds",
+    );
+    return;
+  }
+
+  // Rule 8 — fleet operator must exist + not revoked.
+  if (!isFleetOperatorActive(record.hardware_spec.fleet_operator_pubkey)) {
+    logAuthFail("fleet_operator_unknown_or_revoked", record.hardware_spec.fleet_operator_pubkey);
+    reject(
+      res,
+      403,
+      "FLEET_OPERATOR_UNKNOWN",
+      "fleet_operator_pubkey is not registered or has been revoked",
+      "fleet_operator_pubkey",
+    );
+    return;
+  }
+
+  // Rule 9 — fleet_operator_signature valid sr25519.
+  const fleetOpPreimage = canonicalCborForFleetOpSig(record.worker_id, record.hardware_spec);
+  if (
+    !verifySr25519(
+      fleetOpPreimage,
+      record.hardware_spec.fleet_operator_pubkey,
+      record.hardware_spec.fleet_operator_signature,
+    )
+  ) {
+    logAuthFail("fleet_operator_sig_invalid", record.hardware_spec.fleet_operator_pubkey);
+    reject(
+      res,
+      401,
+      "FLEET_OPERATOR_SIG_INVALID",
+      "fleet_operator_signature does not verify against fleet_operator_pubkey",
+      "fleet_operator_signature",
+    );
+    return;
+  }
+
+  // Rule 10 — worker_signature valid sr25519 over the full pre-image
+  // (including the fleet_operator_signature already verified above).
+  const workerPreimage = canonicalCborForWorkerSig(record);
+  if (
+    !verifySr25519(
+      workerPreimage,
+      record.worker_pubkey,
+      record.worker_signature,
+    )
+  ) {
+    logAuthFail("worker_sig_invalid", record.worker_pubkey);
+    reject(
+      res,
+      401,
+      "WORKER_SIG_INVALID",
+      "worker_signature does not verify against worker_pubkey",
+      "worker_signature",
+    );
+    return;
+  }
+
+  // Rule 11 — observer (optional). When present, must be registered, not
+  // revoked, and the signature must verify against the SAME pre-image as the
+  // worker signature.
+  if (record.observer) {
+    if (!isObserverActive(record.observer.observer_pubkey)) {
+      logAuthFail("observer_unknown_or_revoked", record.observer.observer_pubkey);
+      reject(
+        res,
+        403,
+        "OBSERVER_UNKNOWN",
+        "observer_pubkey is not registered or has been revoked",
+        "observer_pubkey",
+      );
+      return;
+    }
+    if (
+      !verifySr25519(
+        workerPreimage,
+        record.observer.observer_pubkey,
+        record.observer.observer_signature,
+      )
+    ) {
+      logAuthFail("observer_sig_invalid", record.observer.observer_pubkey);
+      reject(
+        res,
+        401,
+        "OBSERVER_SIG_INVALID",
+        "observer_signature does not verify against observer_pubkey",
+        "observer_signature",
+      );
+      return;
+    }
+  }
+
+  // Replay shortcut — same record submitted twice in a row → 200 status:replay.
+  // We use the same per-worker single-slot dedup as v1 (cheap, off the chain
+  // anti-replay). Note: this only catches an immediate retry of the SAME
+  // content_hash. A different record with monotonic-violating period_start
+  // is caught below.
+  if (isReplayedContent(record.worker_id, content_hash)) {
+    res.status(200).json({
+      ok: true,
+      status: "replay",
+      content_hash,
+      schema_hash,
+      worker_id: record.worker_id,
+    });
+    return;
+  }
+
+  // Replay against a DIFFERENT historical record with the same content_hash
+  // is a 409 — distinct from the same-record retry above. (We can detect this
+  // because content_hash matches but worker_state.last_content_hash doesn't,
+  // which happens when the replayed record predates the most recent one.)
+  // NOTE: The chain is the canonical anti-replay; this is a friendly local
+  // guard, not the only line of defence. We do NOT have a full historical
+  // content_hash store at the gateway — that lives in the chain. So we treat
+  // the replay shortcut above as the only deterministic local replay guard
+  // and rely on the chain to enforce uniqueness of content_hash.
+
+  // Monotonic non-decreasing period_start_ms per worker_id (replay/rewind
+  // guard). This is the same rule v1 enforces for `period_start`; we apply
+  // it identically using the same backing store.
+  const lastStart = getLastPeriodStart(record.worker_id);
+  if (record.period_start_ms < lastStart) {
+    reject(
+      res,
+      409,
+      "MONOTONIC_VIOLATION",
+      `period_start_ms ${record.period_start_ms} < last observed ${lastStart} for worker ${record.worker_id}`,
+      "period_start_ms",
+    );
+    return;
+  }
+
+  // ---------- ACCEPTED — persist, update state, notify ----------
+
+  const operatorSs58 = workerPubkeyToSs58(record.worker_pubkey);
+
+  const manifest = {
+    schema: SCHEMA_VERSION,
+    record,
+    chunks: [],
+    rootHash: content_hash,
+  };
+  await saveManifest(content_hash, manifest);
+  await updateReceiptMeta(content_hash, { uploaderAddress: operatorSs58 });
+
+  recordWorkerSubmission(record.worker_id, record.period_start_ms, content_hash);
+
+  recordMeteringSubmission({
+    content_hash,
+    tenant_id: record.tenant_id,
+    worker_id: record.worker_id,
+    period_start_ms: record.period_start_ms,
+    period_end_ms: record.period_end_ms,
+    cpu_seconds: record.metrics.cpu_seconds,
+    ram_gb_hours: record.metrics.ram_gb_hours,
+    disk_gb_hours: record.metrics.disk_gb_hours,
+    net_bytes_in: record.metrics.net_bytes_in,
+    net_bytes_out: record.metrics.net_bytes_out,
+    gpu_seconds: record.metrics.gpu_seconds,
+    submitted_at_ms: nowMs,
+  });
+
+  void notifySponsoredReceiptSubmitter({
+    contentHash: content_hash,
+    operator: operatorSs58,
+    authTier: "bearer",
+    schemaHash: schema_hash,
+    source: METERING_V2_SOURCE,
+  });
+
+  res.status(200).json({
+    ok: true,
+    status: "accepted",
+    content_hash,
+    schema_hash,
+    worker_id: record.worker_id,
+    operator: operatorSs58,
+    observer_present: Boolean(record.observer),
+    sponsored_receipt_submitter_configured:
+      Boolean(config.sponsoredReceiptSubmitterUrl),
+  });
+}
+
+/**
+ * Quick test export: shape of an accepted v2 response, useful for type-
+ * narrowing in the TS test suite.
+ */
+export interface V2AcceptedBody {
+  ok: true;
+  status: "accepted" | "replay";
+  content_hash: string;
+  schema_hash: string;
+  worker_id: string;
+  operator?: string;
+  observer_present?: boolean;
+  sponsored_receipt_submitter_configured?: boolean;
+}
+
+/** Re-export of the v2 schema hash so route consumers don't need to import it themselves. */
+export { SCHEMA_HASH_HEX as SCHEMA_HASH_HEX_V2 };
+
+/** Re-export the V2 record type so test files can declare typed variables. */
+export type { ComputeMeteringV2 };

--- a/services/blob-gateway/src/routes/metering_v2.ts
+++ b/services/blob-gateway/src/routes/metering_v2.ts
@@ -12,38 +12,69 @@
  *   - Observer (optional, registered third party) co-signs the same pre-image
  *     as the worker. Adds an independent witness for high-trust workloads.
  *
- * 11 validation rules (enforced in this order, fail-fast on first):
+ * 11 validation rules — fail-fast in this order:
  *
- *   (1) Schema validates structurally — delegate to validateComputeMeteringV2
- *   (2) period_end_ms - period_start_ms ≤ 86_400_000 (24 h)
- *   (3) period_end_ms ≤ now + 60_000 (clock-skew tolerance)
- *   (4) All metric values ≥ 0 (already enforced by structural validator —
- *       re-asserted here as belt-and-suspenders)
- *   (5) cpu_seconds ≤ cpu_cores × period_sec × 1.05
- *   (6) ram_gb_hours ≤ ram_gb × period_hr × 1.05
- *   (7) gpu_seconds = 0 if gpu_type=none OR gpu_count=0 (already enforced
- *       structurally; checked here to keep ALL bound logic in one place)
- *   (8) fleet_operator_pubkey exists in fleet_operators table AND not revoked
- *   (9) fleet_operator_signature valid sr25519 over its documented pre-image
- *  (10) worker_signature valid sr25519 over its documented pre-image
- *  (11) If observer present: observer_pubkey exists AND not revoked AND sig valid
+ *   (1) Schema shape + IDs + period + bound checks → delegated to
+ *       `validateComputeMeteringV2(raw, { verify_signatures: false })`.
+ *       Team 1's canonical validator emits structural codes:
+ *         INVALID_JSON, MISSING_FIELD, WRONG_TYPE, WRONG_SCHEMA_VERSION,
+ *         ID_FORMAT, PERIOD_INVALID, NEGATIVE_VALUE, BOUND_EXCEEDED,
+ *         INT_OVERFLOW, HEX_FORMAT, GPU_TYPE_INVALID, GPU_COUNT_MISMATCH,
+ *         HARDWARE_BOUND.
+ *       `statusForStructuralCode` maps shape errors to 400 and bound
+ *       violations (rules 4-7) to 422.
  *
- * On accept:
- *   - persist receipt manifest under receipts/{contentHash}/manifest.json
- *   - update worker_state (last_period_start, last_content_hash)
- *   - append per-record billing snapshot to metering_submissions
- *   - fire-and-forget notify the sponsored-receipt-submitter with
- *     schema_hash = SCHEMA_HASH_HEX_V2 + source = "compute-metering-v2"
+ *   (8) `fleet_operator_pubkey` exists in `fleet_operators` table AND is not
+ *       revoked. Status 403, code FLEET_OPERATOR_UNKNOWN.
  *
- * HTTP status mapping (mirrors the v1 dispatcher's stable codes):
+ *   (9) `fleet_operator_signature` is a valid sr25519 over the documented
+ *       fleet-op pre-image. Status 401, code FLEET_OPERATOR_SIG_INVALID.
  *
- *   400 — schema malformed (rule 1) or period bounds violated (rules 2, 3)
- *   422 — metrics out of bounds (rules 4, 5, 6, 7)
- *   403 — fleet operator unknown or revoked (rule 8)
+ *  (10) `worker_signature` is a valid sr25519 over the documented worker
+ *       pre-image (which itself includes the fleet-op signature, so worker
+ *       attests to having seen the same hardware claim). Status 401, code
+ *       WORKER_SIG_INVALID.
+ *
+ *  (11) When `observer` is present:
+ *         (a) `observer_pubkey` exists AND is not revoked. Status 403, code
+ *             OBSERVER_UNKNOWN.
+ *         (b) `observer_signature` verifies against the SAME bytes as the
+ *             worker pre-image. Status 401, code OBSERVER_SIG_INVALID.
+ *
+ *   Replay shortcut: same `worker_id` + `content_hash` resubmitted →
+ *   200 status:replay. No double-notify of the sponsored-receipt-submitter.
+ *
+ *   Monotonic guard: incoming `period_start_ms` < last observed for this
+ *   worker → 409 MONOTONIC_VIOLATION.
+ *
+ * --- Why we run the structural validator with verify_signatures:false ---
+ *
+ * Team 1's `validateComputeMeteringV2` will, by default, also verify all
+ * sr25519 signatures and emit `FLEET_OP_SIGNATURE_INVALID` /
+ * `WORKER_SIGNATURE_INVALID` / `OBSERVER_SIGNATURE_INVALID`. Those codes are
+ * conceptually correct but they map awkwardly onto the route's HTTP-status
+ * + audit-log contract (we want 401 for sig fails, with route-stable codes
+ * `FLEET_OPERATOR_SIG_INVALID` / `WORKER_SIG_INVALID` / `OBSERVER_SIG_INVALID`,
+ * AND we want to log a `metering_v2_auth_fail` line first).
+ *
+ * Asking the validator for structure-only output (verify_signatures:false)
+ * lets the route own all auth concerns (registry membership + sig verify +
+ * audit log) in one place, with one error contract, while still leaning on
+ * Team 1's encoder + structural rules so the schema is byte-for-byte the
+ * canonical implementation.
+ *
+ * --- HTTP status mapping ---
+ *
+ *   400 — schema shape / period / hex / gpu type / id format
+ *   422 — bound violations (cpu/ram/gpu)
+ *   403 — fleet operator or observer unknown / revoked (rules 8, 11.a)
  *   401 — fleet operator sig invalid (9), worker sig invalid (10),
- *         observer sig invalid (11)
- *   409 — replay (same content_hash) OR monotonic regression on period_start_ms
+ *         observer sig invalid (11.b)
+ *   409 — monotonic regression on period_start_ms
  *   500 — unexpected internal error
+ *
+ *  Replay (already-seen content_hash) returns 200 status:replay, NOT 409 —
+ *  retries by the worker SDK after a network blip should be idempotent.
  */
 
 import type { Request, Response } from "express";
@@ -56,9 +87,7 @@ import {
   canonicalCborForWorkerSig,
   SCHEMA_HASH_HEX,
   SCHEMA_VERSION,
-  MAX_PERIOD_MS,
-  FUTURE_SKEW_MS,
-  JITTER_FACTOR,
+  workerPubkeyToSs58,
   type ComputeMeteringV2,
   type ValidateErrorCode,
 } from "../schemas/compute_metering_v2.js";
@@ -70,7 +99,6 @@ import {
   recordMeteringSubmission,
   isReplayedContent,
 } from "../worker_bounds.js";
-import { workerPubkeyToSs58 } from "../schemas/compute_metering_v1.js";
 import { notifySponsoredReceiptSubmitter } from "../sponsored-receipts.js";
 import { saveManifest, updateReceiptMeta } from "../storage.js";
 
@@ -78,24 +106,17 @@ import { saveManifest, updateReceiptMeta } from "../storage.js";
 export const METERING_V2_SOURCE = "compute-metering-v2" as const;
 
 /**
- * Stable error codes for v2-specific failures (rules not covered by the
- * structural validator's own ValidateErrorCode union).
+ * Stable error codes the v2 route can emit. Includes the structural codes
+ * passed through from Team 1's validator (when `verify_signatures:false`)
+ * plus the route-owned auth/replay/monotonic codes.
  */
 export type V2RouteErrorCode =
   | ValidateErrorCode
-  | "PERIOD_TOO_LONG"
-  | "PERIOD_FUTURE_SKEW"
-  | "CPU_OVER_HARDWARE"
-  | "RAM_OVER_HARDWARE"
   | "FLEET_OPERATOR_UNKNOWN"
-  | "FLEET_OPERATOR_REVOKED"
   | "FLEET_OPERATOR_SIG_INVALID"
   | "WORKER_SIG_INVALID"
   | "OBSERVER_UNKNOWN"
-  | "OBSERVER_REVOKED"
   | "OBSERVER_SIG_INVALID"
-  | "REPLAY_CONTENT_HASH"
-  | "MONOTONIC_VIOLATION"
   | "INTERNAL";
 
 interface V2RejectBody {
@@ -123,6 +144,9 @@ function reject(
  * `| grep metering_v2_auth_fail` gives a clean stream.
  *
  * Per the task spec: never log full pubkeys, never log signatures.
+ * The `pubkey_prefix` is the first 16 lowercase hex chars (8 bytes) — enough
+ * for an operator to correlate against their roster, not enough to recover
+ * the key.
  */
 function logAuthFail(
   reason: string,
@@ -158,28 +182,35 @@ function verifySr25519(
 /**
  * Map a structural-validator error code to its v2-route HTTP status.
  *
- * Note: the route layer's per-rule failures (PERIOD_TOO_LONG, etc.) are
- * handled inline in `handleV2Submit`; this mapping only covers the codes the
- * SCHEMA validator can emit.
+ * Shape / format / wrong-version errors → 400. Bound violations → 422.
+ * Signature codes (`FLEET_OP_SIGNATURE_INVALID`, `WORKER_SIGNATURE_INVALID`,
+ * `OBSERVER_SIGNATURE_INVALID`, `MONOTONIC_VIOLATION`) are NEVER emitted by
+ * the validator on this route because we always pass `verify_signatures:
+ * false`; they're enumerated here for completeness so the switch is total.
  */
 function statusForStructuralCode(code: ValidateErrorCode): number {
   switch (code) {
     case "INVALID_JSON":
     case "MISSING_FIELD":
     case "WRONG_TYPE":
+    case "WRONG_SCHEMA_VERSION":
     case "ID_FORMAT":
     case "PERIOD_INVALID":
     case "HEX_FORMAT":
     case "GPU_TYPE_INVALID":
       return 400;
-    case "WRONG_SCHEMA_VERSION":
     case "NEGATIVE_VALUE":
     case "BOUND_EXCEEDED":
     case "INT_OVERFLOW":
     case "GPU_COUNT_MISMATCH":
+    case "HARDWARE_BOUND":
       return 422;
-    default:
-      return 400;
+    case "FLEET_OP_SIGNATURE_INVALID":
+    case "WORKER_SIGNATURE_INVALID":
+    case "OBSERVER_SIGNATURE_INVALID":
+      return 401;
+    case "MONOTONIC_VIOLATION":
+      return 409;
   }
 }
 
@@ -195,9 +226,12 @@ export async function handleV2Submit(
 ): Promise<void> {
   const nowMs = Date.now();
 
-  // Rule 1 — structural validation (also pulls workers / metrics / hardware
-  // out of the raw input).
-  const sv = validateComputeMeteringV2(raw);
+  // Rules 1-7 — structural validation (shape + period bounds + clock skew +
+  // non-negativity + cpu/ram/gpu bound checks). We disable signature
+  // verification here so the route can own auth-related error codes + audit
+  // logging. Team 1's encoder is still called below for the canonical
+  // pre-image bytes used in our sr25519 verifies.
+  const sv = validateComputeMeteringV2(raw, { verify_signatures: false });
   if (!sv.ok) {
     reject(
       res,
@@ -208,86 +242,7 @@ export async function handleV2Submit(
     );
     return;
   }
-  const { record, content_hash, schema_hash } = sv;
-
-  // Rule 2 — period_end_ms - period_start_ms <= 86_400_000
-  const periodMs = record.period_end_ms - record.period_start_ms;
-  if (periodMs > MAX_PERIOD_MS) {
-    reject(
-      res,
-      400,
-      "PERIOD_TOO_LONG",
-      `period (period_end_ms - period_start_ms) must be <= ${MAX_PERIOD_MS} ms (24 h), got ${periodMs}`,
-      "period_end_ms",
-    );
-    return;
-  }
-
-  // Rule 3 — period_end_ms <= now + 60_000 (clock skew)
-  if (record.period_end_ms > nowMs + FUTURE_SKEW_MS) {
-    reject(
-      res,
-      400,
-      "PERIOD_FUTURE_SKEW",
-      `period_end_ms ${record.period_end_ms} exceeds now+${FUTURE_SKEW_MS}ms`,
-      "period_end_ms",
-    );
-    return;
-  }
-
-  // Rule 4 — non-negative metrics. The structural validator already enforces
-  // this, so this is a sanity-check assertion here. We KEEP this to satisfy
-  // the spec's "rule 4" line and to fail closed if the structural validator
-  // ever loosens.
-  for (const [key, val] of Object.entries(record.metrics) as Array<[string, number]>) {
-    if (val < 0) {
-      reject(res, 422, "NEGATIVE_VALUE", `metric ${key} must be >= 0, got ${val}`, key);
-      return;
-    }
-  }
-
-  // Rules 5 + 6 — hardware-bound CPU / RAM caps with 5% tolerance.
-  const periodSec = periodMs / 1000;
-  const periodHr = periodMs / 3_600_000;
-  const cpuCap = record.hardware_spec.cpu_cores * periodSec * JITTER_FACTOR;
-  if (record.metrics.cpu_seconds > cpuCap) {
-    reject(
-      res,
-      422,
-      "CPU_OVER_HARDWARE",
-      `cpu_seconds ${record.metrics.cpu_seconds} exceeds hardware cap ${cpuCap.toFixed(3)} (cpu_cores=${record.hardware_spec.cpu_cores}, period_sec=${periodSec}, tolerance=${JITTER_FACTOR})`,
-      "cpu_seconds",
-    );
-    return;
-  }
-  const ramCap = record.hardware_spec.ram_gb * periodHr * JITTER_FACTOR;
-  if (record.metrics.ram_gb_hours > ramCap) {
-    reject(
-      res,
-      422,
-      "RAM_OVER_HARDWARE",
-      `ram_gb_hours ${record.metrics.ram_gb_hours} exceeds hardware cap ${ramCap.toFixed(3)} (ram_gb=${record.hardware_spec.ram_gb}, period_hr=${periodHr.toFixed(3)}, tolerance=${JITTER_FACTOR})`,
-      "ram_gb_hours",
-    );
-    return;
-  }
-
-  // Rule 7 — GPU consistency. Structural validator already checks this.
-  // Re-enforced inline so an audit reading just this file sees the rule.
-  if (
-    (record.hardware_spec.gpu_type === "none" ||
-      record.hardware_spec.gpu_count === 0) &&
-    record.metrics.gpu_seconds !== 0
-  ) {
-    reject(
-      res,
-      422,
-      "GPU_COUNT_MISMATCH",
-      `gpu_seconds must be 0 when gpu_type="none" or gpu_count=0`,
-      "gpu_seconds",
-    );
-    return;
-  }
+  const { record, content_hash, schema_hash, worker_pre_image, fleet_op_pre_image } = sv;
 
   // Rule 8 — fleet operator must exist + not revoked.
   if (!isFleetOperatorActive(record.hardware_spec.fleet_operator_pubkey)) {
@@ -302,11 +257,12 @@ export async function handleV2Submit(
     return;
   }
 
-  // Rule 9 — fleet_operator_signature valid sr25519.
-  const fleetOpPreimage = canonicalCborForFleetOpSig(record.worker_id, record.hardware_spec);
+  // Rule 9 — fleet_operator_signature valid sr25519. Pre-image bytes come
+  // straight from Team 1's canonical encoder via the validator's return
+  // value, so worker SDKs in any language can sign the same bytes.
   if (
     !verifySr25519(
-      fleetOpPreimage,
+      fleet_op_pre_image,
       record.hardware_spec.fleet_operator_pubkey,
       record.hardware_spec.fleet_operator_signature,
     )
@@ -323,11 +279,11 @@ export async function handleV2Submit(
   }
 
   // Rule 10 — worker_signature valid sr25519 over the full pre-image
-  // (including the fleet_operator_signature already verified above).
-  const workerPreimage = canonicalCborForWorkerSig(record);
+  // (including the fleet_operator_signature already verified above —
+  // tampering with either fleet portion or worker portion breaks this).
   if (
     !verifySr25519(
-      workerPreimage,
+      worker_pre_image,
       record.worker_pubkey,
       record.worker_signature,
     )
@@ -345,7 +301,8 @@ export async function handleV2Submit(
 
   // Rule 11 — observer (optional). When present, must be registered, not
   // revoked, and the signature must verify against the SAME pre-image as the
-  // worker signature.
+  // worker signature. Order matches rules 8/9 for consistency: registry
+  // first, then sig.
   if (record.observer) {
     if (!isObserverActive(record.observer.observer_pubkey)) {
       logAuthFail("observer_unknown_or_revoked", record.observer.observer_pubkey);
@@ -360,7 +317,7 @@ export async function handleV2Submit(
     }
     if (
       !verifySr25519(
-        workerPreimage,
+        worker_pre_image,
         record.observer.observer_pubkey,
         record.observer.observer_signature,
       )
@@ -379,9 +336,8 @@ export async function handleV2Submit(
 
   // Replay shortcut — same record submitted twice in a row → 200 status:replay.
   // We use the same per-worker single-slot dedup as v1 (cheap, off the chain
-  // anti-replay). Note: this only catches an immediate retry of the SAME
-  // content_hash. A different record with monotonic-violating period_start
-  // is caught below.
+  // anti-replay). This catches an immediate retry of the SAME content_hash.
+  // The chain is the canonical anti-replay; this is a friendly local guard.
   if (isReplayedContent(record.worker_id, content_hash)) {
     res.status(200).json({
       ok: true,
@@ -392,16 +348,6 @@ export async function handleV2Submit(
     });
     return;
   }
-
-  // Replay against a DIFFERENT historical record with the same content_hash
-  // is a 409 — distinct from the same-record retry above. (We can detect this
-  // because content_hash matches but worker_state.last_content_hash doesn't,
-  // which happens when the replayed record predates the most recent one.)
-  // NOTE: The chain is the canonical anti-replay; this is a friendly local
-  // guard, not the only line of defence. We do NOT have a full historical
-  // content_hash store at the gateway — that lives in the chain. So we treat
-  // the replay shortcut above as the only deterministic local replay guard
-  // and rely on the chain to enforce uniqueness of content_hash.
 
   // Monotonic non-decreasing period_start_ms per worker_id (replay/rewind
   // guard). This is the same rule v1 enforces for `period_start`; we apply
@@ -489,3 +435,11 @@ export { SCHEMA_HASH_HEX as SCHEMA_HASH_HEX_V2 };
 
 /** Re-export the V2 record type so test files can declare typed variables. */
 export type { ComputeMeteringV2 };
+
+// Expose the canonical encoders to test files that need to forge or
+// re-derive pre-images for negative tests. Re-exporting from this module
+// keeps the route as the single import surface for v2 callers.
+export {
+  canonicalCborForFleetOpSig,
+  canonicalCborForWorkerSig,
+};

--- a/services/blob-gateway/src/routes/observers.ts
+++ b/services/blob-gateway/src/routes/observers.ts
@@ -1,0 +1,165 @@
+/**
+ * Admin routes for the OBSERVERS registry (compute_metering_v2 optional
+ * co-signers).
+ *
+ *   POST   /admin/observers            -- register a new observer
+ *   DELETE /admin/observers/:pubkey    -- mark an observer revoked
+ *   GET    /admin/observers            -- list all (active + revoked)
+ *
+ * Same admin-token gating + 503-when-unconfigured pattern as
+ * `routes/fleet_operators.ts` and `routes/tokens.ts`.
+ */
+
+import type { Express, Request, Response } from "express";
+import { config } from "../config.js";
+import { adminGuard } from "../bearer-auth.js";
+import {
+  registerObserver,
+  revokeObserver,
+  getObserver,
+  listObservers,
+  type ObserverRow,
+} from "../observers.js";
+
+const HEX64_LOOSE = /^(0x)?[0-9a-fA-F]{64}$/;
+
+export interface RegisterObserverRoutesOpts {
+  /** Admin shared secret (falls back to config.daemonNotifyToken if empty). */
+  adminToken?: string;
+}
+
+function rowToJson(row: ObserverRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    pubkey_hex: row.pubkey_hex,
+    label: row.label,
+    registered_at: row.registered_at,
+    revoked_at: row.revoked_at,
+    notes: row.notes,
+  };
+}
+
+export function registerObserverRoutes(
+  app: Express,
+  opts: RegisterObserverRoutesOpts = {},
+): void {
+  const adminToken = (opts.adminToken || config.daemonNotifyToken || "").trim();
+  if (!adminToken) {
+    app.post("/admin/observers", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    app.delete("/admin/observers/:pubkey", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    app.get("/admin/observers", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    return;
+  }
+  const guard = adminGuard(adminToken);
+
+  app.post("/admin/observers", guard, (req: Request, res: Response) => {
+    try {
+      const body = (req.body ?? {}) as {
+        pubkey?: unknown;
+        label?: unknown;
+        notes?: unknown;
+      };
+      if (typeof body.pubkey !== "string" || !HEX64_LOOSE.test(body.pubkey)) {
+        res.status(400).json({
+          error: "pubkey is required and must be 32 bytes hex (64 chars, optional 0x prefix)",
+        });
+        return;
+      }
+      const label =
+        typeof body.label === "string" && body.label.trim()
+          ? body.label.trim()
+          : null;
+      const notes =
+        typeof body.notes === "string" && body.notes.trim()
+          ? body.notes.trim()
+          : null;
+
+      const existing = getObserver(body.pubkey);
+      if (existing) {
+        res.status(409).json({
+          error: "observer already registered",
+          existing: rowToJson(existing),
+        });
+        return;
+      }
+
+      const row = registerObserver({
+        pubkey: body.pubkey,
+        label,
+        notes,
+      });
+
+      console.log(
+        `[blob-gateway] observer registered pubkey_prefix=${row.pubkey_hex.slice(0, 16)} label=${label ?? "-"}`,
+      );
+
+      res.status(200).json({
+        status: "created",
+        observer: rowToJson(row),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/UNIQUE/i.test(msg)) {
+        res.status(409).json({ error: "observer already registered" });
+        return;
+      }
+      res.status(500).json({ error: msg });
+    }
+  });
+
+  app.delete(
+    "/admin/observers/:pubkey",
+    guard,
+    (req: Request, res: Response) => {
+      try {
+        const pubkey = String(req.params.pubkey || "");
+        if (!HEX64_LOOSE.test(pubkey)) {
+          res.status(400).json({
+            error: "invalid pubkey (expected 64 hex chars, optional 0x prefix)",
+          });
+          return;
+        }
+        const row = getObserver(pubkey);
+        if (!row) {
+          res.status(404).json({ error: "observer not found" });
+          return;
+        }
+        const ok = revokeObserver(pubkey);
+        if (!ok) {
+          res.status(200).json({
+            status: "already-revoked",
+            observer: rowToJson(getObserver(pubkey)!),
+          });
+          return;
+        }
+        console.log(
+          `[blob-gateway] observer revoked pubkey_prefix=${row.pubkey_hex.slice(0, 16)}`,
+        );
+        res.status(200).json({
+          status: "revoked",
+          observer: rowToJson(getObserver(pubkey)!),
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        res.status(500).json({ error: msg });
+      }
+    },
+  );
+
+  app.get("/admin/observers", guard, (req: Request, res: Response) => {
+    try {
+      const active = req.query.active === "1" || req.query.active === "true";
+      const rows = listObservers(active ? { active: true } : {});
+      res.status(200).json({ observers: rows.map(rowToJson) });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: msg });
+    }
+  });
+}

--- a/services/blob-gateway/src/schemas/__tests__/metering_route.test.ts
+++ b/services/blob-gateway/src/schemas/__tests__/metering_route.test.ts
@@ -336,7 +336,11 @@ describe("POST /metering/submit — failure modes", () => {
   });
 
   test("wrong schema_version → 422", async () => {
-    const rec = { ...buildSigned(), schema_version: "compute_metering_v2" };
+    // Use a clearly-unknown schema_version so the dispatcher routes to the v1
+    // validator (any non-v2 / non-v1 schema string falls through). The v2
+    // dispatch trigger ("compute_metering_v2") is no longer "wrong" now that
+    // v2 is live — see metering_v2_route.test.ts for v2-side rejection tests.
+    const rec = { ...buildSigned(), schema_version: "compute_metering_vfuture" };
     const res = await fetchJson(ctx.app, "POST", "/metering/submit", rec);
     expect(res.status).toBe(422);
   });


### PR DESCRIPTION
Wave 1+2 Team 2 of 3: extends blob-gateway to validate `compute_metering_v2` records, adds `fleet_operators` and `observers` SQLite registries with admin endpoints, and dispatches v1/v2 by `schema_version`. v1 path untouched — backward compatible.

## ⚠️ Schema-file overlap with Team 1 (#26)

Team 2 shipped a 655-LoC stub of `services/blob-gateway/src/schemas/compute_metering_v2.ts` so it could implement against the pinned contract while Team 1 was still in flight. **Team 1's PR (#26) ships the real 1091-LoC version** — when #26 merges, Team 1's file replaces this stub 1:1 (the public exports match the spec, so the route layer + tests stay green).

**Merge order:** merge #26 first, then rebase this PR on the new main and drop the stub. I'll handle that step here once #26 lands.

## Files (14 files, +4506 / -1)

```
src/__tests__/fleet_operators.test.ts            +399  (32 tests)
src/__tests__/metering_v2_admin.test.ts          +518  (30 tests)
src/__tests__/metering_v2_live_preprod.test.ts   +379  (1 test, LIVE_PREPROD-gated)
src/__tests__/metering_v2_route.test.ts          +996  (39 tests)
src/__tests__/observers.test.ts                  +282  (22 tests)
src/fleet_operators.ts                           +224
src/index.ts                                      +11
src/observers.ts                                 +189
src/routes/fleet_operators.ts                    +176
src/routes/metering.ts                            +16  (v1/v2 dispatcher)
src/routes/metering_v2.ts                        +491
src/routes/observers.ts                          +165
src/schemas/__tests__/metering_route.test.ts      +6/-1
src/schemas/compute_metering_v2.ts               +655  (stub — replaced by #26 at merge)
```

## Tests

- **Baseline (origin/main):** 281 + 2 skipped
- **Branch:** 404 + 3 skipped → **+123 passing**
- All 5 new test files green
- TypeScript clean (`tsc --noEmit` exit 0)
- Live preprod test skips cleanly when `LIVE_PREPROD` unset

## Validation rules enforced (all 11)

1-7: structural + bounds + hardware-spec admits values
8: `fleet_operator_pubkey` ∈ registered `fleet_operators` table AND not revoked
9: `fleet_operator_signature` valid sr25519
10: `worker_signature` valid sr25519
11: optional observer signature valid

## Status codes

| Failure | HTTP |
|---|---|
| Schema malformed | 400 |
| Period bounds violated | 400 |
| Metrics out of bounds | 422 |
| Fleet operator unknown/revoked | 403 |
| Fleet/worker/observer sig invalid | 401 |
| Replay (same content_hash) | 200 with status:replay |
| Monotonic regression | 409 |

## Migration verification

Real on-disk SQLite tested in fresh-temp-dir + reopen + concurrent-handle scenarios for both registries. Pre-existing rows survive re-init (idempotent CREATE IF NOT EXISTS verified end-to-end). Two simultaneous `Database()` handles both pass init without error.

## Audit logging

Auth failures emit structured warn-log: `event=metering_v2_auth_fail reason=&lt;which&gt; pubkey_prefix=&lt;first 16 hex&gt;`. Never full pubkeys, never signatures (asserted in test).

## Trace

`2a69bcad-1a5f-4ea7-ad26-12049fb167e5` (finalized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)