### PR TITLE
feat(compute-meter-sdk): compute_metering_v2 envelope (Wave 1+2 Team 3)

### DIFF
--- a/packages/compute-meter-sdk/README.md
+++ b/packages/compute-meter-sdk/README.md
@@ -13,6 +13,17 @@ the TypeScript gateway validator (`services/blob-gateway/src/schemas/
 compute_metering_v1.ts`) stay byte-pinned together. CI verifies the
 canonical CBOR encoders agree across both languages on every PR.
 
+## Schema versions
+
+| Version | Schema string         | Status     | Adds |
+|---------|-----------------------|------------|------|
+| v1      | `compute_metering_v1` | shipped    | original worker-signed record |
+| v2      | `compute_metering_v2` | 0.2.0-rc1  | mandatory `hardware_spec` (FPS-fleet-operator-signed); optional `observer` co-signature (Wave 2) |
+
+v1 stays untouched — backward compat is mandatory. v2 is opt-in: build a
+v2 record with `build_record_v2(...)` + `sign_record_v2(...)` and submit
+via `submit_v2(...)`.
+
 ## Install
 
 From PyPI (recommended for production workers):
@@ -29,7 +40,7 @@ cd orynq-sdk/packages/compute-meter-sdk
 pip install -e '.[dev]'
 ```
 
-## Usage
+## Usage — v1 (existing)
 
 ```python
 from materios_compute_meter import WorkerKeypair, MeteringRecord, submit
@@ -67,6 +78,103 @@ print(signed.content_hash, signed.signature[:16] + "...")
 result = submit(signed, gateway_url=..., api_key=...)
 ```
 
+## Usage — v2 (new in 0.2.0-rc1)
+
+v2 envelopes carry a **mandatory `hardware_spec`** that's signed by an
+FPS-registered fleet operator (so a worker can't lie about its cores) and
+an **optional observer co-signature** (Wave 2: an independent observer
+attests to the same metric set the worker signed).
+
+### Fleet operator workflow (offline / FPS-internal)
+
+The fleet operator runs a one-time signing ceremony per worker (or per
+hardware re-provisioning). Production fleet operators use HSM-backed
+keys; tests and local dev can use `from_seed_hex` for determinism.
+
+```python
+from materios_compute_meter import WorkerKeypair, sign_hardware_spec
+
+fleet_kp = WorkerKeypair.load("/secrets/fleet-operator.json")  # offline / HSM
+spec = sign_hardware_spec(
+    worker_id="worker-001",
+    cpu_cores=8,
+    ram_gb=32,
+    gpu_type="none",        # "none" | "nvidia-h100" | ... | "custom"
+    gpu_count=0,
+    issued_ms=1_700_000_000_000,
+    fleet_operator_keypair=fleet_kp,
+)
+spec.save("/etc/materios/hardware.json")  # ship to the worker
+```
+
+### Worker workflow
+
+```python
+from materios_compute_meter import (
+    HardwareSpec, WorkerKeypair,
+    build_record_v2, sign_record_v2,
+    submit_v2,
+)
+
+# 1) Load the fleet-signed hardware spec at startup.
+spec = HardwareSpec.load("/etc/materios/hardware.json")
+assert spec.verify("worker-001"), "hardware spec was issued for a different worker"
+
+# 2) Load (or generate) a worker key.
+worker_kp = WorkerKeypair.load("/var/lib/materios/worker-key.json")
+
+# 3) For each billable interval, build + sign + submit a v2 envelope.
+body = build_record_v2(
+    worker_id="worker-001",
+    tenant_id="tenant-acme",
+    period_start_ms=1_700_000_000_000,
+    period_end_ms=1_700_000_060_000,
+    metrics={
+        "cpu_seconds": 60,
+        "ram_gb_hours": 0.25,
+        "disk_gb_hours": 0.0,
+        "net_bytes_in": 1024,
+        "net_bytes_out": 512,
+        "gpu_seconds": 0,
+    },
+    hardware_spec=spec,
+)
+sealed = sign_record_v2(body, worker_kp)
+res = submit_v2(
+    sealed,
+    gateway_url="https://materios.fluxpointstudios.com/preprod-blobs",
+    bearer="matra_...",
+)
+print(res.receipt_id, res.content_hash)
+```
+
+### Observer workflow (Wave 2 — optional)
+
+An independent observer (a watchdog process, peer worker, or third-party
+attestor) co-signs the SAME canonical bytes the worker signed. Different
+key, same payload. The observer's role is to stake reputation on the
+honesty of the metric set — it does NOT add metrics of its own.
+
+```python
+from materios_compute_meter import ObserverKeypair, attach_observer_signature_v2
+
+observer_kp = ObserverKeypair.load("/var/lib/materios/observer-key.json")
+co_signed = attach_observer_signature_v2(sealed, observer_kp)
+res = submit_v2(co_signed, gateway_url=..., bearer=...)
+```
+
+### Migration from v1
+
+* v1 calls (`submit(...)`, `MeteringRecord`, `WorkerKeypair.sign(...)`)
+  remain unchanged. You can mix v1 and v2 submissions in the same process.
+* The gateway routes both v1 and v2 to `/metering/submit`; the
+  `schema_version` field discriminates.
+* The replay cache is shared per-(worker_id) across v1 and v2 — switching
+  schema versions in mid-stream still respects monotonic period_start_ms.
+* `content_hash` semantics differ: v1 hashes the flat record; v2 hashes
+  the v2 pre-image (worker-sig pre-image, observer-stripped). Don't try
+  to compare hashes across versions — they won't match by design.
+
 ## Loading existing keys
 
 ```python
@@ -89,7 +197,7 @@ The gateway also rejects replays server-side at the
 `(signer_pub, period_start_ms)` tuple — the SDK's local cache is a
 defense-in-depth + cost-saving check.
 
-## Wire format
+## Wire format — v1
 
 The signed payload is `sha256(canonical_cbor(record_without_signature))`.
 The gateway request body is:
@@ -110,6 +218,87 @@ Canonical CBOR rules:
 - Only built-in primitives (dict / list / tuple / str / bytes / int /
   float / bool / None) are accepted; foreign types are rejected with
   `TypeError` so the canonical form cannot drift via custom encoders.
+
+## Wire format — v2
+
+The v2 envelope carries THREE signatures over distinct (overlapping)
+pre-images:
+
+1. `fleet_operator_signature` — issued offline by FPS, attests that this
+   `worker_id` is bound to a specific (cpu_cores, ram_gb, gpu_type, ...)
+   spec. Pre-image = sorted-key canonical CBOR of
+   `{schema_version, worker_id, hardware_spec MINUS fleet_operator_signature}`.
+2. `worker_signature` — sealed by the worker each interval. Pre-image =
+   the full record MINUS `worker_signature` AND `observer`.
+3. `observer_signature` (optional, Wave 2) — co-signed over the SAME
+   bytes the worker signed; different key.
+
+Wire body (`POST /metering/submit`, with `Bearer <token>` and
+`X-Schema-Version: compute_metering_v2` headers):
+
+```json
+{
+  "schema_version": "compute_metering_v2",
+  "worker_id": "...",
+  "tenant_id": "...",
+  "period_start_ms": ...,
+  "period_end_ms": ...,
+  "metrics": {
+    "cpu_seconds": int, "ram_gb_hours": float, "disk_gb_hours": float,
+    "net_bytes_in": int, "net_bytes_out": int, "gpu_seconds": int
+  },
+  "hardware_spec": {
+    "cpu_cores": int, "ram_gb": int,
+    "gpu_type": "...", "gpu_count": int,
+    "fleet_operator_pubkey_hex":     "<64 hex>",
+    "fleet_operator_signature_hex":  "<128 hex>",
+    "issued_ms": int
+  },
+  "worker_pubkey_hex":     "<64 hex>",
+  "worker_signature_hex":  "<128 hex>",
+  "observer": {
+    "observer_pubkey_hex":     "<64 hex>",
+    "observer_signature_hex":  "<128 hex>"
+  }
+}
+```
+
+Canonical CBOR rules for v2:
+- Map keys sorted lexicographically by encoded-byte order (RFC 8949 §4.2.1).
+- Strings: UTF-8 (major type 3); bytes: major type 2.
+- Integers: shortest form (uint major 0/1).
+- Whole-valued floats encode as integers (e.g. `64.0` → `uint(64)`) for
+  parity with the JS encoder where `Number.isInteger(64.0) === true`.
+- Non-integer floats: ALWAYS IEEE-754 binary64 (8 bytes, BE). No f16/f32
+  shortening — the v1 TS encoder pinned this rule, v2 mirrors it.
+- NaN / Infinity rejected.
+
+The Python encoder (`canonical.canonical_cbor_v2`) and the TypeScript
+encoder (`services/blob-gateway/src/schemas/compute_metering_v1.ts`'s
+canonical body builder, plus `tests/_v2_ts_encoder.mjs` for v2-specific
+fields) produce byte-identical bytes for the same input — verified on
+every PR by `tests/test_v2_cross_language_bytes.py`.
+
+## CLI
+
+```bash
+# v2 submit, optional observer:
+python3 -m materios_compute_meter.cli submit-v2 \
+    --gateway https://materios.fluxpointstudios.com/preprod-blobs \
+    --bearer matra_xxx \
+    --hardware-spec /etc/materios/hardware.json \
+    --worker-key /var/lib/materios/worker-key.json \
+    --worker-id worker-001 \
+    --tenant-id tenant-acme \
+    --period-start-ms 1700000000000 \
+    --period-end-ms 1700000060000 \
+    --cpu-seconds 60 \
+    --ram-gb-hours 0.25 \
+    --observer-key /var/lib/materios/observer-key.json   # optional
+```
+
+Exit codes: `0`=success, `1`=config error, `2`=validation/replay,
+`3`=network/gateway.
 
 ## Testing
 

--- a/packages/compute-meter-sdk/pyproject.toml
+++ b/packages/compute-meter-sdk/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "materios-compute-meter"
-version = "0.1.1"
-description = "Worker signing identity SDK for Materios verifiable compute metering."
+version = "0.2.0-rc1"
+description = "Worker signing identity SDK for Materios verifiable compute metering (compute_metering_v1 + v2)."
 readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"

--- a/packages/compute-meter-sdk/src/materios_compute_meter/__init__.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/__init__.py
@@ -1,7 +1,7 @@
 """materios_compute_meter — worker signing identity SDK for Materios verifiable
 compute metering.
 
-Public API:
+Public API (v1, unchanged):
 
     from materios_compute_meter import (
         WorkerKeypair,
@@ -29,35 +29,126 @@ Public API:
 
     # Or one-shot:
     result = submit(kp, record, gateway_url="...", api_key="matra_...")
+
+Public API (v2, new — Wave 1+2):
+
+    from materios_compute_meter import (
+        # v1 above stays valid; v2 adds:
+        ObserverKeypair,
+        HardwareSpec,
+        sign_hardware_spec,
+        build_record_v2,
+        sign_record_v2,
+        attach_observer_signature_v2,
+        verify_record_v2,
+        next_period_start_ms,
+        submit_v2,
+        SubmissionResult,
+        SCHEMA_VERSION_V2,
+        SCHEMA_HASH_V2_HEX,
+        canonical_cbor_for_fleet_op_sig,
+        canonical_cbor_for_worker_sig,
+        canonical_cbor_for_observer_sig,
+        canonical_content_hash_v2,
+    )
+
+    # Load fleet-operator-signed hardware attestation:
+    spec = HardwareSpec.load("/etc/materios/hardware.json")
+    assert spec.verify("worker-001")
+
+    # Build + seal a v2 envelope:
+    body = build_record_v2(
+        worker_id="worker-001",
+        tenant_id="tenant-acme",
+        period_start_ms=1700000000000,
+        period_end_ms=1700000060000,
+        metrics={
+            "cpu_seconds": 60, "ram_gb_hours": 0.25, "disk_gb_hours": 0.0,
+            "net_bytes_in": 1024, "net_bytes_out": 512, "gpu_seconds": 0,
+        },
+        hardware_spec=spec,
+    )
+    sealed = sign_record_v2(body, worker_kp)
+
+    # Optional: attach an observer co-signature (Wave 2):
+    sealed = attach_observer_signature_v2(sealed, observer_kp)
+
+    # Submit:
+    res = submit_v2(sealed, gateway_url="...", bearer="matra_...")
+    print(res.receipt_id, res.content_hash)
 """
 from __future__ import annotations
 
+from .canonical import (
+    SCHEMA_HASH_V2_HEX,
+    SCHEMA_VERSION_V2,
+    canonical_cbor_for_fleet_op_sig,
+    canonical_cbor_for_observer_sig,
+    canonical_cbor_for_worker_sig,
+    canonical_content_hash_v2,
+)
 from .exceptions import (
     ComputeMeterError,
     GatewayError,
+    InvalidHardwareSpecError,
     InvalidKeyfileError,
     InvalidRecordError,
     InvalidSeedError,
+    InvalidV2RecordError,
     ReplayRejectedError,
     SubmitError,
 )
-from .keypair import WorkerKeypair
-from .record import MeteringRecord, Signed
-from .submit import submit
+from .hardware_spec import HardwareSpec, SUPPORTED_GPU_TYPES, sign_hardware_spec
+from .keypair import ObserverKeypair, WorkerKeypair
+from .record import (
+    MeteringRecord,
+    Signed,
+    attach_observer_signature_v2,
+    build_record_v2,
+    next_period_start_ms,
+    sign_record_v2,
+    verify_record_v2,
+)
+from .submit import SubmissionResult, submit, submit_v2
 
 __all__ = [
+    # v1
     "WorkerKeypair",
     "MeteringRecord",
     "Signed",
     "submit",
+    # v2 keys
+    "ObserverKeypair",
+    # v2 hardware spec
+    "HardwareSpec",
+    "SUPPORTED_GPU_TYPES",
+    "sign_hardware_spec",
+    # v2 record
+    "build_record_v2",
+    "sign_record_v2",
+    "attach_observer_signature_v2",
+    "verify_record_v2",
+    "next_period_start_ms",
+    # v2 submit
+    "submit_v2",
+    "SubmissionResult",
+    # v2 canonical helpers (re-exported for advanced verifiers)
+    "SCHEMA_VERSION_V2",
+    "SCHEMA_HASH_V2_HEX",
+    "canonical_cbor_for_fleet_op_sig",
+    "canonical_cbor_for_worker_sig",
+    "canonical_cbor_for_observer_sig",
+    "canonical_content_hash_v2",
     # Exceptions
     "ComputeMeterError",
     "GatewayError",
     "InvalidKeyfileError",
     "InvalidRecordError",
     "InvalidSeedError",
+    "InvalidHardwareSpecError",
+    "InvalidV2RecordError",
     "ReplayRejectedError",
     "SubmitError",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0-rc1"

--- a/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
@@ -297,11 +297,17 @@ def _v2_metrics_to_cbor(metrics: dict) -> _CborValue:
     )
 
 
-def _v2_hex_to_bytes(hex_str: str) -> bytes:
-    """Decode a 0x-prefix-less lowercase hex string to raw bytes."""
-    if not isinstance(hex_str, str):
-        raise TypeError(f"hex must be str, got {type(hex_str).__name__}")
-    return bytes.fromhex(hex_str)
+def _v2_hex_to_bytes(value) -> bytes:
+    """Coerce hex-string OR raw-bytes input to raw bytes.
+
+    Worker-side SDK passes raw bytes (32-byte sr25519 pubkey); gateway-side
+    passes hex strings (wire-decoded). Same canonical output either way.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        return bytes.fromhex(value.removeprefix("0x"))
+    raise TypeError(f"expected bytes or hex str, got {type(value).__name__}")
 
 
 def _v2_hardware_spec_no_sig_to_cbor(spec: dict) -> _CborValue:
@@ -422,6 +428,13 @@ def canonical_cbor_for_worker_sig(record: dict) -> bytes:
             ]
         )
     )
+
+
+# Observer signs the EXACT SAME bytes as the worker (per the v2 spec — observer
+# is an independent witness over the same record body). Exposed as an alias for
+# call-site clarity; do NOT diverge — gateway verifies both sigs against the
+# same pre-image.
+canonical_cbor_for_observer_sig = canonical_cbor_for_worker_sig
 
 
 def canonical_content_hash_v2(record: dict) -> str:

--- a/packages/compute-meter-sdk/src/materios_compute_meter/cli.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/cli.py
@@ -1,0 +1,298 @@
+"""Command-line interface for materios_compute_meter.
+
+Two subcommands:
+
+  * `submit`     — sign + POST a v1 (`compute_metering_v1`) record.
+  * `submit-v2`  — sign + POST a v2 (`compute_metering_v2`) record with a
+                   mandatory hardware_spec and optional observer co-sig.
+
+Examples:
+
+    # v1 (existing behaviour, unchanged):
+    python3 -m materios_compute_meter.cli submit \\
+        --gateway https://materios.fluxpointstudios.com/preprod-blobs \\
+        --bearer matra_xxx \\
+        --worker-id worker-001 \\
+        --tenant-id tenant-acme \\
+        --period-start-ms 1700000000000 \\
+        --period-end-ms 1700000060000 \\
+        --cpu-seconds 60 \\
+        --worker-key /var/lib/materios/worker-key.json
+
+    # v2 (new):
+    python3 -m materios_compute_meter.cli submit-v2 \\
+        --gateway https://materios.fluxpointstudios.com/preprod-blobs \\
+        --bearer matra_xxx \\
+        --hardware-spec /etc/materios/hardware.json \\
+        --worker-key /var/lib/materios/worker-key.json \\
+        --worker-id worker-001 \\
+        --tenant-id tenant-acme \\
+        --period-start-ms 1700000000000 \\
+        --period-end-ms 1700000060000 \\
+        --cpu-seconds 60 \\
+        --ram-gb-hours 0.25 \\
+        --disk-gb-hours 0 \\
+        --net-bytes-in 1024 \\
+        --net-bytes-out 512 \\
+        --gpu-seconds 0 \\
+        --observer-key /var/lib/materios/observer-key.json   # optional
+
+Exit codes:
+
+  0 = success
+  1 = configuration error (missing arg, file not found, etc.)
+  2 = validation / canonical error (bad metric, bad hardware spec, etc.)
+  3 = network / gateway error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from typing import List, Optional, Sequence
+
+from .exceptions import (
+    ComputeMeterError,
+    GatewayError,
+    InvalidHardwareSpecError,
+    InvalidV2RecordError,
+    ReplayRejectedError,
+    SubmitError,
+)
+from .hardware_spec import HardwareSpec
+from .keypair import ObserverKeypair, WorkerKeypair
+from .record import (
+    MeteringRecord,
+    attach_observer_signature_v2,
+    build_record_v2,
+    sign_record_v2,
+)
+from .submit import submit, submit_v2
+
+_LOG = logging.getLogger("materios_compute_meter.cli")
+
+
+# ---------------------------------------------------------------------------
+# v1 submit (kept for backward compat at the CLI level)
+# ---------------------------------------------------------------------------
+
+
+def _build_v1_parser(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--gateway", required=True, help="Gateway base URL")
+    p.add_argument(
+        "--bearer",
+        "--api-key",
+        dest="bearer",
+        required=True,
+        help="Bearer token (matra_*)",
+    )
+    p.add_argument("--worker-key", required=True, help="Path to worker keyfile")
+    p.add_argument("--worker-id", required=True)
+    p.add_argument("--tenant-id", required=True)
+    p.add_argument("--period-start-ms", type=int, required=True)
+    p.add_argument("--period-end-ms", type=int, required=True)
+    p.add_argument("--cpu-seconds", type=float, required=True)
+    p.add_argument("--ram-gb-hours", type=float, default=0.0)
+    p.add_argument("--disk-gb-hours", type=float, default=0.0)
+    p.add_argument("--net-bytes-in", type=int, default=0)
+    p.add_argument("--net-bytes-out", type=int, default=0)
+    p.add_argument("--gpu-seconds", type=float, default=0.0)
+
+
+def _run_v1_submit(args: argparse.Namespace) -> int:
+    kp = WorkerKeypair.load(args.worker_key)
+    rec = MeteringRecord(
+        worker_id=args.worker_id,
+        tenant_id=args.tenant_id,
+        period_start_ms=args.period_start_ms,
+        period_end_ms=args.period_end_ms,
+        cpu_seconds=args.cpu_seconds,
+        ram_gb_hours=args.ram_gb_hours,
+        disk_gb_hours=args.disk_gb_hours,
+        net_bytes_in=args.net_bytes_in,
+        net_bytes_out=args.net_bytes_out,
+        gpu_seconds=args.gpu_seconds,
+    )
+    res = submit(
+        kp,
+        rec,
+        gateway_url=args.gateway,
+        api_key=args.bearer,
+    )
+    print(json.dumps(res, indent=2, sort_keys=True))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# v2 submit
+# ---------------------------------------------------------------------------
+
+
+def _build_v2_parser(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--gateway", required=True, help="Gateway base URL")
+    p.add_argument(
+        "--bearer",
+        "--api-key",
+        dest="bearer",
+        required=True,
+        help="Bearer token (matra_*)",
+    )
+    p.add_argument(
+        "--hardware-spec",
+        required=True,
+        help="Path to fleet-operator-signed hardware spec JSON",
+    )
+    p.add_argument("--worker-key", required=True, help="Path to worker keyfile")
+    p.add_argument(
+        "--observer-key",
+        default=None,
+        help="OPTIONAL: path to observer keyfile to attach a co-signature",
+    )
+    p.add_argument("--worker-id", required=True)
+    p.add_argument("--tenant-id", required=True)
+    p.add_argument(
+        "--period-start-ms",
+        type=int,
+        default=None,
+        help="UNIX-epoch ms; defaults to now-60_000 if omitted",
+    )
+    p.add_argument(
+        "--period-end-ms",
+        type=int,
+        default=None,
+        help="UNIX-epoch ms; defaults to now if omitted",
+    )
+    p.add_argument("--cpu-seconds", type=int, required=True)
+    p.add_argument("--ram-gb-hours", type=float, default=0.0)
+    p.add_argument("--disk-gb-hours", type=float, default=0.0)
+    p.add_argument("--net-bytes-in", type=int, default=0)
+    p.add_argument("--net-bytes-out", type=int, default=0)
+    p.add_argument("--gpu-seconds", type=int, default=0)
+    p.add_argument(
+        "--skip-spec-verify",
+        action="store_true",
+        help="Skip the local fleet-operator-sig verify (default: verify on; "
+        "rejects an unverifiable spec before sending the record).",
+    )
+
+
+def _run_v2_submit(args: argparse.Namespace) -> int:
+    spec = HardwareSpec.load(args.hardware_spec)
+    if not args.skip_spec_verify:
+        if not spec.verify(args.worker_id):
+            print(
+                f"ERROR: hardware_spec at {args.hardware_spec} does not "
+                f"verify against worker_id={args.worker_id!r}. Re-issue the "
+                "spec or pass --skip-spec-verify if you know what you're doing.",
+                file=sys.stderr,
+            )
+            return 2
+
+    worker_kp = WorkerKeypair.load(args.worker_key)
+
+    now_ms = int(time.time() * 1000)
+    period_start_ms = (
+        args.period_start_ms if args.period_start_ms is not None else now_ms - 60_000
+    )
+    period_end_ms = (
+        args.period_end_ms if args.period_end_ms is not None else now_ms
+    )
+
+    body = build_record_v2(
+        worker_id=args.worker_id,
+        tenant_id=args.tenant_id,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+        metrics={
+            "cpu_seconds": args.cpu_seconds,
+            "ram_gb_hours": args.ram_gb_hours,
+            "disk_gb_hours": args.disk_gb_hours,
+            "net_bytes_in": args.net_bytes_in,
+            "net_bytes_out": args.net_bytes_out,
+            "gpu_seconds": args.gpu_seconds,
+        },
+        hardware_spec=spec,
+    )
+    sealed = sign_record_v2(body, worker_kp)
+    if args.observer_key:
+        observer_kp = ObserverKeypair.load(args.observer_key)
+        sealed = attach_observer_signature_v2(sealed, observer_kp)
+
+    result = submit_v2(
+        sealed,
+        gateway_url=args.gateway,
+        bearer=args.bearer,
+    )
+    print(
+        json.dumps(
+            {
+                "status_code": result.status_code,
+                "receipt_id": result.receipt_id,
+                "content_hash": result.content_hash,
+                "accepted_at": result.accepted_at,
+                "observer_attached": "observer" in sealed,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# entry point
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="materios_compute_meter.cli",
+        description=(
+            "CLI for the Materios verifiable-compute-metering SDK. Signs and "
+            "submits compute_metering_v1 / v2 records to a Materios blob gateway."
+        ),
+    )
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable INFO-level logging.",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    _build_v1_parser(sub.add_parser("submit", help="Submit a v1 record"))
+    _build_v2_parser(sub.add_parser("submit-v2", help="Submit a v2 record"))
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    try:
+        if args.cmd == "submit":
+            return _run_v1_submit(args)
+        if args.cmd == "submit-v2":
+            return _run_v2_submit(args)
+        parser.error(f"unknown command: {args.cmd!r}")
+        return 1  # pragma: no cover
+    except (InvalidHardwareSpecError, InvalidV2RecordError) as e:
+        print(f"ERROR (validation): {e}", file=sys.stderr)
+        return 2
+    except ReplayRejectedError as e:
+        print(f"ERROR (replay): {e}", file=sys.stderr)
+        return 2
+    except (GatewayError, SubmitError) as e:
+        print(f"ERROR (network/gateway): {e}", file=sys.stderr)
+        return 3
+    except ComputeMeterError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/compute-meter-sdk/src/materios_compute_meter/exceptions.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/exceptions.py
@@ -51,3 +51,27 @@ class ReplayRejectedError(ComputeMeterError):
     with `period_start_ms <= last_seen` for the same `worker_id`. This is
     the SDK's own pre-flight check; the gateway also rejects replays
     server-side as a defense in depth."""
+
+
+# ---------------------------------------------------------------------------
+# v2 (compute_metering_v2) exceptions
+# ---------------------------------------------------------------------------
+
+
+class InvalidHardwareSpecError(ComputeMeterError):
+    """Raised by `HardwareSpec.load` / `HardwareSpec.__post_init__` when the
+    on-disk JSON spec is missing fields, has malformed values (wrong type,
+    out-of-range counts, unsupported gpu_type), or carries pubkey/signature
+    blobs that aren't 32/64 raw bytes respectively.
+
+    Does NOT raise on signature verification failure — that returns False
+    from `HardwareSpec.verify(worker_id)`. Only structural problems trigger
+    this exception.
+    """
+
+
+class InvalidV2RecordError(ComputeMeterError):
+    """Raised when the v2 record-builder sees a value-domain violation:
+    period out of range, bad metric value, gpu_type inconsistent with
+    gpu_count, etc. Distinct from `InvalidRecordError` (v1) so callers can
+    discriminate which envelope shape they were constructing."""

--- a/packages/compute-meter-sdk/src/materios_compute_meter/hardware_spec.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/hardware_spec.py
@@ -1,0 +1,432 @@
+"""HardwareSpec — FPS-fleet-operator-attested hardware binding for a worker.
+
+In v2 (`compute_metering_v2`), a worker can no longer self-attest its
+hardware: a `hardware_spec` block, signed by an FPS-registered fleet
+operator, must be embedded in every record. The fleet-operator signature
+is computed offline (or by an FPS-internal service) and the resulting
+JSON is what the worker SDK loads from disk.
+
+Wire shape inside the v2 envelope (see canonical.py):
+
+    {
+        "cpu_cores": int,
+        "ram_gb": int,
+        "gpu_type": str,        # "none" | "nvidia-h100" | ... | "custom"
+        "gpu_count": int,
+        "fleet_operator_pubkey": bytes(32),
+        "fleet_operator_signature": bytes(64),
+        "issued_ms": int,
+    }
+
+On-disk JSON shape (the file the FPS offline-signing tool produces):
+
+    {
+        "cpu_cores": 8,
+        "ram_gb": 32,
+        "gpu_type": "none",
+        "gpu_count": 0,
+        "fleet_operator_pubkey_hex":     "<64 hex chars>",
+        "fleet_operator_signature_hex":  "<128 hex chars>",
+        "issued_ms": 1700000000000
+    }
+
+`HardwareSpec.load(path)` decodes the JSON, validates structure + value
+domains, and returns a frozen dataclass with bytes-typed pubkey / sig.
+`spec.verify(worker_id)` recomputes the canonical fleet-op pre-image and
+sr25519-verifies the signature; returns True/False, logs the failure
+reason on False (no exception — verify is for control-flow).
+`sign_hardware_spec(...)` is the inverse: produces a signed spec from a
+fleet operator's `WorkerKeypair`. Used by the FPS internal signing tool
+(and by tests).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, Optional
+
+from .canonical import (
+    SCHEMA_VERSION_V2,
+    canonical_cbor_for_fleet_op_sig,
+)
+from .exceptions import InvalidHardwareSpecError
+from .keypair import WorkerKeypair
+
+_LOG = logging.getLogger(__name__)
+
+
+#: Allowlisted gpu_type strings. Anything else is rejected at load time.
+SUPPORTED_GPU_TYPES: FrozenSet[str] = frozenset(
+    {
+        "none",
+        "nvidia-h100",
+        "nvidia-h200",
+        "nvidia-b100",
+        "nvidia-a100",
+        "amd-mi300",
+        "custom",
+    }
+)
+
+
+@dataclass(frozen=True)
+class HardwareSpec:
+    """Immutable hardware-spec record signed by an FPS fleet operator.
+
+    Attributes:
+        cpu_cores: CPU cores available to this worker. >0.
+        ram_gb: RAM in GB. >0.
+        gpu_type: One of `SUPPORTED_GPU_TYPES`.
+        gpu_count: Number of GPUs of `gpu_type`. >=0. Must be 0 iff
+            `gpu_type == "none"`; must be >0 otherwise (incoherent specs
+            are rejected at load time).
+        fleet_operator_pubkey: 32 raw bytes — sr25519 public key of the
+            FPS fleet operator that issued this attestation.
+        fleet_operator_signature: 64 raw bytes — sr25519 signature over
+            the canonical fleet-op pre-image (worker_id-bound, see
+            `canonical_cbor_for_fleet_op_sig`).
+        issued_ms: UNIX epoch milliseconds at which the operator signed.
+            Workers / gateway may reject a too-old spec; the SDK does not
+            enforce a TTL itself.
+    """
+
+    cpu_cores: int
+    ram_gb: int
+    gpu_type: str
+    gpu_count: int
+    fleet_operator_pubkey: bytes
+    fleet_operator_signature: bytes
+    issued_ms: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.cpu_cores, int) or isinstance(self.cpu_cores, bool):
+            raise InvalidHardwareSpecError(
+                f"cpu_cores must be int, got {type(self.cpu_cores).__name__}"
+            )
+        if self.cpu_cores <= 0:
+            raise InvalidHardwareSpecError(
+                f"cpu_cores must be > 0, got {self.cpu_cores}"
+            )
+        if not isinstance(self.ram_gb, int) or isinstance(self.ram_gb, bool):
+            raise InvalidHardwareSpecError(
+                f"ram_gb must be int, got {type(self.ram_gb).__name__}"
+            )
+        if self.ram_gb <= 0:
+            raise InvalidHardwareSpecError(
+                f"ram_gb must be > 0, got {self.ram_gb}"
+            )
+        if not isinstance(self.gpu_type, str):
+            raise InvalidHardwareSpecError(
+                f"gpu_type must be str, got {type(self.gpu_type).__name__}"
+            )
+        if self.gpu_type not in SUPPORTED_GPU_TYPES:
+            raise InvalidHardwareSpecError(
+                f"gpu_type {self.gpu_type!r} is not in the supported set "
+                f"{sorted(SUPPORTED_GPU_TYPES)}"
+            )
+        if not isinstance(self.gpu_count, int) or isinstance(self.gpu_count, bool):
+            raise InvalidHardwareSpecError(
+                f"gpu_count must be int, got {type(self.gpu_count).__name__}"
+            )
+        if self.gpu_count < 0:
+            raise InvalidHardwareSpecError(
+                f"gpu_count must be >= 0, got {self.gpu_count}"
+            )
+        # Coherence: gpu_type=="none" iff gpu_count==0.
+        if self.gpu_type == "none" and self.gpu_count != 0:
+            raise InvalidHardwareSpecError(
+                f"gpu_type='none' but gpu_count={self.gpu_count}; mutually "
+                "exclusive — set gpu_count=0 or pick a real gpu_type"
+            )
+        if self.gpu_type != "none" and self.gpu_count == 0:
+            raise InvalidHardwareSpecError(
+                f"gpu_type={self.gpu_type!r} but gpu_count=0; incoherent — "
+                "either set gpu_type='none' or gpu_count>=1"
+            )
+        if not isinstance(self.fleet_operator_pubkey, (bytes, bytearray)):
+            raise InvalidHardwareSpecError(
+                "fleet_operator_pubkey must be bytes, got "
+                f"{type(self.fleet_operator_pubkey).__name__}"
+            )
+        if len(self.fleet_operator_pubkey) != 32:
+            raise InvalidHardwareSpecError(
+                "fleet_operator_pubkey must be exactly 32 bytes, got "
+                f"{len(self.fleet_operator_pubkey)}"
+            )
+        if not isinstance(self.fleet_operator_signature, (bytes, bytearray)):
+            raise InvalidHardwareSpecError(
+                "fleet_operator_signature must be bytes, got "
+                f"{type(self.fleet_operator_signature).__name__}"
+            )
+        if len(self.fleet_operator_signature) != 64:
+            raise InvalidHardwareSpecError(
+                "fleet_operator_signature must be exactly 64 bytes, got "
+                f"{len(self.fleet_operator_signature)}"
+            )
+        if not isinstance(self.issued_ms, int) or isinstance(self.issued_ms, bool):
+            raise InvalidHardwareSpecError(
+                f"issued_ms must be int, got {type(self.issued_ms).__name__}"
+            )
+        if self.issued_ms <= 0:
+            raise InvalidHardwareSpecError(
+                f"issued_ms must be > 0, got {self.issued_ms}"
+            )
+        # Frozen dataclass + bytearray would be a foot-gun for hashing; coerce.
+        if isinstance(self.fleet_operator_pubkey, bytearray):
+            object.__setattr__(
+                self,
+                "fleet_operator_pubkey",
+                bytes(self.fleet_operator_pubkey),
+            )
+        if isinstance(self.fleet_operator_signature, bytearray):
+            object.__setattr__(
+                self,
+                "fleet_operator_signature",
+                bytes(self.fleet_operator_signature),
+            )
+
+    # ----------------------- on-disk format ------------------------------
+
+    @classmethod
+    def load(cls, path: str) -> "HardwareSpec":
+        """Read a hardware-spec JSON file produced by FPS's offline signing
+        tool and return a validated `HardwareSpec`.
+
+        Args:
+            path: Filesystem path to the JSON file.
+
+        Returns:
+            A validated, immutable `HardwareSpec`.
+
+        Raises:
+            InvalidHardwareSpecError: on any structural problem (missing
+                fields, wrong type, malformed hex, out-of-range value).
+        """
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                blob: Any = json.load(f)
+        except FileNotFoundError as e:
+            raise InvalidHardwareSpecError(
+                f"hardware-spec file not found: {path}"
+            ) from e
+        except (OSError, json.JSONDecodeError) as e:
+            raise InvalidHardwareSpecError(
+                f"could not read hardware-spec JSON at {path}: {e}"
+            ) from e
+
+        if not isinstance(blob, dict):
+            raise InvalidHardwareSpecError(
+                f"hardware-spec root must be a JSON object, got {type(blob).__name__}"
+            )
+
+        required = {
+            "cpu_cores",
+            "ram_gb",
+            "gpu_type",
+            "gpu_count",
+            "fleet_operator_pubkey_hex",
+            "fleet_operator_signature_hex",
+            "issued_ms",
+        }
+        missing = required - blob.keys()
+        if missing:
+            raise InvalidHardwareSpecError(
+                f"hardware-spec missing required fields: {sorted(missing)}"
+            )
+
+        try:
+            pubkey = bytes.fromhex(blob["fleet_operator_pubkey_hex"])
+        except (TypeError, ValueError) as e:
+            raise InvalidHardwareSpecError(
+                f"fleet_operator_pubkey_hex is not valid hex: {e}"
+            ) from e
+        try:
+            sig = bytes.fromhex(blob["fleet_operator_signature_hex"])
+        except (TypeError, ValueError) as e:
+            raise InvalidHardwareSpecError(
+                f"fleet_operator_signature_hex is not valid hex: {e}"
+            ) from e
+
+        # __post_init__ runs the rest of the checks (length, gpu coherence,
+        # int domain, gpu_type allowlist).
+        return cls(
+            cpu_cores=blob["cpu_cores"],
+            ram_gb=blob["ram_gb"],
+            gpu_type=blob["gpu_type"],
+            gpu_count=blob["gpu_count"],
+            fleet_operator_pubkey=pubkey,
+            fleet_operator_signature=sig,
+            issued_ms=blob["issued_ms"],
+        )
+
+    def save(self, path: str) -> None:
+        """Write this spec to disk in the FPS hex-on-the-wire JSON shape.
+
+        Args:
+            path: Filesystem path to write to. Parent directory must exist.
+                The file is written in JSON (UTF-8) with hex-encoded
+                pubkey/signature for human-inspectability.
+        """
+        blob = self.to_disk_dict()
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(blob, f, indent=2, sort_keys=True)
+
+    def to_disk_dict(self) -> Dict[str, Any]:
+        """Return the on-disk JSON shape (hex-encoded pubkey / sig)."""
+        return {
+            "cpu_cores": self.cpu_cores,
+            "ram_gb": self.ram_gb,
+            "gpu_type": self.gpu_type,
+            "gpu_count": self.gpu_count,
+            "fleet_operator_pubkey_hex": self.fleet_operator_pubkey.hex(),
+            "fleet_operator_signature_hex": self.fleet_operator_signature.hex(),
+            "issued_ms": self.issued_ms,
+        }
+
+    # ----------------------- envelope shape ------------------------------
+
+    def to_envelope_dict(self) -> Dict[str, Any]:
+        """Return the wire-shape dict (bytes for pubkey/sig) for embedding
+        in a v2 envelope's `hardware_spec` slot.
+
+        This is what `record_v2.build_record_v2(...)` puts into the envelope
+        and what `canonical_cbor_for_*_sig` consumes.
+        """
+        return {
+            "cpu_cores": self.cpu_cores,
+            "ram_gb": self.ram_gb,
+            "gpu_type": self.gpu_type,
+            "gpu_count": self.gpu_count,
+            "fleet_operator_pubkey": self.fleet_operator_pubkey,
+            "fleet_operator_signature": self.fleet_operator_signature,
+            "issued_ms": self.issued_ms,
+        }
+
+    # ----------------------- verify --------------------------------------
+
+    def verify(self, worker_id: str) -> bool:
+        """Verify the embedded `fleet_operator_signature` against the
+        canonical fleet-op pre-image bound to `worker_id`.
+
+        Args:
+            worker_id: The worker_id this spec is supposed to attest to.
+
+        Returns:
+            True iff the signature is valid for (worker_id, this spec).
+            False (NEVER raises) on any mismatch — wrong worker_id, wrong
+            pubkey, tampered fields, malformed sig. The reason is logged at
+            WARNING level for operator visibility.
+        """
+        if not isinstance(worker_id, str) or not worker_id:
+            _LOG.warning(
+                "HardwareSpec.verify: worker_id must be a non-empty string"
+            )
+            return False
+        record = {
+            "schema_version": SCHEMA_VERSION_V2,
+            "worker_id": worker_id,
+            "hardware_spec": self.to_envelope_dict(),
+        }
+        try:
+            body = canonical_cbor_for_fleet_op_sig(record)
+        except (TypeError, KeyError) as e:
+            _LOG.warning(
+                "HardwareSpec.verify: failed to encode pre-image: %s", e
+            )
+            return False
+
+        # Use a substrate-interface Keypair to verify (no secret needed).
+        try:
+            from substrateinterface import Keypair, KeypairType
+
+            verifier = Keypair(
+                public_key=self.fleet_operator_pubkey,
+                crypto_type=KeypairType.SR25519,
+                ss58_format=42,
+            )
+            ok = bool(verifier.verify(body, self.fleet_operator_signature))
+        except Exception as e:  # pragma: no cover - defensive
+            _LOG.warning(
+                "HardwareSpec.verify: sr25519 verifier raised: %s", e
+            )
+            return False
+
+        if not ok:
+            _LOG.warning(
+                "HardwareSpec.verify: signature does not verify for "
+                "worker_id=%r under fleet_operator_pubkey=%s...",
+                worker_id,
+                self.fleet_operator_pubkey.hex()[:16],
+            )
+        return ok
+
+
+def sign_hardware_spec(
+    *,
+    worker_id: str,
+    cpu_cores: int,
+    ram_gb: int,
+    gpu_type: str,
+    gpu_count: int,
+    issued_ms: int,
+    fleet_operator_keypair: WorkerKeypair,
+) -> HardwareSpec:
+    """Issue a fleet-operator-signed `HardwareSpec` for a worker.
+
+    Used by FPS's offline-signing tool (and by tests). Production fleet
+    operators run this on an air-gapped machine with the operator key
+    loaded from an HSM; the SDK ships only the verify path by default.
+
+    Args:
+        worker_id: The worker the attestation is bound to.
+        cpu_cores: See `HardwareSpec`.
+        ram_gb: See `HardwareSpec`.
+        gpu_type: See `HardwareSpec`.
+        gpu_count: See `HardwareSpec`.
+        issued_ms: UNIX epoch ms. Use `time.time_ns() // 1_000_000` typically.
+        fleet_operator_keypair: The fleet operator's `WorkerKeypair`.
+            (We reuse `WorkerKeypair` because both ends are sr25519 and the
+            class already has the right shape; semantically this is a
+            distinct role — the operator is NOT a worker.)
+
+    Returns:
+        A signed `HardwareSpec` ready to drop into a v2 envelope.
+
+    Raises:
+        InvalidHardwareSpecError: on value-domain violation (passed
+            through from `HardwareSpec.__post_init__`).
+    """
+    if not isinstance(worker_id, str) or not worker_id:
+        raise InvalidHardwareSpecError("worker_id must be a non-empty string")
+    if not isinstance(fleet_operator_keypair, WorkerKeypair):
+        raise InvalidHardwareSpecError(
+            "fleet_operator_keypair must be a WorkerKeypair instance"
+        )
+
+    pubkey = bytes.fromhex(fleet_operator_keypair.public_hex)
+    # Build the unsigned envelope-shape dict so we can hash + sign it.
+    unsigned_envelope = {
+        "cpu_cores": cpu_cores,
+        "ram_gb": ram_gb,
+        "gpu_type": gpu_type,
+        "gpu_count": gpu_count,
+        "fleet_operator_pubkey": pubkey,
+        "issued_ms": issued_ms,
+    }
+    pre_image_record = {
+        "schema_version": SCHEMA_VERSION_V2,
+        "worker_id": worker_id,
+        "hardware_spec": unsigned_envelope,
+    }
+    body = canonical_cbor_for_fleet_op_sig(pre_image_record)
+    signature = fleet_operator_keypair.sign_bytes(body)
+    return HardwareSpec(
+        cpu_cores=cpu_cores,
+        ram_gb=ram_gb,
+        gpu_type=gpu_type,
+        gpu_count=gpu_count,
+        fleet_operator_pubkey=pubkey,
+        fleet_operator_signature=signature,
+        issued_ms=issued_ms,
+    )

--- a/packages/compute-meter-sdk/src/materios_compute_meter/keypair.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/keypair.py
@@ -263,3 +263,85 @@ class WorkerKeypair:
             signature=sig.hex(),
             signer_public_hex=self.public_hex,
         )
+
+
+class ObserverKeypair(WorkerKeypair):
+    """sr25519 keypair for an INDEPENDENT observer (Wave 2).
+
+    Functionally identical to `WorkerKeypair` (same sr25519 algorithm, same
+    file format on disk, same SS58 prefix), but discriminated as a
+    SEPARATE TYPE so:
+
+      * Call sites read clearly:
+            `attach_observer_signature_v2(record, observer_kp)` — vs a
+            generic `WorkerKeypair` parameter that hides the role.
+      * Keyfiles can be tagged with `scheme=sr25519-observer` on disk so an
+        operator's `ls` of the secrets dir distinguishes worker from
+        observer keys.
+      * Future divergence (e.g. observer-only HSM integration, observer
+        attestation TTL) lives in this subclass without touching the
+        per-worker SDK surface.
+
+    The pre-image the observer signs is the SAME bytes the worker signs
+    (see `canonical_cbor_for_observer_sig`). DIFFERENT key, SAME bytes.
+
+    Subclassing rationale (vs separate class):
+      * Avoids duplicating the constructor / generate / sign_bytes /
+        verify_bytes / save / public_hex / ss58_address surface (about
+        100 LoC of identical code).
+      * `isinstance(kp, ObserverKeypair)` works for type narrowing while
+        `isinstance(kp, WorkerKeypair)` still admits both — the v2
+        signing helpers accept either, by design.
+      * The keyfile scheme tag still gives operators clear separation on
+        disk; the runtime crypto is the same algorithm so a subclass is
+        the honest model.
+
+    Inherits all constructors and methods from `WorkerKeypair`. The only
+    differences:
+
+      * `SCHEME = "sr25519-observer"` for keyfile tagging on save.
+      * `load()` accepts EITHER `sr25519-observer` (preferred) or
+        `sr25519` (legacy / cross-role reuse). Other schemes rejected.
+    """
+
+    SCHEME = "sr25519-observer"
+
+    @classmethod
+    def load(cls, path: str) -> "ObserverKeypair":
+        """Load an observer keyfile.
+
+        Accepts either `sr25519-observer` (preferred, written by `save()`)
+        or `sr25519` (legacy / cross-role reuse). Other schemes are rejected.
+        """
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                blob = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise InvalidKeyfileError(f"could not read {path}: {e}") from e
+
+        if not isinstance(blob, dict):
+            raise InvalidKeyfileError("keyfile root is not a JSON object")
+        scheme = blob.get("scheme")
+        if scheme not in (cls.SCHEME, "sr25519"):
+            raise InvalidKeyfileError(
+                f"unsupported scheme {scheme!r} for ObserverKeypair, "
+                f"expected {cls.SCHEME!r} or 'sr25519'"
+            )
+        secret_hex = blob.get("secret")
+        public_hex = blob.get("public")
+        if not isinstance(secret_hex, str) or not isinstance(public_hex, str):
+            raise InvalidKeyfileError("keyfile missing 'secret' or 'public' field")
+
+        try:
+            secret = bytes.fromhex(secret_hex)
+            public = bytes.fromhex(public_hex)
+        except ValueError as e:
+            raise InvalidKeyfileError(f"secret/public is not valid hex: {e}") from e
+
+        derived_public = bytes(sr25519.public_from_secret_key(secret))
+        if derived_public != public:
+            raise InvalidKeyfileError(
+                "keyfile public does not match the public derived from secret"
+            )
+
+        return cls(public_key=public, secret_key=secret)

--- a/packages/compute-meter-sdk/src/materios_compute_meter/record.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/record.py
@@ -12,13 +12,24 @@ Validation runs in `__post_init__`. We refuse:
 
 Replay protection is enforced in `submit()` (per-worker monotonic
 `period_start_ms`), not here — a record by itself is just data.
+
+v2 (compute_metering_v2):
+  * `build_record_v2(...)` — new top-level builder, accepts hardware_spec.
+  * `sign_record_v2(record_body, worker_keypair)` — seals worker_signature.
+  * `attach_observer_signature_v2(record, observer_keypair)` — bolts on
+    the optional observer co-signature.
+  * `verify_record_v2(record)` — validates worker (+ optional observer)
+    signatures. Does NOT validate the fleet_operator_signature inside
+    hardware_spec — call `HardwareSpec.verify(worker_id)` for that.
+  * `next_period_start_ms(last_seen_ms)` — caller-side monotonic helper.
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, Mapping, Optional
 
-from .exceptions import InvalidRecordError
+from .exceptions import InvalidRecordError, InvalidV2RecordError
 
 
 @dataclass
@@ -142,3 +153,469 @@ class Signed:
             return bool(verifier.verify(digest, bytes.fromhex(self.signature)))
         except Exception:
             return False
+
+
+# ---------------------------------------------------------------------------
+# v2 record builders / signers
+# ---------------------------------------------------------------------------
+#
+# v2 envelopes are richer than v1: nested `metrics`, mandatory `hardware_spec`
+# (signed by FPS fleet operator), optional `observer` co-signature. We model
+# them as plain dicts (not dataclasses) because the wire shape includes
+# nested mappings and the canonical encoder operates on dicts directly. A
+# dataclass would force a separate `to_dict()` step and extra serialisation
+# rules; for an immutable, signed envelope, the simpler primitive shape wins.
+
+# Period upper bound (24 h), pinned to v1 / v2 schema.
+_MAX_PERIOD_MS = 86_400_000
+
+# Required keys in the `metrics` sub-object. Matches the v2 spec exactly.
+_REQUIRED_METRIC_KEYS = (
+    "cpu_seconds",
+    "ram_gb_hours",
+    "disk_gb_hours",
+    "net_bytes_in",
+    "net_bytes_out",
+    "gpu_seconds",
+)
+
+# Per-key type constraint: True == "must be int (not float, not bool)".
+# False == "may be int or float (non-bool, finite, >= 0)".
+_METRIC_INT_ONLY = {
+    "cpu_seconds": True,
+    "ram_gb_hours": False,
+    "disk_gb_hours": False,
+    "net_bytes_in": True,
+    "net_bytes_out": True,
+    "gpu_seconds": True,
+}
+
+# Regex enforced for tenant_id per the v2 spec.
+_TENANT_ID_PATTERN = re.compile(r"^[a-z0-9-]{4,64}$")
+
+
+def _validate_metrics(metrics: Mapping[str, Any]) -> Dict[str, Any]:
+    """Normalise + validate the metrics sub-dict. Returns a fresh sorted-key
+    dict with floats coerced for stable canonical form."""
+    if not isinstance(metrics, Mapping):
+        raise InvalidV2RecordError(
+            f"metrics must be a mapping, got {type(metrics).__name__}"
+        )
+    missing = [k for k in _REQUIRED_METRIC_KEYS if k not in metrics]
+    if missing:
+        raise InvalidV2RecordError(
+            f"metrics missing required keys: {missing}"
+        )
+    extra = [k for k in metrics if k not in _REQUIRED_METRIC_KEYS]
+    if extra:
+        raise InvalidV2RecordError(
+            f"metrics has unexpected keys: {extra}"
+        )
+    out: Dict[str, Any] = {}
+    for k in _REQUIRED_METRIC_KEYS:
+        v = metrics[k]
+        if isinstance(v, bool):
+            raise InvalidV2RecordError(
+                f"metrics[{k!r}] must be a number, got bool"
+            )
+        if not isinstance(v, (int, float)):
+            raise InvalidV2RecordError(
+                f"metrics[{k!r}] must be int/float, got {type(v).__name__}"
+            )
+        # Reject NaN/Inf.
+        if isinstance(v, float):
+            import math
+
+            if not math.isfinite(v):
+                raise InvalidV2RecordError(
+                    f"metrics[{k!r}] must be finite, got {v}"
+                )
+        if v < 0:
+            raise InvalidV2RecordError(
+                f"metrics[{k!r}] must be >= 0, got {v}"
+            )
+        if _METRIC_INT_ONLY[k]:
+            if not isinstance(v, int):
+                raise InvalidV2RecordError(
+                    f"metrics[{k!r}] must be an int, got {type(v).__name__}"
+                )
+            out[k] = int(v)
+        else:
+            # Coerce ints to float for stable canonical form across dicts.
+            out[k] = float(v)
+    return out
+
+
+def _validate_worker_id_v2(worker_id: str) -> None:
+    """Per the v2 spec: 1-128 chars, UTF-8, no spaces, no commas."""
+    if not isinstance(worker_id, str):
+        raise InvalidV2RecordError(
+            f"worker_id must be str, got {type(worker_id).__name__}"
+        )
+    if not (1 <= len(worker_id) <= 128):
+        raise InvalidV2RecordError(
+            f"worker_id length must be 1..128, got {len(worker_id)}"
+        )
+    if " " in worker_id or "," in worker_id:
+        raise InvalidV2RecordError(
+            "worker_id must not contain spaces or commas"
+        )
+    # UTF-8 well-formedness — Python 3 str is always Unicode; the only way
+    # this fails is unpaired surrogates, which can't be encoded.
+    try:
+        worker_id.encode("utf-8")
+    except UnicodeEncodeError as e:
+        raise InvalidV2RecordError(
+            f"worker_id is not UTF-8 encodable: {e}"
+        ) from e
+
+
+def _validate_tenant_id_v2(tenant_id: str) -> None:
+    if not isinstance(tenant_id, str):
+        raise InvalidV2RecordError(
+            f"tenant_id must be str, got {type(tenant_id).__name__}"
+        )
+    if not _TENANT_ID_PATTERN.match(tenant_id):
+        raise InvalidV2RecordError(
+            f"tenant_id {tenant_id!r} must match [a-z0-9-]{{4,64}}"
+        )
+
+
+def _validate_period_v2(period_start_ms: int, period_end_ms: int) -> None:
+    for name, val in (
+        ("period_start_ms", period_start_ms),
+        ("period_end_ms", period_end_ms),
+    ):
+        if not isinstance(val, int) or isinstance(val, bool):
+            raise InvalidV2RecordError(
+                f"{name} must be int, got {type(val).__name__}"
+            )
+        if val < 0:
+            raise InvalidV2RecordError(
+                f"{name} must be >= 0, got {val}"
+            )
+    if period_end_ms <= period_start_ms:
+        raise InvalidV2RecordError(
+            f"period_end_ms ({period_end_ms}) must be > period_start_ms "
+            f"({period_start_ms})"
+        )
+    if period_end_ms - period_start_ms > _MAX_PERIOD_MS:
+        raise InvalidV2RecordError(
+            f"period (period_end_ms - period_start_ms) must be <= "
+            f"{_MAX_PERIOD_MS} ms (24 h), got {period_end_ms - period_start_ms}"
+        )
+
+
+def build_record_v2(
+    *,
+    worker_id: str,
+    tenant_id: str,
+    period_start_ms: int,
+    period_end_ms: int,
+    metrics: Mapping[str, Any],
+    hardware_spec: Any,
+    worker_pubkey: Optional[bytes] = None,
+) -> Dict[str, Any]:
+    """Build a v2 record body (everything signable except `worker_signature`
+    and `observer`).
+
+    The returned dict is suitable for `sign_record_v2(...)` immediately.
+    `worker_pubkey` is optional here because the same dict is sometimes built
+    BEFORE the signing keypair is available (e.g. in offline batching).
+    `sign_record_v2` will overwrite this field with the signing key's pubkey.
+
+    Args:
+        worker_id: 1-128 UTF-8 chars, no spaces, no commas.
+        tenant_id: lowercase / digit / hyphen, 4-64 chars.
+        period_start_ms: UNIX-epoch ms, monotonic per worker_id (caller's
+            responsibility — see `next_period_start_ms` helper for callers
+            that want SDK-side enforcement).
+        period_end_ms: UNIX-epoch ms, > period_start_ms,
+            ≤ period_start_ms + 86_400_000.
+        metrics: dict with keys cpu_seconds, ram_gb_hours, disk_gb_hours,
+            net_bytes_in, net_bytes_out, gpu_seconds (per-key int/float
+            domain enforced).
+        hardware_spec: a `HardwareSpec` instance OR its envelope dict.
+        worker_pubkey: 32 raw bytes. Optional; populated by `sign_record_v2`.
+
+    Returns:
+        A dict ready for `sign_record_v2`.
+
+    Raises:
+        InvalidV2RecordError: any value-domain violation.
+    """
+    _validate_worker_id_v2(worker_id)
+    _validate_tenant_id_v2(tenant_id)
+    _validate_period_v2(period_start_ms, period_end_ms)
+    norm_metrics = _validate_metrics(metrics)
+
+    # hardware_spec accepts either the dataclass or its dict shape.
+    hw_dict: Dict[str, Any]
+    # Local import — avoid circular at module load (hardware_spec already
+    # imports keypair which transitively imports record indirectly via
+    # the package __init__). Resolved at call-time.
+    from .hardware_spec import HardwareSpec
+
+    if isinstance(hardware_spec, HardwareSpec):
+        hw_dict = hardware_spec.to_envelope_dict()
+    elif isinstance(hardware_spec, Mapping):
+        # Trust the caller (we don't re-validate keys here — that's the
+        # responsibility of HardwareSpec.load if loaded from disk).
+        hw_dict = dict(hardware_spec)
+    else:
+        raise InvalidV2RecordError(
+            "hardware_spec must be a HardwareSpec instance or dict, got "
+            f"{type(hardware_spec).__name__}"
+        )
+
+    if worker_pubkey is not None:
+        if not isinstance(worker_pubkey, (bytes, bytearray)):
+            raise InvalidV2RecordError(
+                "worker_pubkey must be bytes, got "
+                f"{type(worker_pubkey).__name__}"
+            )
+        if len(worker_pubkey) != 32:
+            raise InvalidV2RecordError(
+                f"worker_pubkey must be 32 bytes, got {len(worker_pubkey)}"
+            )
+        worker_pubkey = bytes(worker_pubkey)
+
+    # Local import — same reason.
+    from .canonical import SCHEMA_VERSION_V2
+
+    record: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION_V2,
+        "worker_id": worker_id,
+        "tenant_id": tenant_id,
+        "period_start_ms": period_start_ms,
+        "period_end_ms": period_end_ms,
+        "metrics": norm_metrics,
+        "hardware_spec": hw_dict,
+    }
+    if worker_pubkey is not None:
+        record["worker_pubkey"] = worker_pubkey
+    return record
+
+
+def sign_record_v2(
+    record_body: Dict[str, Any],
+    worker_keypair: Any,
+) -> Dict[str, Any]:
+    """Seal a v2 record body with the worker's sr25519 signature.
+
+    The function:
+      1. Sets/overwrites `worker_pubkey` to match the signing key.
+      2. Computes the canonical worker-sig pre-image.
+      3. sr25519-signs the pre-image bytes.
+      4. Returns a NEW dict (does not mutate `record_body`) with the
+         `worker_signature` field filled in.
+
+    Args:
+        record_body: Output of `build_record_v2(...)`.
+        worker_keypair: A `WorkerKeypair` (the worker's signing key).
+
+    Returns:
+        A new dict identical to `record_body` plus `worker_pubkey` (32 bytes)
+        and `worker_signature` (64 bytes).
+
+    Raises:
+        InvalidV2RecordError: if `worker_keypair` isn't a WorkerKeypair, or
+            the body is missing required fields.
+    """
+    # Avoid a hard import at module load.
+    from .keypair import WorkerKeypair
+
+    if not isinstance(record_body, dict):
+        raise InvalidV2RecordError(
+            f"record_body must be dict, got {type(record_body).__name__}"
+        )
+    if not isinstance(worker_keypair, WorkerKeypair):
+        raise InvalidV2RecordError(
+            "worker_keypair must be a WorkerKeypair instance"
+        )
+    # Shallow copy so we don't mutate the caller's dict.
+    sealed: Dict[str, Any] = dict(record_body)
+    sealed["worker_pubkey"] = bytes.fromhex(worker_keypair.public_hex)
+
+    # Strip any pre-existing observer/signature before computing the pre-image
+    # — defense in depth: callers should never pass them in here, but if they
+    # do, they MUST NOT contaminate the signed bytes.
+    pre_image_record = {
+        k: v for k, v in sealed.items()
+        if k not in ("worker_signature", "observer")
+    }
+    from .canonical import canonical_cbor_for_worker_sig
+
+    body = canonical_cbor_for_worker_sig(pre_image_record)
+    sig = worker_keypair.sign_bytes(body)
+    sealed["worker_signature"] = sig
+    return sealed
+
+
+def attach_observer_signature_v2(
+    record: Mapping[str, Any],
+    observer_keypair: Any,
+) -> Dict[str, Any]:
+    """Attach an observer's co-signature to a worker-sealed v2 record.
+
+    The observer signs the SAME pre-image as the worker (different key,
+    same bytes). The returned record has an `observer` block populated;
+    the worker's existing `worker_signature` is preserved unchanged.
+
+    Args:
+        record: A worker-sealed v2 record (output of `sign_record_v2`).
+        observer_keypair: An `ObserverKeypair` (or any sr25519 keypair
+            with a `sign_bytes` method and `public_hex` property).
+
+    Returns:
+        A new dict identical to `record` plus an `observer` sub-dict
+        with `observer_pubkey` (32 bytes) and `observer_signature` (64 bytes).
+
+    Raises:
+        InvalidV2RecordError: if `record` is missing `worker_signature` or
+            `observer_keypair` doesn't have the right shape.
+    """
+    from .keypair import WorkerKeypair
+
+    if not isinstance(record, Mapping):
+        raise InvalidV2RecordError(
+            f"record must be a mapping, got {type(record).__name__}"
+        )
+    if "worker_signature" not in record:
+        raise InvalidV2RecordError(
+            "observer can only co-sign a worker-sealed record; pass the "
+            "output of sign_record_v2(...)"
+        )
+    if not isinstance(observer_keypair, WorkerKeypair):
+        raise InvalidV2RecordError(
+            "observer_keypair must be a WorkerKeypair (or ObserverKeypair) "
+            "instance"
+        )
+
+    # Recompute pre-image WITHOUT worker_signature & observer (per the
+    # canonical contract). The worker's pre-image bytes are what we sign.
+    from .canonical import canonical_cbor_for_observer_sig
+
+    body = canonical_cbor_for_observer_sig(record)
+    sig = observer_keypair.sign_bytes(body)
+    obs_pub = bytes.fromhex(observer_keypair.public_hex)
+
+    sealed: Dict[str, Any] = dict(record)
+    sealed["observer"] = {
+        "observer_pubkey": obs_pub,
+        "observer_signature": sig,
+    }
+    return sealed
+
+
+def next_period_start_ms(
+    last_seen_ms: int, *, now_ms: Optional[int] = None
+) -> int:
+    """Helper: return a `period_start_ms` value that's strictly greater than
+    `last_seen_ms` for the same worker.
+
+    The caller is responsible for tracking `last_seen_ms` per worker
+    (per `feedback_intent_settlement_chain_tdd.md`-style chain-side
+    monotonic enforcement). This helper exists so a misclock'd machine
+    doesn't accidentally produce a non-monotonic record — pass the
+    last-recorded ms and current wall-clock; the helper picks the right one.
+
+    Args:
+        last_seen_ms: Greatest `period_start_ms` previously sealed for
+            this worker_id. Pass 0 for never-seen.
+        now_ms: Current wall-clock ms; defaults to time.time_ns() // 1e6.
+
+    Returns:
+        `max(last_seen_ms + 1, now_ms)`.
+    """
+    if not isinstance(last_seen_ms, int) or isinstance(last_seen_ms, bool):
+        raise InvalidV2RecordError(
+            f"last_seen_ms must be int, got {type(last_seen_ms).__name__}"
+        )
+    if last_seen_ms < 0:
+        raise InvalidV2RecordError(
+            f"last_seen_ms must be >= 0, got {last_seen_ms}"
+        )
+    if now_ms is None:
+        import time as _time
+
+        now_ms = _time.time_ns() // 1_000_000
+    if not isinstance(now_ms, int) or isinstance(now_ms, bool):
+        raise InvalidV2RecordError(
+            f"now_ms must be int, got {type(now_ms).__name__}"
+        )
+    return max(last_seen_ms + 1, now_ms)
+
+
+def verify_record_v2(record: Mapping[str, Any]) -> bool:
+    """Recompute the canonical pre-images and verify both the worker
+    signature and (if present) the observer signature.
+
+    Args:
+        record: A v2 record dict — the OUTPUT of `sign_record_v2(...)` or
+            `attach_observer_signature_v2(...)`.
+
+    Returns:
+        True iff every embedded signature verifies. False on any mismatch.
+        The fleet-operator signature inside `hardware_spec` is NOT checked
+        here — call `HardwareSpec(...).verify(worker_id)` for that (it's
+        a different pre-image structure and a different threat model).
+    """
+    if not isinstance(record, Mapping):
+        return False
+    if "worker_signature" not in record or "worker_pubkey" not in record:
+        return False
+    try:
+        from substrateinterface import Keypair, KeypairType
+
+        from .canonical import (
+            canonical_cbor_for_observer_sig,
+            canonical_cbor_for_worker_sig,
+        )
+    except Exception:
+        return False
+
+    worker_pub = record["worker_pubkey"]
+    worker_sig = record["worker_signature"]
+    if not isinstance(worker_pub, bytes) or len(worker_pub) != 32:
+        return False
+    if not isinstance(worker_sig, bytes) or len(worker_sig) != 64:
+        return False
+
+    try:
+        body = canonical_cbor_for_worker_sig(record)
+    except (TypeError, KeyError):
+        return False
+    try:
+        verifier = Keypair(
+            public_key=worker_pub,
+            crypto_type=KeypairType.SR25519,
+            ss58_format=42,
+        )
+        if not verifier.verify(body, worker_sig):
+            return False
+    except Exception:
+        return False
+
+    obs = record.get("observer")
+    if obs is not None:
+        if not isinstance(obs, Mapping):
+            return False
+        obs_pub = obs.get("observer_pubkey")
+        obs_sig = obs.get("observer_signature")
+        if not isinstance(obs_pub, bytes) or len(obs_pub) != 32:
+            return False
+        if not isinstance(obs_sig, bytes) or len(obs_sig) != 64:
+            return False
+        try:
+            obs_body = canonical_cbor_for_observer_sig(record)
+            obs_verifier = Keypair(
+                public_key=obs_pub,
+                crypto_type=KeypairType.SR25519,
+                ss58_format=42,
+            )
+            if not obs_verifier.verify(obs_body, obs_sig):
+                return False
+        except Exception:
+            return False
+    return True

--- a/packages/compute-meter-sdk/src/materios_compute_meter/submit.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/submit.py
@@ -14,16 +14,25 @@ Behavioural details:
   * Retry policy: one retry on 5xx with a 2-second backoff. 4xx is fatal.
   * Default timeout: 15 seconds, matches publisher convention.
   * URL normalization: trailing slash on `gateway_url` is stripped.
+
+v2 (compute_metering_v2): `submit_v2(record, gateway_url=..., bearer=...)`
+posts a sealed v2 envelope (worker_signature + optional observer co-sig)
+to the same `/metering/submit` route. Wire format hex-encodes the byte
+fields; the SDK recomputes content_hash locally and asserts equality
+against the gateway's response (refuses to trust a server-substituted
+hash).
 """
 from __future__ import annotations
 
 import logging
 import threading
 import time
-from typing import Any, Dict, Optional, Union
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional, Union
 
 import httpx
 
+from .canonical import SCHEMA_VERSION_V2, canonical_content_hash_v2
 from .exceptions import (
     GatewayError,
     ReplayRejectedError,
@@ -259,3 +268,321 @@ def _reset_replay_cache_for_tests() -> None:
     parameterized runs that intentionally reuse `worker_id` values."""
     with _REPLAY_LOCK:
         _REPLAY_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# v2 submit (compute_metering_v2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SubmissionResult:
+    """Structured response from a v2 submit.
+
+    Attributes:
+        status_code: HTTP status code returned by the gateway (200..299).
+        receipt_id: Stable receipt identifier the gateway assigned.
+        content_hash: SHA-256 hex of the worker-sig canonical pre-image.
+            The SDK MUST recompute this locally and assert equality before
+            returning, so the caller never sees a server-substituted hash.
+        accepted_at: Server-side timestamp (typically UNIX seconds or ms;
+            opaque — passthrough).
+        body: The full decoded JSON response body, for debugging /
+            forward-compat fields the SDK doesn't yet model.
+    """
+
+    status_code: int
+    receipt_id: str
+    content_hash: str
+    accepted_at: Any
+    body: Dict[str, Any]
+
+
+# v2 wire-shape: hardware_spec + observer carry raw bytes (CBOR-friendly).
+# We hex-encode them in the JSON body for safe transport. The gateway
+# reverses the hex on its side using the same canonical encoder.
+
+# Map for human-readable errors when the gateway returns one of the new
+# v2-specific status codes.
+_V2_STATUS_MEANINGS = {
+    400: "bad request (malformed envelope or missing field)",
+    401: "unauthorized (Bearer token rejected)",
+    403: "fleet_operator unknown (the operator pubkey is not registered)",
+    409: "duplicate (replay rejected by gateway)",
+    422: "hardware bound violated (metric exceeds spec capacity)",
+}
+
+
+def _v2_record_to_wire(record: Mapping[str, Any]) -> Dict[str, Any]:
+    """Translate the in-memory v2 record (bytes for pubkeys/sigs) to the JSON
+    wire shape (hex-encoded bytes). Does not mutate the input.
+
+    Required record keys: schema_version, worker_id, tenant_id,
+    period_start_ms, period_end_ms, metrics, hardware_spec,
+    worker_pubkey, worker_signature.
+
+    Optional: observer.
+
+    Raises:
+        SubmitError: if a required key is missing or wrong type.
+    """
+    if not isinstance(record, Mapping):
+        raise SubmitError(
+            f"v2 record must be a mapping, got {type(record).__name__}"
+        )
+
+    required = {
+        "schema_version",
+        "worker_id",
+        "tenant_id",
+        "period_start_ms",
+        "period_end_ms",
+        "metrics",
+        "hardware_spec",
+        "worker_pubkey",
+        "worker_signature",
+    }
+    missing = required - record.keys()
+    if missing:
+        raise SubmitError(
+            f"v2 record missing required keys: {sorted(missing)}"
+        )
+
+    hardware_spec = record["hardware_spec"]
+    if not isinstance(hardware_spec, Mapping):
+        raise SubmitError("hardware_spec must be a mapping")
+    hw_pub = hardware_spec.get("fleet_operator_pubkey")
+    hw_sig = hardware_spec.get("fleet_operator_signature")
+    if not isinstance(hw_pub, (bytes, bytearray)) or len(hw_pub) != 32:
+        raise SubmitError(
+            "hardware_spec.fleet_operator_pubkey must be 32-byte bytes"
+        )
+    if not isinstance(hw_sig, (bytes, bytearray)) or len(hw_sig) != 64:
+        raise SubmitError(
+            "hardware_spec.fleet_operator_signature must be 64-byte bytes"
+        )
+
+    worker_pub = record["worker_pubkey"]
+    worker_sig = record["worker_signature"]
+    if not isinstance(worker_pub, (bytes, bytearray)) or len(worker_pub) != 32:
+        raise SubmitError("worker_pubkey must be 32-byte bytes")
+    if not isinstance(worker_sig, (bytes, bytearray)) or len(worker_sig) != 64:
+        raise SubmitError("worker_signature must be 64-byte bytes")
+
+    wire_hw = {
+        "cpu_cores": hardware_spec["cpu_cores"],
+        "ram_gb": hardware_spec["ram_gb"],
+        "gpu_type": hardware_spec["gpu_type"],
+        "gpu_count": hardware_spec["gpu_count"],
+        "fleet_operator_pubkey_hex": bytes(hw_pub).hex(),
+        "fleet_operator_signature_hex": bytes(hw_sig).hex(),
+        "issued_ms": hardware_spec["issued_ms"],
+    }
+
+    wire: Dict[str, Any] = {
+        "schema_version": record["schema_version"],
+        "worker_id": record["worker_id"],
+        "tenant_id": record["tenant_id"],
+        "period_start_ms": record["period_start_ms"],
+        "period_end_ms": record["period_end_ms"],
+        "metrics": dict(record["metrics"]),
+        "hardware_spec": wire_hw,
+        "worker_pubkey_hex": bytes(worker_pub).hex(),
+        "worker_signature_hex": bytes(worker_sig).hex(),
+    }
+
+    obs = record.get("observer")
+    if obs is not None:
+        if not isinstance(obs, Mapping):
+            raise SubmitError("observer must be a mapping when present")
+        obs_pub = obs.get("observer_pubkey")
+        obs_sig = obs.get("observer_signature")
+        if not isinstance(obs_pub, (bytes, bytearray)) or len(obs_pub) != 32:
+            raise SubmitError("observer.observer_pubkey must be 32-byte bytes")
+        if not isinstance(obs_sig, (bytes, bytearray)) or len(obs_sig) != 64:
+            raise SubmitError("observer.observer_signature must be 64-byte bytes")
+        wire["observer"] = {
+            "observer_pubkey_hex": bytes(obs_pub).hex(),
+            "observer_signature_hex": bytes(obs_sig).hex(),
+        }
+
+    return wire
+
+
+def _v2_check_replay(record: Mapping[str, Any]) -> None:
+    """Same per-(worker_id) monotonic check as v1 submit, applied to v2
+    records. Worker_id and period_start_ms are field names from the v2
+    schema."""
+    worker_id = record["worker_id"]
+    period_start_ms = record["period_start_ms"]
+    if not isinstance(worker_id, str):
+        raise SubmitError("v2 record worker_id must be str")
+    if not isinstance(period_start_ms, int):
+        raise SubmitError("v2 record period_start_ms must be int")
+    with _REPLAY_LOCK:
+        last = _REPLAY_CACHE.get(worker_id)
+        if last is not None and period_start_ms <= last:
+            raise ReplayRejectedError(
+                f"replay rejected for worker_id={worker_id!r}: "
+                f"period_start_ms={period_start_ms} is not greater than "
+                f"last seen {last} (records must be monotonically increasing)"
+            )
+        _REPLAY_CACHE[worker_id] = period_start_ms
+
+
+def submit_v2(
+    record: Mapping[str, Any],
+    *,
+    gateway_url: str,
+    api_key: Optional[str] = None,
+    bearer: Optional[str] = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    _client: Optional[httpx.Client] = None,
+    _retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
+) -> SubmissionResult:
+    """Submit a sealed v2 record to the Materios blob gateway.
+
+    Args:
+        record: A worker-sealed v2 record (output of
+            `materios_compute_meter.record.sign_record_v2(...)`).
+            Optionally also observer-co-signed via
+            `attach_observer_signature_v2(...)`.
+        gateway_url: Base URL of the Materios blob gateway. The SDK appends
+            `/metering/submit`. Trailing slash tolerated.
+        api_key: Bearer token (mutually exclusive with `bearer` —
+            equivalent — both names provided so callers using either v1
+            or x402 idiom feel at home).
+        bearer: Alias for `api_key`. Pass either, not both.
+        timeout_seconds: Per-request timeout. Default 15s.
+
+    Returns:
+        A `SubmissionResult` carrying the gateway-returned receipt_id +
+        the SDK-verified content_hash (the SDK recomputes content_hash
+        locally and asserts it matches the server's response — so callers
+        never blindly trust a server-substituted hash).
+
+    Raises:
+        SubmitError: configuration / wire-shape / network error.
+        GatewayError: gateway returned a non-2xx after retries. Includes
+            v2-specific status meanings (403=fleet_operator unknown,
+            422=hardware bound violated).
+        ReplayRejectedError: SDK replay cache rejected the record.
+    """
+    if not gateway_url:
+        raise SubmitError("gateway_url must be a non-empty string")
+    if api_key and bearer and api_key != bearer:
+        raise SubmitError(
+            "submit_v2 received conflicting api_key and bearer; pass one"
+        )
+    token = api_key or bearer
+    if not token:
+        raise SubmitError(
+            "submit_v2 requires either api_key= or bearer= (Bearer token)"
+        )
+
+    base = gateway_url.rstrip("/")
+    url = f"{base}/metering/submit"
+
+    # Translate to wire shape FIRST — surfaces structural errors before any
+    # state mutation (replay-cache update happens after).
+    wire = _v2_record_to_wire(record)
+
+    # Compute the SDK-side content_hash from the original record (NOT the
+    # wire shape). This is what we'll cross-check against the server's
+    # response, so a mid-flight tamper or server bug surfaces here.
+    expected_content_hash = canonical_content_hash_v2(record)
+
+    # Replay check + cache update (post-wire-validation, pre-network).
+    _v2_check_replay(record)
+
+    headers = {
+        "authorization": f"Bearer {token}",
+        "content-type": "application/json",
+        "user-agent": "materios-compute-meter/0.2.0-rc1",
+        "x-schema-version": SCHEMA_VERSION_V2,
+    }
+
+    owns_client = _client is None
+    client = _client or httpx.Client(timeout=timeout_seconds)
+    try:
+        r = _post_with_retry(
+            client=client,
+            url=url,
+            headers=headers,
+            body=wire,
+            retry_backoff_seconds=_retry_backoff_seconds,
+        )
+
+        if not (200 <= r.status_code < 300):
+            try:
+                body: Optional[object] = r.json()
+            except Exception:
+                body = r.text
+            # Prefer the gateway's structured `code`/`message`/`error` over
+            # our status-code-based heuristic — the gateway knows exactly
+            # what went wrong and we should surface that to the operator.
+            err_msg: Any = None
+            if isinstance(body, dict):
+                # Validator-style: {"ok": false, "code": "...", "message": "..."}
+                if body.get("code") and body.get("message"):
+                    err_msg = f"{body['code']}: {body['message']}"
+                elif body.get("error"):
+                    err_msg = body["error"]
+                elif body.get("message"):
+                    err_msg = body["message"]
+            if err_msg is None:
+                err_msg = r.text or _V2_STATUS_MEANINGS.get(r.status_code, "")
+            # If we recognise the status, surface the meaning as a hint
+            # AFTER the structured error (so operators see both).
+            meaning = _V2_STATUS_MEANINGS.get(r.status_code)
+            full_msg = (
+                f"{err_msg} [{meaning}]" if meaning and meaning not in str(err_msg) else str(err_msg)
+            )
+            raise GatewayError(
+                status=r.status_code,
+                message=full_msg[:500],
+                body=body,
+            )
+
+        try:
+            decoded = r.json()
+        except Exception as e:
+            raise SubmitError(
+                f"gateway returned non-JSON 2xx body: {r.text[:200]!r}"
+            ) from e
+
+        if not isinstance(decoded, dict):
+            raise SubmitError(
+                f"gateway 2xx body is not a JSON object: {decoded!r}"
+            )
+
+        receipt_id = decoded.get("receipt_id")
+        server_content_hash = decoded.get("content_hash")
+        accepted_at = decoded.get("accepted_at")
+        if not isinstance(receipt_id, str):
+            raise SubmitError(
+                f"gateway response missing receipt_id (got {decoded!r})"
+            )
+        if not isinstance(server_content_hash, str):
+            raise SubmitError(
+                f"gateway response missing content_hash (got {decoded!r})"
+            )
+        if server_content_hash.lower() != expected_content_hash.lower():
+            raise SubmitError(
+                "gateway returned a content_hash that does not match the "
+                "SDK-computed canonical digest. SDK="
+                f"{expected_content_hash}, server={server_content_hash}. "
+                "This indicates a server-side encoder drift OR a network "
+                "tamper — refusing to trust the response."
+            )
+
+        return SubmissionResult(
+            status_code=r.status_code,
+            receipt_id=receipt_id,
+            content_hash=expected_content_hash,
+            accepted_at=accepted_at,
+            body=decoded,
+        )
+    finally:
+        if owns_client:
+            client.close()

--- a/packages/compute-meter-sdk/tests/E2E.md
+++ b/packages/compute-meter-sdk/tests/E2E.md
@@ -128,3 +128,70 @@ those are the parts that don't depend on the canonical encoding.
 5. Assert on the canonical content_hash AND the gateway's response field —
    both must match. A passing assertion that only checks one side is a
    regression-risk gap.
+
+---
+
+## v2 (`compute_metering_v2`) E2E suite — `tests/test_v2_e2e_preprod.py`
+
+Separate suite for the v2 envelope (mandatory `hardware_spec` +
+optional `observer` co-signature). Gated by env vars per the team-3
+brief; skips gracefully when any prerequisite is missing.
+
+### Quick run
+
+```bash
+cd /home/deci/work/orynq-sdk/packages/compute-meter-sdk
+
+# Required:
+export MATERIOS_E2E_BEARER="matra_<your_token>"
+export MATERIOS_E2E_HARDWARE_SPEC="/path/to/fleet-signed-hardware.json"
+
+# Choose ONE worker_id-binding strategy:
+export MATERIOS_E2E_WORKER_ID="worker-baked-into-the-spec"
+# OR (preferred for repeated runs — re-issues per run):
+export MATERIOS_E2E_FLEET_OPERATOR_KEY="/path/to/fleet-operator-key.json"
+
+# Optional:
+export MATERIOS_E2E_GATEWAY="https://materios.fluxpointstudios.com/preprod-blobs"
+export MATERIOS_E2E_WORKER_KEY="/path/to/worker-key.json"
+export MATERIOS_E2E_OBSERVER_KEY="/path/to/observer-key.json"
+export MATERIOS_E2E_TENANT_ID="tenant-acme"
+
+.venv/bin/pytest tests/test_v2_e2e_preprod.py -m e2e -v
+```
+
+### v2 environment variables
+
+| var | required | default | purpose |
+|---|---|---|---|
+| `MATERIOS_E2E_BEARER` | yes | — | Bearer token for `/metering/submit`. Same token shape as v1 (`matra_*`). |
+| `MATERIOS_E2E_HARDWARE_SPEC` | yes | — | Path to a fleet-operator-signed hardware spec JSON (the file `HardwareSpec.save()` writes). |
+| `MATERIOS_E2E_FLEET_OPERATOR_KEY` | no | — | Path to the fleet operator's `WorkerKeypair` JSON keyfile. If set, the test re-issues hardware specs per run so each test gets a unique worker_id. Recommended. |
+| `MATERIOS_E2E_WORKER_KEY` | no | (generates) | Path to the worker's keyfile. Defaults to a fresh `WorkerKeypair.generate()`. |
+| `MATERIOS_E2E_OBSERVER_KEY` | no | (generates) | Path to the observer's `ObserverKeypair` JSON. Defaults to a fresh `ObserverKeypair.generate()`. |
+| `MATERIOS_E2E_TENANT_ID` | no | `tenant-e2e` | The `tenant_id` field for the test record. Must match `[a-z0-9-]{4,64}`. |
+| `MATERIOS_E2E_WORKER_ID` | no | `worker-e2e` | Prefix for the per-test worker_id. Each test appends a timestamp + suffix so submissions don't collide. |
+| `MATERIOS_E2E_GATEWAY` | no | preprod-blobs | Gateway base URL. |
+
+### Tests in the v2 suite
+
+| name | what it proves | budget |
+|---|---|---|
+| `test_live_v2_submit_no_observer_round_trips` | Build → sign → submit a v2 envelope WITHOUT an observer block. Gateway returns 2xx + a `content_hash` matching the SDK's locally-recomputed canonical hash. | <30s |
+| `test_live_v2_submit_with_observer_round_trips` | Same, with an observer co-signature attached. content_hash MUST equal the worker's pre-image hash (observer doesn't change content). | <30s |
+| `test_live_v2_replay_rejected_by_gateway` | Submit twice with the same (worker_id, period_start_ms). Second submit must be rejected by either the SDK's local cache OR the gateway's 409. | <30s |
+
+### v2 skip behaviour
+
+The suite gracefully skips with a CLEAR diagnostic at module level when:
+
+* `MATERIOS_E2E_BEARER` or `MATERIOS_E2E_HARDWARE_SPEC` is unset.
+* The hardware spec JSON file doesn't exist.
+* The gateway is unreachable.
+* The gateway's `/metering/submit` returns 404 (no metering route at all).
+* The gateway accepts only `compute_metering_v1` (Team 2's v2 validator
+  hasn't shipped). Detected by probing with a `compute_metering_v2`
+  schema_version and checking for a `WRONG_SCHEMA_VERSION` response.
+
+A skipped E2E run is NOT a failure — it tells the operator exactly which
+upstream piece is missing so they can fix THAT, not chase the SDK.

--- a/packages/compute-meter-sdk/tests/test_cli.py
+++ b/packages/compute-meter-sdk/tests/test_cli.py
@@ -1,0 +1,545 @@
+"""Tests for the CLI: submit + submit-v2 subcommands.
+
+Mocks httpx (so no real network) but uses REAL keypairs, REAL hardware
+specs on disk, and REAL signature flow. Asserts:
+
+  * argparse plumbing works (--gateway, --bearer, --hardware-spec,
+    --observer-key, --period-*, --cpu-seconds, ...).
+  * The v2 path picks up the on-disk hardware spec and the worker key,
+    builds the right envelope, and POSTs it.
+  * Observer key is honoured iff --observer-key is given.
+  * Hardware-spec verify-on-load fires by default.
+  * Exit codes follow the documented contract.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Tuple
+
+import httpx
+import pytest
+
+from materios_compute_meter.canonical import canonical_content_hash_v2
+from materios_compute_meter.cli import main as cli_main
+from materios_compute_meter.hardware_spec import sign_hardware_spec
+from materios_compute_meter.keypair import ObserverKeypair, WorkerKeypair
+
+
+_FLEET_SEED = "0x" + "40" * 32
+_WORKER_SEED = "0x" + "50" * 32
+_OBSERVER_SEED = "0x" + "60" * 32
+
+
+def _materialize_keys_and_spec(
+    tmp_path: Path, *, worker_id: str = "worker-cli-001"
+) -> Tuple[Path, Path, Path]:
+    """Persist a fleet-signed hardware spec, a worker keyfile, and an
+    observer keyfile to tmp_path. Returns (hw_path, worker_kp_path,
+    observer_kp_path)."""
+    fleet_kp = WorkerKeypair.from_seed_hex(_FLEET_SEED)
+    worker_kp = WorkerKeypair.from_seed_hex(_WORKER_SEED)
+    observer_kp = ObserverKeypair.from_seed_hex(_OBSERVER_SEED)
+
+    hw = sign_hardware_spec(
+        worker_id=worker_id,
+        cpu_cores=8,
+        ram_gb=32,
+        gpu_type="none",
+        gpu_count=0,
+        issued_ms=1_700_000_000_000,
+        fleet_operator_keypair=fleet_kp,
+    )
+    hw_path = tmp_path / "hardware.json"
+    hw.save(str(hw_path))
+
+    worker_path = tmp_path / "worker.json"
+    worker_kp.save(str(worker_path))
+
+    observer_path = tmp_path / "observer.json"
+    observer_kp.save(str(observer_path))
+
+    return hw_path, worker_path, observer_path
+
+
+@pytest.fixture
+def patched_httpx(monkeypatch: pytest.MonkeyPatch):
+    """Replace httpx.Client with a MockTransport-backed client. Returns
+    a dict the test populates with `handler` (a callable taking Request,
+    returning Response). The CLI's submit() / submit_v2() paths build
+    their own Client(); we monkey-patch the constructor to inject the
+    mock transport."""
+    state: dict = {}
+
+    real_init = httpx.Client.__init__
+
+    def patched_init(self, *args, **kwargs):
+        # Inject a transport pointing at state["handler"]; default to 503.
+        def handler(request: httpx.Request) -> httpx.Response:
+            h = state.get("handler")
+            if h is None:
+                return httpx.Response(503)
+            return h(request)
+
+        kwargs["transport"] = httpx.MockTransport(handler)
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.Client, "__init__", patched_init)
+    return state
+
+
+def test_cli_help_lists_both_subcommands(capsys: pytest.CaptureFixture) -> None:
+    """The top-level --help should advertise both submit and submit-v2."""
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "submit" in out
+    assert "submit-v2" in out
+
+
+def test_cli_v2_help_lists_required_v2_flags(capsys: pytest.CaptureFixture) -> None:
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["submit-v2", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    for flag in ("--gateway", "--bearer", "--hardware-spec", "--worker-key", "--observer-key", "--cpu-seconds"):
+        assert flag in out
+
+
+def test_cli_v2_submit_happy_path_no_observer(
+    tmp_path: Path,
+    patched_httpx: dict,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    hw_path, worker_path, _ = _materialize_keys_and_spec(tmp_path)
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        captured["body"] = body
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        # Compute content_hash from the SDK's perspective by reconstructing
+        # the v2 record. We can't do that easily here; the gateway in this
+        # test is a stand-in. Instead, we hard-code a content_hash that
+        # matches what the SDK will compute by reading the SDK's response
+        # validator: it MUST match the SDK's local recompute. So we have
+        # the test pre-build the same sealed record and use its hash.
+        # Easier path: have the handler pre-compute content_hash from the
+        # POSTed wire format by reverse-mapping it.
+        from materios_compute_meter.canonical import canonical_content_hash_v2
+
+        # Reconstruct the bytes-typed record from the wire format.
+        rec = {
+            "schema_version": body["schema_version"],
+            "worker_id": body["worker_id"],
+            "tenant_id": body["tenant_id"],
+            "period_start_ms": body["period_start_ms"],
+            "period_end_ms": body["period_end_ms"],
+            "metrics": body["metrics"],
+            "hardware_spec": {
+                "cpu_cores": body["hardware_spec"]["cpu_cores"],
+                "ram_gb": body["hardware_spec"]["ram_gb"],
+                "gpu_type": body["hardware_spec"]["gpu_type"],
+                "gpu_count": body["hardware_spec"]["gpu_count"],
+                "fleet_operator_pubkey": bytes.fromhex(
+                    body["hardware_spec"]["fleet_operator_pubkey_hex"]
+                ),
+                "fleet_operator_signature": bytes.fromhex(
+                    body["hardware_spec"]["fleet_operator_signature_hex"]
+                ),
+                "issued_ms": body["hardware_spec"]["issued_ms"],
+            },
+            "worker_pubkey": bytes.fromhex(body["worker_pubkey_hex"]),
+            "worker_signature": bytes.fromhex(body["worker_signature_hex"]),
+        }
+        ch = canonical_content_hash_v2(rec)
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0xreceipt_cli_v2",
+                "content_hash": ch,
+                "accepted_at": 1_700_000_999,
+            },
+        )
+
+    patched_httpx["handler"] = handler
+
+    rc = cli_main(
+        [
+            "submit-v2",
+            "--gateway",
+            "https://example.com/gw",
+            "--bearer",
+            "matra_cli_test",
+            "--hardware-spec",
+            str(hw_path),
+            "--worker-key",
+            str(worker_path),
+            "--worker-id",
+            "worker-cli-001",
+            "--tenant-id",
+            "tenant-cli",
+            "--period-start-ms",
+            "1700000100000",
+            "--period-end-ms",
+            "1700000160000",
+            "--cpu-seconds",
+            "60",
+            "--ram-gb-hours",
+            "0.25",
+        ]
+    )
+    assert rc == 0
+    assert captured["url"].endswith("/metering/submit")
+    assert captured["headers"]["authorization"] == "Bearer matra_cli_test"
+    assert captured["body"]["schema_version"] == "compute_metering_v2"
+    # No observer block.
+    assert "observer" not in captured["body"]
+
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["receipt_id"] == "0xreceipt_cli_v2"
+    assert parsed["status_code"] == 200
+    assert parsed["observer_attached"] is False
+
+
+def test_cli_v2_submit_with_observer_attaches_block(
+    tmp_path: Path,
+    patched_httpx: dict,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    hw_path, worker_path, observer_path = _materialize_keys_and_spec(tmp_path)
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        captured["body"] = body
+        # Compute content_hash like above.
+        from materios_compute_meter.canonical import canonical_content_hash_v2
+
+        rec = {
+            "schema_version": body["schema_version"],
+            "worker_id": body["worker_id"],
+            "tenant_id": body["tenant_id"],
+            "period_start_ms": body["period_start_ms"],
+            "period_end_ms": body["period_end_ms"],
+            "metrics": body["metrics"],
+            "hardware_spec": {
+                "cpu_cores": body["hardware_spec"]["cpu_cores"],
+                "ram_gb": body["hardware_spec"]["ram_gb"],
+                "gpu_type": body["hardware_spec"]["gpu_type"],
+                "gpu_count": body["hardware_spec"]["gpu_count"],
+                "fleet_operator_pubkey": bytes.fromhex(
+                    body["hardware_spec"]["fleet_operator_pubkey_hex"]
+                ),
+                "fleet_operator_signature": bytes.fromhex(
+                    body["hardware_spec"]["fleet_operator_signature_hex"]
+                ),
+                "issued_ms": body["hardware_spec"]["issued_ms"],
+            },
+            "worker_pubkey": bytes.fromhex(body["worker_pubkey_hex"]),
+            "worker_signature": bytes.fromhex(body["worker_signature_hex"]),
+        }
+        # Observer doesn't change worker pre-image.
+        ch = canonical_content_hash_v2(rec)
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0xobs",
+                "content_hash": ch,
+                "accepted_at": 0,
+            },
+        )
+
+    patched_httpx["handler"] = handler
+
+    rc = cli_main(
+        [
+            "submit-v2",
+            "--gateway",
+            "https://example.com/gw",
+            "--bearer",
+            "matra_obs",
+            "--hardware-spec",
+            str(hw_path),
+            "--worker-key",
+            str(worker_path),
+            "--observer-key",
+            str(observer_path),
+            "--worker-id",
+            "worker-cli-001",
+            "--tenant-id",
+            "tenant-cli",
+            "--period-start-ms",
+            "1700000200000",
+            "--period-end-ms",
+            "1700000260000",
+            "--cpu-seconds",
+            "60",
+        ]
+    )
+    assert rc == 0
+    body = captured["body"]
+    assert "observer" in body
+    assert "observer_pubkey_hex" in body["observer"]
+    assert "observer_signature_hex" in body["observer"]
+
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["observer_attached"] is True
+
+
+def test_cli_v2_rejects_unverifiable_hardware_spec(
+    tmp_path: Path,
+    patched_httpx: dict,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """If the hardware_spec was issued for worker_id A and the CLI is
+    called with --worker-id B, the spec verify must fail and the CLI
+    must abort with exit code 2 BEFORE any network call."""
+    hw_path, worker_path, _ = _materialize_keys_and_spec(
+        tmp_path, worker_id="worker-A"
+    )
+    sent = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        sent["count"] += 1
+        return httpx.Response(200, json={})
+
+    patched_httpx["handler"] = handler
+
+    rc = cli_main(
+        [
+            "submit-v2",
+            "--gateway",
+            "https://example.com/gw",
+            "--bearer",
+            "t",
+            "--hardware-spec",
+            str(hw_path),
+            "--worker-key",
+            str(worker_path),
+            "--worker-id",
+            "worker-B",  # mismatch
+            "--tenant-id",
+            "tenant-cli",
+            "--period-start-ms",
+            "1700000300000",
+            "--period-end-ms",
+            "1700000360000",
+            "--cpu-seconds",
+            "1",
+        ]
+    )
+    assert rc == 2
+    assert sent["count"] == 0
+    err = capsys.readouterr().err
+    assert "does not verify" in err
+
+
+def test_cli_v2_skip_spec_verify_bypasses_check(
+    tmp_path: Path,
+    patched_httpx: dict,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """--skip-spec-verify allows submitting a spec that doesn't verify
+    locally (the gateway will still reject it; this is for development /
+    debugging only)."""
+    hw_path, worker_path, _ = _materialize_keys_and_spec(
+        tmp_path, worker_id="worker-A"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        from materios_compute_meter.canonical import canonical_content_hash_v2
+
+        rec = {
+            "schema_version": body["schema_version"],
+            "worker_id": body["worker_id"],
+            "tenant_id": body["tenant_id"],
+            "period_start_ms": body["period_start_ms"],
+            "period_end_ms": body["period_end_ms"],
+            "metrics": body["metrics"],
+            "hardware_spec": {
+                "cpu_cores": body["hardware_spec"]["cpu_cores"],
+                "ram_gb": body["hardware_spec"]["ram_gb"],
+                "gpu_type": body["hardware_spec"]["gpu_type"],
+                "gpu_count": body["hardware_spec"]["gpu_count"],
+                "fleet_operator_pubkey": bytes.fromhex(
+                    body["hardware_spec"]["fleet_operator_pubkey_hex"]
+                ),
+                "fleet_operator_signature": bytes.fromhex(
+                    body["hardware_spec"]["fleet_operator_signature_hex"]
+                ),
+                "issued_ms": body["hardware_spec"]["issued_ms"],
+            },
+            "worker_pubkey": bytes.fromhex(body["worker_pubkey_hex"]),
+            "worker_signature": bytes.fromhex(body["worker_signature_hex"]),
+        }
+        ch = canonical_content_hash_v2(rec)
+        return httpx.Response(
+            200,
+            json={"receipt_id": "0xskip", "content_hash": ch, "accepted_at": 0},
+        )
+
+    patched_httpx["handler"] = handler
+
+    rc = cli_main(
+        [
+            "submit-v2",
+            "--gateway",
+            "https://example.com/gw",
+            "--bearer",
+            "t",
+            "--hardware-spec",
+            str(hw_path),
+            "--worker-key",
+            str(worker_path),
+            "--worker-id",
+            "worker-B",  # mismatch
+            "--tenant-id",
+            "tenant-cli",
+            "--period-start-ms",
+            "1700000400000",
+            "--period-end-ms",
+            "1700000460000",
+            "--cpu-seconds",
+            "1",
+            "--skip-spec-verify",
+        ]
+    )
+    assert rc == 0
+
+
+def test_cli_v2_returns_exit_3_on_gateway_error(
+    tmp_path: Path,
+    patched_httpx: dict,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    hw_path, worker_path, _ = _materialize_keys_and_spec(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"error": "fleet_operator unknown"})
+
+    patched_httpx["handler"] = handler
+
+    rc = cli_main(
+        [
+            "submit-v2",
+            "--gateway",
+            "https://example.com/gw",
+            "--bearer",
+            "t",
+            "--hardware-spec",
+            str(hw_path),
+            "--worker-key",
+            str(worker_path),
+            "--worker-id",
+            "worker-cli-001",
+            "--tenant-id",
+            "tenant-cli",
+            "--period-start-ms",
+            "1700000500000",
+            "--period-end-ms",
+            "1700000560000",
+            "--cpu-seconds",
+            "1",
+        ]
+    )
+    assert rc == 3
+    err = capsys.readouterr().err
+    assert "fleet_operator unknown" in err.lower()
+
+
+def test_cli_v2_returns_exit_2_on_validation_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Bad hardware spec file (missing fields) should be exit 2, not 1, not 3."""
+    hw_path = tmp_path / "broken.json"
+    hw_path.write_text(json.dumps({"cpu_cores": 8}))  # missing fields
+    worker_path = tmp_path / "w.json"
+    WorkerKeypair.from_seed_hex(_WORKER_SEED).save(str(worker_path))
+
+    rc = cli_main(
+        [
+            "submit-v2",
+            "--gateway",
+            "https://example.com/gw",
+            "--bearer",
+            "t",
+            "--hardware-spec",
+            str(hw_path),
+            "--worker-key",
+            str(worker_path),
+            "--worker-id",
+            "worker-cli-001",
+            "--tenant-id",
+            "tenant-cli",
+            "--period-start-ms",
+            "1",
+            "--period-end-ms",
+            "2",
+            "--cpu-seconds",
+            "1",
+        ]
+    )
+    assert rc == 2
+
+
+def test_cli_v1_submit_still_works(
+    tmp_path: Path,
+    patched_httpx: dict,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """v1 backward compat: the original 'submit' subcommand still functions."""
+    worker_kp = WorkerKeypair.from_seed_hex(_WORKER_SEED)
+    worker_path = tmp_path / "worker.json"
+    worker_kp.save(str(worker_path))
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        captured["body"] = body
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0xv1",
+                "content_hash": body["content_hash"],
+                "accepted_at": 0,
+            },
+        )
+
+    patched_httpx["handler"] = handler
+
+    rc = cli_main(
+        [
+            "submit",
+            "--gateway",
+            "https://example.com/gw",
+            "--bearer",
+            "matra_v1",
+            "--worker-key",
+            str(worker_path),
+            "--worker-id",
+            "worker-001",
+            "--tenant-id",
+            "tenant-acme",
+            "--period-start-ms",
+            "1",
+            "--period-end-ms",
+            "2",
+            "--cpu-seconds",
+            "1.0",
+        ]
+    )
+    assert rc == 0
+    assert captured["body"]["scheme"] == "sr25519"
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["receipt_id"] == "0xv1"

--- a/packages/compute-meter-sdk/tests/test_hardware_spec.py
+++ b/packages/compute-meter-sdk/tests/test_hardware_spec.py
@@ -1,0 +1,415 @@
+"""Tests for HardwareSpec — the FPS-fleet-operator-signed hardware
+attestation that pins a worker to a specific machine spec.
+
+Real on-disk JSON round-trips. Real sr25519 signatures.  Mocks are NOT
+allowed in this file (per the brief's TDD bar).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from materios_compute_meter.canonical import canonical_cbor_for_fleet_op_sig
+from materios_compute_meter.exceptions import InvalidHardwareSpecError
+from materios_compute_meter.hardware_spec import (
+    HardwareSpec,
+    sign_hardware_spec,
+)
+from materios_compute_meter.keypair import WorkerKeypair
+
+
+# Deterministic seeds for reproducible tests. NEVER reused outside tests.
+_FLEET_SEED_HEX = "0x" + "01" * 32
+_OTHER_FLEET_SEED_HEX = "0x" + "02" * 32
+
+_WORKER_ID = "worker-fixture-001"
+
+
+def _fleet_kp() -> WorkerKeypair:
+    """Return a deterministic 'fleet operator' keypair for tests."""
+    return WorkerKeypair.from_seed_hex(_FLEET_SEED_HEX)
+
+
+def _other_fleet_kp() -> WorkerKeypair:
+    return WorkerKeypair.from_seed_hex(_OTHER_FLEET_SEED_HEX)
+
+
+def _make_signed_spec(
+    *,
+    worker_id: str = _WORKER_ID,
+    cpu_cores: int = 8,
+    ram_gb: int = 32,
+    gpu_type: str = "none",
+    gpu_count: int = 0,
+    issued_ms: int = 1_700_000_000_000,
+) -> HardwareSpec:
+    """Build a hardware spec and sign it with the deterministic fleet key."""
+    fleet = _fleet_kp()
+    return sign_hardware_spec(
+        worker_id=worker_id,
+        cpu_cores=cpu_cores,
+        ram_gb=ram_gb,
+        gpu_type=gpu_type,
+        gpu_count=gpu_count,
+        issued_ms=issued_ms,
+        fleet_operator_keypair=fleet,
+    )
+
+
+# --- construction + sign round trip --------------------------------------
+
+
+def test_sign_hardware_spec_returns_immutable_spec_with_valid_sig() -> None:
+    spec = _make_signed_spec()
+    assert spec.cpu_cores == 8
+    assert spec.ram_gb == 32
+    assert spec.gpu_type == "none"
+    assert spec.gpu_count == 0
+    assert len(spec.fleet_operator_pubkey) == 32
+    assert len(spec.fleet_operator_signature) == 64
+    assert spec.issued_ms == 1_700_000_000_000
+
+    # Verifies against worker_id used at sign-time.
+    assert spec.verify(_WORKER_ID) is True
+
+
+def test_hardware_spec_is_frozen_dataclass() -> None:
+    """Mutating a field after construction raises; the fleet_operator_signature
+    would be invalidated and we don't want silent drift."""
+    spec = _make_signed_spec()
+    with pytest.raises((AttributeError, Exception)):
+        spec.cpu_cores = 16  # type: ignore[misc]
+
+
+def test_verify_returns_false_for_wrong_worker_id() -> None:
+    """The signature is bound to a specific worker_id; any other worker_id
+    must fail verification."""
+    spec = _make_signed_spec(worker_id="worker-A")
+    assert spec.verify("worker-A") is True
+    assert spec.verify("worker-B") is False
+
+
+def test_verify_returns_false_when_hardware_spec_tampered() -> None:
+    """Tampering with the spec's fields (after the fact) breaks the sig."""
+    spec = _make_signed_spec()
+    # Build a tampered copy by rebuilding the dataclass with a different cpu_cores.
+    tampered = HardwareSpec(
+        cpu_cores=999,  # tampered
+        ram_gb=spec.ram_gb,
+        gpu_type=spec.gpu_type,
+        gpu_count=spec.gpu_count,
+        fleet_operator_pubkey=spec.fleet_operator_pubkey,
+        fleet_operator_signature=spec.fleet_operator_signature,
+        issued_ms=spec.issued_ms,
+    )
+    assert tampered.verify(_WORKER_ID) is False
+
+
+def test_verify_returns_false_when_signed_by_different_key() -> None:
+    """A spec signed with key A must NOT verify against key B's pubkey."""
+    a_spec = _make_signed_spec()
+    b_kp = _other_fleet_kp()
+    bad = HardwareSpec(
+        cpu_cores=a_spec.cpu_cores,
+        ram_gb=a_spec.ram_gb,
+        gpu_type=a_spec.gpu_type,
+        gpu_count=a_spec.gpu_count,
+        fleet_operator_pubkey=bytes.fromhex(b_kp.public_hex),  # wrong pubkey
+        fleet_operator_signature=a_spec.fleet_operator_signature,
+        issued_ms=a_spec.issued_ms,
+    )
+    assert bad.verify(_WORKER_ID) is False
+
+
+# --- on-disk JSON round trip (REAL files; not in-memory) ------------------
+
+
+def test_save_load_round_trip_via_real_file(tmp_path: Path) -> None:
+    spec = _make_signed_spec()
+    p = tmp_path / "fleet-sig.json"
+    spec.save(str(p))
+    loaded = HardwareSpec.load(str(p))
+    assert loaded == spec
+    assert loaded.verify(_WORKER_ID) is True
+
+
+def test_load_real_json_with_fleet_operator_pubkey_hex_keys(tmp_path: Path) -> None:
+    """The on-disk JSON schema (per the brief) uses hex-string fields for the
+    bytes blobs: `fleet_operator_pubkey_hex`, `fleet_operator_signature_hex`."""
+    spec = _make_signed_spec()
+    p = tmp_path / "fleet.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": spec.cpu_cores,
+                "ram_gb": spec.ram_gb,
+                "gpu_type": spec.gpu_type,
+                "gpu_count": spec.gpu_count,
+                "fleet_operator_pubkey_hex": spec.fleet_operator_pubkey.hex(),
+                "fleet_operator_signature_hex": spec.fleet_operator_signature.hex(),
+                "issued_ms": spec.issued_ms,
+            }
+        )
+    )
+    loaded = HardwareSpec.load(str(p))
+    assert loaded == spec
+
+
+def test_save_writes_human_readable_json(tmp_path: Path) -> None:
+    spec = _make_signed_spec()
+    p = tmp_path / "spec.json"
+    spec.save(str(p))
+    blob = json.loads(p.read_text())
+    # All seven fields present + hex keys.
+    assert blob["cpu_cores"] == 8
+    assert blob["ram_gb"] == 32
+    assert blob["gpu_type"] == "none"
+    assert blob["gpu_count"] == 0
+    assert blob["issued_ms"] == 1_700_000_000_000
+    assert blob["fleet_operator_pubkey_hex"] == spec.fleet_operator_pubkey.hex()
+    assert blob["fleet_operator_signature_hex"] == spec.fleet_operator_signature.hex()
+
+
+# --- malformed input rejection -------------------------------------------
+
+
+def test_load_rejects_missing_field(tmp_path: Path) -> None:
+    p = tmp_path / "missing.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": 8,
+                "ram_gb": 32,
+                # missing gpu_type, gpu_count, etc.
+            }
+        )
+    )
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+def test_load_rejects_unsupported_gpu_type(tmp_path: Path) -> None:
+    p = tmp_path / "bad_gpu.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": 8,
+                "ram_gb": 32,
+                "gpu_type": "tpu-v5",  # not in allowlist
+                "gpu_count": 1,
+                "fleet_operator_pubkey_hex": "ab" * 32,
+                "fleet_operator_signature_hex": "cd" * 64,
+                "issued_ms": 1_700_000_000_000,
+            }
+        )
+    )
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+def test_load_rejects_negative_cpu_cores(tmp_path: Path) -> None:
+    p = tmp_path / "neg.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": -1,
+                "ram_gb": 32,
+                "gpu_type": "none",
+                "gpu_count": 0,
+                "fleet_operator_pubkey_hex": "ab" * 32,
+                "fleet_operator_signature_hex": "cd" * 64,
+                "issued_ms": 1_700_000_000_000,
+            }
+        )
+    )
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+def test_load_rejects_pubkey_wrong_length(tmp_path: Path) -> None:
+    p = tmp_path / "bad_pub.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": 8,
+                "ram_gb": 32,
+                "gpu_type": "none",
+                "gpu_count": 0,
+                "fleet_operator_pubkey_hex": "ab" * 16,  # 16 bytes, not 32
+                "fleet_operator_signature_hex": "cd" * 64,
+                "issued_ms": 1_700_000_000_000,
+            }
+        )
+    )
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+def test_load_rejects_signature_wrong_length(tmp_path: Path) -> None:
+    p = tmp_path / "bad_sig.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": 8,
+                "ram_gb": 32,
+                "gpu_type": "none",
+                "gpu_count": 0,
+                "fleet_operator_pubkey_hex": "ab" * 32,
+                "fleet_operator_signature_hex": "cd" * 32,  # 32 bytes, not 64
+                "issued_ms": 1_700_000_000_000,
+            }
+        )
+    )
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+def test_load_rejects_non_hex_pubkey(tmp_path: Path) -> None:
+    p = tmp_path / "non_hex.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": 8,
+                "ram_gb": 32,
+                "gpu_type": "none",
+                "gpu_count": 0,
+                "fleet_operator_pubkey_hex": "zz" * 32,
+                "fleet_operator_signature_hex": "cd" * 64,
+                "issued_ms": 1_700_000_000_000,
+            }
+        )
+    )
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+def test_load_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(tmp_path / "nonexistent.json"))
+
+
+def test_load_rejects_malformed_json(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("{not json at all]")
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+def test_load_rejects_root_not_object(tmp_path: Path) -> None:
+    p = tmp_path / "list.json"
+    p.write_text(json.dumps([1, 2, 3]))
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+def test_load_rejects_gpu_count_zero_when_gpu_type_present(tmp_path: Path) -> None:
+    """gpu_type=='nvidia-h100' with gpu_count==0 is incoherent and rejected."""
+    p = tmp_path / "incoherent.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": 8,
+                "ram_gb": 32,
+                "gpu_type": "nvidia-h100",
+                "gpu_count": 0,  # incoherent
+                "fleet_operator_pubkey_hex": "ab" * 32,
+                "fleet_operator_signature_hex": "cd" * 64,
+                "issued_ms": 1_700_000_000_000,
+            }
+        )
+    )
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+def test_load_rejects_gpu_count_nonzero_when_gpu_type_none(tmp_path: Path) -> None:
+    """gpu_type=='none' with gpu_count>0 is incoherent and rejected."""
+    p = tmp_path / "incoherent2.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": 8,
+                "ram_gb": 32,
+                "gpu_type": "none",
+                "gpu_count": 4,  # incoherent
+                "fleet_operator_pubkey_hex": "ab" * 32,
+                "fleet_operator_signature_hex": "cd" * 64,
+                "issued_ms": 1_700_000_000_000,
+            }
+        )
+    )
+    with pytest.raises(InvalidHardwareSpecError):
+        HardwareSpec.load(str(p))
+
+
+# --- supported gpu_type allowlist ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "gpu_type",
+    [
+        "none",
+        "nvidia-h100",
+        "nvidia-h200",
+        "nvidia-b100",
+        "nvidia-a100",
+        "amd-mi300",
+        "custom",
+    ],
+)
+def test_load_accepts_all_documented_gpu_types(
+    tmp_path: Path, gpu_type: str
+) -> None:
+    """All seven documented gpu_type values must round-trip."""
+    p = tmp_path / f"{gpu_type}.json"
+    p.write_text(
+        json.dumps(
+            {
+                "cpu_cores": 8,
+                "ram_gb": 32,
+                "gpu_type": gpu_type,
+                "gpu_count": 0 if gpu_type == "none" else 1,
+                "fleet_operator_pubkey_hex": "ab" * 32,
+                "fleet_operator_signature_hex": "cd" * 64,
+                "issued_ms": 1_700_000_000_000,
+            }
+        )
+    )
+    spec = HardwareSpec.load(str(p))
+    assert spec.gpu_type == gpu_type
+
+
+# --- envelope-shape helper -----------------------------------------------
+
+
+def test_to_envelope_dict_returns_cbor_friendly_shape() -> None:
+    """The dict shape returned by to_envelope_dict must be exactly what goes
+    into the v2 record's `hardware_spec` slot — bytes for pubkey/sig, ints
+    for counts/issued_ms, str for gpu_type."""
+    spec = _make_signed_spec()
+    d = spec.to_envelope_dict()
+    assert d["cpu_cores"] == spec.cpu_cores
+    assert d["ram_gb"] == spec.ram_gb
+    assert d["gpu_type"] == spec.gpu_type
+    assert d["gpu_count"] == spec.gpu_count
+    assert d["issued_ms"] == spec.issued_ms
+    assert d["fleet_operator_pubkey"] == spec.fleet_operator_pubkey  # bytes
+    assert d["fleet_operator_signature"] == spec.fleet_operator_signature  # bytes
+    assert isinstance(d["fleet_operator_pubkey"], bytes)
+    assert isinstance(d["fleet_operator_signature"], bytes)
+
+
+def test_envelope_shape_matches_canonical_cbor_input() -> None:
+    """The envelope dict, when fed into canonical_cbor_for_fleet_op_sig,
+    produces the same bytes that were originally signed (= verify works)."""
+    spec = _make_signed_spec()
+    record = {
+        "schema_version": "compute_metering_v2",
+        "worker_id": _WORKER_ID,
+        "hardware_spec": spec.to_envelope_dict(),
+    }
+    body = canonical_cbor_for_fleet_op_sig(record)
+    fleet = _fleet_kp()
+    assert fleet.verify_bytes(body, spec.fleet_operator_signature) is True

--- a/packages/compute-meter-sdk/tests/test_observer_keypair.py
+++ b/packages/compute-meter-sdk/tests/test_observer_keypair.py
@@ -1,0 +1,152 @@
+"""Tests for ObserverKeypair — sr25519 keypair for the optional Wave 2
+observer co-signature.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from materios_compute_meter.exceptions import (
+    InvalidKeyfileError,
+    InvalidSeedError,
+)
+from materios_compute_meter.keypair import ObserverKeypair, WorkerKeypair
+
+
+def test_observer_keypair_is_subclass_of_worker_keypair() -> None:
+    """Subclassing rationale: same crypto, separate role. v2 signing helpers
+    accept either type via WorkerKeypair isinstance check."""
+    assert issubclass(ObserverKeypair, WorkerKeypair)
+
+
+def test_observer_keypair_generate_returns_valid_keypair() -> None:
+    kp = ObserverKeypair.generate()
+    assert isinstance(kp, ObserverKeypair)
+    assert isinstance(kp, WorkerKeypair)
+    assert len(bytes.fromhex(kp.public_hex)) == 32
+    assert len(bytes.fromhex(kp.secret_hex)) == 64
+
+
+def test_observer_keypair_from_seed_hex_is_deterministic() -> None:
+    seed = "0x" + "ab" * 32
+    a = ObserverKeypair.from_seed_hex(seed)
+    b = ObserverKeypair.from_seed_hex(seed)
+    assert a.public_hex == b.public_hex
+    assert isinstance(a, ObserverKeypair)
+
+
+def test_observer_keypair_signs_and_verifies_via_inherited_api() -> None:
+    kp = ObserverKeypair.generate()
+    payload = b"hello observer"
+    sig = kp.sign_bytes(payload)
+    assert len(sig) == 64
+    assert kp.verify_bytes(payload, sig) is True
+
+
+def test_observer_keypair_save_writes_observer_scheme_tag(tmp_path: Path) -> None:
+    """On disk, observer keyfiles are tagged sr25519-observer so an `ls`
+    distinguishes them from worker keys."""
+    kp = ObserverKeypair.generate()
+    p = tmp_path / "observer-key.json"
+    kp.save(str(p))
+    blob = json.loads(p.read_text())
+    assert blob["scheme"] == "sr25519-observer"
+    assert blob["public"] == kp.public_hex
+    assert blob["secret"] == kp.secret_hex
+
+
+def test_observer_keypair_save_uses_mode_0600(tmp_path: Path) -> None:
+    kp = ObserverKeypair.generate()
+    p = tmp_path / "observer-key.json"
+    kp.save(str(p))
+    mode = os.stat(p).st_mode
+    assert stat.S_IMODE(mode) == 0o600
+
+
+def test_observer_keypair_load_round_trip(tmp_path: Path) -> None:
+    kp = ObserverKeypair.generate()
+    p = tmp_path / "obs.json"
+    kp.save(str(p))
+    loaded = ObserverKeypair.load(str(p))
+    assert isinstance(loaded, ObserverKeypair)
+    assert loaded.public_hex == kp.public_hex
+    assert loaded.secret_hex == kp.secret_hex
+
+
+def test_observer_keypair_load_accepts_legacy_sr25519_scheme(tmp_path: Path) -> None:
+    """A keyfile that was written with scheme=sr25519 (e.g. an existing
+    worker key being repurposed as an observer) must still load via
+    ObserverKeypair.load."""
+    worker = WorkerKeypair.generate()
+    p = tmp_path / "legacy.json"
+    worker.save(str(p))  # writes scheme=sr25519
+    loaded = ObserverKeypair.load(str(p))
+    assert isinstance(loaded, ObserverKeypair)
+    assert loaded.public_hex == worker.public_hex
+
+
+def test_observer_keypair_load_rejects_unknown_scheme(tmp_path: Path) -> None:
+    """A scheme like ed25519 or random gibberish must be rejected."""
+    p = tmp_path / "bad.json"
+    p.write_text(
+        json.dumps(
+            {
+                "scheme": "ed25519",
+                "public": "ab" * 32,
+                "secret": "cd" * 64,
+            }
+        )
+    )
+    with pytest.raises(InvalidKeyfileError):
+        ObserverKeypair.load(str(p))
+
+
+def test_observer_keypair_load_rejects_malformed_json(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("{not json}")
+    with pytest.raises(InvalidKeyfileError):
+        ObserverKeypair.load(str(p))
+
+
+def test_observer_keypair_load_rejects_mismatched_pub_secret(tmp_path: Path) -> None:
+    """Same tamper-detection as WorkerKeypair: stored public must derive
+    from stored secret."""
+    kp = ObserverKeypair.generate()
+    p = tmp_path / "tampered.json"
+    p.write_text(
+        json.dumps(
+            {
+                "scheme": "sr25519-observer",
+                "secret": kp.secret_hex,
+                "public": "00" * 32,  # wrong public
+            }
+        )
+    )
+    with pytest.raises(InvalidKeyfileError):
+        ObserverKeypair.load(str(p))
+
+
+def test_observer_keypair_from_seed_hex_rejects_short_seed() -> None:
+    with pytest.raises(InvalidSeedError):
+        ObserverKeypair.from_seed_hex("0xab")
+
+
+def test_observer_keypair_pubkey_differs_from_worker_keypair_with_same_seed() -> None:
+    """They use the same algorithm, so the SAME seed should derive the SAME
+    public key — this test pins that property (the type discrimination is
+    metadata, not crypto)."""
+    seed = "0x" + "1f" * 32
+    worker = WorkerKeypair.from_seed_hex(seed)
+    observer = ObserverKeypair.from_seed_hex(seed)
+    assert worker.public_hex == observer.public_hex
+
+
+def test_observer_keypair_can_be_used_in_worker_keypair_isinstance_checks() -> None:
+    """v2 signing helpers accept WorkerKeypair OR ObserverKeypair via
+    isinstance(kp, WorkerKeypair). This pins the contract."""
+    obs = ObserverKeypair.generate()
+    assert isinstance(obs, WorkerKeypair)

--- a/packages/compute-meter-sdk/tests/test_record_v2.py
+++ b/packages/compute-meter-sdk/tests/test_record_v2.py
@@ -1,0 +1,601 @@
+"""Tests for v2 record builders / signers.
+
+Real sr25519 signatures (deterministic seeds for reproducibility). Real
+hardware_spec round-trips. NO mocked crypto in this file.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from materios_compute_meter.canonical import (
+    SCHEMA_VERSION_V2,
+    canonical_cbor_for_observer_sig,
+    canonical_cbor_for_worker_sig,
+    canonical_content_hash_v2,
+)
+from materios_compute_meter.exceptions import InvalidV2RecordError
+from materios_compute_meter.hardware_spec import HardwareSpec, sign_hardware_spec
+from materios_compute_meter.keypair import WorkerKeypair
+from materios_compute_meter.record import (
+    attach_observer_signature_v2,
+    build_record_v2,
+    next_period_start_ms,
+    sign_record_v2,
+    verify_record_v2,
+)
+
+
+# Deterministic seeds — three distinct keypairs.
+_FLEET_SEED = "0x" + "01" * 32
+_WORKER_SEED = "0x" + "02" * 32
+_OBSERVER_SEED = "0x" + "03" * 32
+
+
+def _fleet_kp() -> WorkerKeypair:
+    return WorkerKeypair.from_seed_hex(_FLEET_SEED)
+
+
+def _worker_kp() -> WorkerKeypair:
+    return WorkerKeypair.from_seed_hex(_WORKER_SEED)
+
+
+def _observer_kp() -> WorkerKeypair:
+    return WorkerKeypair.from_seed_hex(_OBSERVER_SEED)
+
+
+def _make_spec(worker_id: str = "worker-v2-001") -> HardwareSpec:
+    return sign_hardware_spec(
+        worker_id=worker_id,
+        cpu_cores=8,
+        ram_gb=32,
+        gpu_type="none",
+        gpu_count=0,
+        issued_ms=1_700_000_000_000,
+        fleet_operator_keypair=_fleet_kp(),
+    )
+
+
+def _good_metrics() -> dict:
+    return {
+        "cpu_seconds": 60,
+        "ram_gb_hours": 0.25,
+        "disk_gb_hours": 0.0,
+        "net_bytes_in": 1024,
+        "net_bytes_out": 512,
+        "gpu_seconds": 0,
+    }
+
+
+def _build_default_body() -> dict:
+    return build_record_v2(
+        worker_id="worker-v2-001",
+        tenant_id="tenant-acme",
+        period_start_ms=1_700_000_000_000,
+        period_end_ms=1_700_000_060_000,
+        metrics=_good_metrics(),
+        hardware_spec=_make_spec(),
+    )
+
+
+# ----- build ------------------------------------------------------------
+
+
+def test_build_record_v2_returns_dict_with_all_required_v2_fields() -> None:
+    body = _build_default_body()
+    assert body["schema_version"] == SCHEMA_VERSION_V2
+    assert body["worker_id"] == "worker-v2-001"
+    assert body["tenant_id"] == "tenant-acme"
+    assert body["period_start_ms"] == 1_700_000_000_000
+    assert body["period_end_ms"] == 1_700_000_060_000
+    assert body["metrics"]["cpu_seconds"] == 60
+    assert body["metrics"]["ram_gb_hours"] == 0.25
+    assert body["hardware_spec"]["cpu_cores"] == 8
+    # Pre-sign, no worker_signature.
+    assert "worker_signature" not in body
+    # Pre-sign, no worker_pubkey since we didn't pass one in.
+    assert "worker_pubkey" not in body
+
+
+def test_build_record_v2_accepts_hardware_spec_dict_form() -> None:
+    """Passing the envelope-dict form of hardware_spec works too."""
+    spec = _make_spec()
+    body = build_record_v2(
+        worker_id="worker-v2-001",
+        tenant_id="tenant-acme",
+        period_start_ms=1,
+        period_end_ms=2,
+        metrics=_good_metrics(),
+        hardware_spec=spec.to_envelope_dict(),
+    )
+    assert body["hardware_spec"]["cpu_cores"] == 8
+
+
+def test_build_record_v2_normalizes_metric_floats() -> None:
+    """Float metrics stay float; integer-only metrics enforced as int."""
+    body = build_record_v2(
+        worker_id="worker-v2-001",
+        tenant_id="tenant-acme",
+        period_start_ms=1,
+        period_end_ms=2,
+        metrics={
+            "cpu_seconds": 60,
+            "ram_gb_hours": 1,  # int — coerced to float
+            "disk_gb_hours": 0.5,
+            "net_bytes_in": 100,
+            "net_bytes_out": 50,
+            "gpu_seconds": 0,
+        },
+        hardware_spec=_make_spec(),
+    )
+    assert isinstance(body["metrics"]["ram_gb_hours"], float)
+    assert body["metrics"]["ram_gb_hours"] == 1.0
+    assert isinstance(body["metrics"]["cpu_seconds"], int)
+
+
+def test_build_record_v2_rejects_bad_worker_id_with_space() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker with space",
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=_good_metrics(),
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_bad_worker_id_with_comma() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker,001",
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=_good_metrics(),
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_too_long_worker_id() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="x" * 129,  # 129 > 128 max
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=_good_metrics(),
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_bad_tenant_id_uppercase() -> None:
+    """tenant_id must be lowercase per the [a-z0-9-]{4,64} regex."""
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="Tenant-ACME",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=_good_metrics(),
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_bad_tenant_id_too_short() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="abc",  # 3 chars, min is 4
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=_good_metrics(),
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_period_zero_length() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="tenant-acme",
+            period_start_ms=100,
+            period_end_ms=100,  # equal — must be strictly greater
+            metrics=_good_metrics(),
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_period_over_24h() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="tenant-acme",
+            period_start_ms=0,
+            period_end_ms=86_400_001,  # 24h + 1ms
+            metrics=_good_metrics(),
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_accepts_period_exactly_24h() -> None:
+    """24h boundary is inclusive."""
+    body = build_record_v2(
+        worker_id="worker-001",
+        tenant_id="tenant-acme",
+        period_start_ms=0,
+        period_end_ms=86_400_000,
+        metrics=_good_metrics(),
+        hardware_spec=_make_spec(),
+    )
+    assert body["period_end_ms"] == 86_400_000
+
+
+def test_build_record_v2_rejects_negative_metric() -> None:
+    bad = _good_metrics()
+    bad["cpu_seconds"] = -1
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=bad,
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_nan_metric() -> None:
+    bad = _good_metrics()
+    bad["ram_gb_hours"] = float("nan")
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=bad,
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_infinity_metric() -> None:
+    bad = _good_metrics()
+    bad["disk_gb_hours"] = math.inf
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=bad,
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_missing_metric_key() -> None:
+    bad = _good_metrics()
+    del bad["gpu_seconds"]
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=bad,
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_extra_metric_key() -> None:
+    bad = _good_metrics()
+    bad["bonus_metric"] = 1
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=bad,
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_bool_metric_value() -> None:
+    """Python bools are int subclasses — explicitly reject them."""
+    bad = _good_metrics()
+    bad["cpu_seconds"] = True  # would silently equal 1 if we let it through
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=bad,
+            hardware_spec=_make_spec(),
+        )
+
+
+def test_build_record_v2_rejects_float_for_int_only_metric() -> None:
+    bad = _good_metrics()
+    bad["net_bytes_in"] = 100.5  # int-only field
+    with pytest.raises(InvalidV2RecordError):
+        build_record_v2(
+            worker_id="worker-001",
+            tenant_id="tenant-acme",
+            period_start_ms=1,
+            period_end_ms=2,
+            metrics=bad,
+            hardware_spec=_make_spec(),
+        )
+
+
+# ----- sign --------------------------------------------------------------
+
+
+def test_sign_record_v2_fills_pubkey_and_signature() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    assert isinstance(sealed["worker_pubkey"], bytes)
+    assert len(sealed["worker_pubkey"]) == 32
+    assert isinstance(sealed["worker_signature"], bytes)
+    assert len(sealed["worker_signature"]) == 64
+
+
+def test_sign_record_v2_does_not_mutate_input() -> None:
+    body = _build_default_body()
+    body_snapshot = dict(body)
+    sign_record_v2(body, _worker_kp())
+    assert body == body_snapshot
+    assert "worker_signature" not in body
+
+
+def test_sign_record_v2_signature_verifies_against_canonical_bytes() -> None:
+    """The signature MUST verify against the canonical worker-sig pre-image
+    derived from the sealed record."""
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    expected_body = canonical_cbor_for_worker_sig(sealed)
+    kp = _worker_kp()
+    assert kp.verify_bytes(expected_body, sealed["worker_signature"]) is True
+
+
+def test_sign_record_v2_pubkey_overrides_caller_provided_one() -> None:
+    """If the caller pre-populated worker_pubkey with a different key,
+    sign_record_v2 must overwrite it with the signing keypair's pubkey."""
+    body = _build_default_body()
+    other_pub = bytes.fromhex(_observer_kp().public_hex)
+    body["worker_pubkey"] = other_pub
+    sealed = sign_record_v2(body, _worker_kp())
+    assert sealed["worker_pubkey"] == bytes.fromhex(_worker_kp().public_hex)
+    assert sealed["worker_pubkey"] != other_pub
+
+
+def test_sign_record_v2_rejects_non_dict_input() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        sign_record_v2([1, 2, 3], _worker_kp())  # type: ignore[arg-type]
+
+
+def test_sign_record_v2_rejects_non_keypair() -> None:
+    body = _build_default_body()
+    with pytest.raises(InvalidV2RecordError):
+        sign_record_v2(body, "not a keypair")  # type: ignore[arg-type]
+
+
+def test_verify_record_v2_returns_true_for_correctly_sealed() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    assert verify_record_v2(sealed) is True
+
+
+def test_verify_record_v2_returns_false_when_metric_tampered() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    # Tamper after sealing — verify must catch it.
+    sealed["metrics"]["cpu_seconds"] = 9999
+    assert verify_record_v2(sealed) is False
+
+
+def test_verify_record_v2_returns_false_when_signature_swapped_for_different_record() -> None:
+    body_a = _build_default_body()
+    sealed_a = sign_record_v2(body_a, _worker_kp())
+    # Build a different record (different period) and steal A's sig.
+    body_b = build_record_v2(
+        worker_id="worker-v2-001",
+        tenant_id="tenant-acme",
+        period_start_ms=2_000_000_000_000,
+        period_end_ms=2_000_000_060_000,
+        metrics=_good_metrics(),
+        hardware_spec=_make_spec(),
+    )
+    sealed_b = sign_record_v2(body_b, _worker_kp())
+    sealed_b["worker_signature"] = sealed_a["worker_signature"]
+    assert verify_record_v2(sealed_b) is False
+
+
+def test_verify_record_v2_returns_false_when_pubkey_swapped() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    sealed["worker_pubkey"] = bytes.fromhex(_observer_kp().public_hex)
+    assert verify_record_v2(sealed) is False
+
+
+def test_content_hash_v2_helper_matches_canonical_pre_image() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    expected_hex = canonical_content_hash_v2(sealed)
+    # Strip variable signatures so the hash is computed over the worker
+    # pre-image only — the helper does this for us.
+    assert len(expected_hex) == 64
+    assert isinstance(expected_hex, str)
+
+
+# ----- observer ----------------------------------------------------------
+
+
+def test_attach_observer_signature_v2_round_trip() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    co = attach_observer_signature_v2(sealed, _observer_kp())
+    assert "observer" in co
+    obs = co["observer"]
+    assert isinstance(obs["observer_pubkey"], bytes)
+    assert len(obs["observer_pubkey"]) == 32
+    assert isinstance(obs["observer_signature"], bytes)
+    assert len(obs["observer_signature"]) == 64
+    # Worker sig preserved unchanged.
+    assert co["worker_signature"] == sealed["worker_signature"]
+    assert co["worker_pubkey"] == sealed["worker_pubkey"]
+
+
+def test_attach_observer_does_not_mutate_input() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    sealed_snapshot = dict(sealed)
+    attach_observer_signature_v2(sealed, _observer_kp())
+    assert sealed == sealed_snapshot
+    assert "observer" not in sealed
+
+
+def test_observer_signature_verifies_against_same_pre_image_as_worker() -> None:
+    """The observer signs the SAME bytes as the worker."""
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    co = attach_observer_signature_v2(sealed, _observer_kp())
+    # Pre-image identical:
+    assert canonical_cbor_for_worker_sig(co) == canonical_cbor_for_observer_sig(co)
+    # Observer sig verifies under observer's pubkey:
+    obs_kp = _observer_kp()
+    body_bytes = canonical_cbor_for_observer_sig(co)
+    assert obs_kp.verify_bytes(body_bytes, co["observer"]["observer_signature"]) is True
+    # And worker sig STILL verifies:
+    worker_kp = _worker_kp()
+    assert worker_kp.verify_bytes(body_bytes, co["worker_signature"]) is True
+
+
+def test_attach_observer_rejects_record_without_worker_signature() -> None:
+    """Observer can only co-sign a worker-sealed record."""
+    body = _build_default_body()
+    with pytest.raises(InvalidV2RecordError):
+        attach_observer_signature_v2(body, _observer_kp())
+
+
+def test_attach_observer_rejects_non_keypair() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    with pytest.raises(InvalidV2RecordError):
+        attach_observer_signature_v2(sealed, "not a keypair")  # type: ignore[arg-type]
+
+
+def test_attach_observer_rejects_non_mapping() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        attach_observer_signature_v2([1, 2, 3], _observer_kp())  # type: ignore[arg-type]
+
+
+def test_verify_record_v2_with_observer_returns_true() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    co = attach_observer_signature_v2(sealed, _observer_kp())
+    assert verify_record_v2(co) is True
+
+
+def test_verify_record_v2_returns_false_when_observer_signature_tampered() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    co = attach_observer_signature_v2(sealed, _observer_kp())
+    # Tamper observer sig (flip 1 byte at the end so it's still valid length).
+    bad_sig = bytearray(co["observer"]["observer_signature"])
+    bad_sig[-1] ^= 0xff
+    co["observer"]["observer_signature"] = bytes(bad_sig)
+    assert verify_record_v2(co) is False
+
+
+def test_verify_record_v2_returns_false_when_observer_pubkey_swapped() -> None:
+    body = _build_default_body()
+    sealed = sign_record_v2(body, _worker_kp())
+    co = attach_observer_signature_v2(sealed, _observer_kp())
+    co["observer"]["observer_pubkey"] = bytes.fromhex(_worker_kp().public_hex)
+    assert verify_record_v2(co) is False
+
+
+# ----- monotonic helper --------------------------------------------------
+
+
+def test_next_period_start_ms_returns_now_when_now_greater() -> None:
+    out = next_period_start_ms(last_seen_ms=100, now_ms=200)
+    assert out == 200
+
+
+def test_next_period_start_ms_returns_last_plus_one_when_now_too_low() -> None:
+    """If wall clock is BEHIND the last record (e.g. NTP drift), monotonic
+    helper returns last + 1 ms to keep things strictly increasing."""
+    out = next_period_start_ms(last_seen_ms=1_700_000_000_000, now_ms=1_500_000_000_000)
+    assert out == 1_700_000_000_001
+
+
+def test_next_period_start_ms_uses_wall_clock_when_no_now() -> None:
+    """No now_ms argument: function reads time.time_ns() // 1e6."""
+    import time as _time
+
+    before = _time.time_ns() // 1_000_000
+    out = next_period_start_ms(last_seen_ms=0)
+    after = _time.time_ns() // 1_000_000
+    assert before <= out <= after + 1
+
+
+def test_next_period_start_ms_rejects_negative_last_seen() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        next_period_start_ms(last_seen_ms=-1, now_ms=100)
+
+
+def test_next_period_start_ms_rejects_bool_last_seen() -> None:
+    with pytest.raises(InvalidV2RecordError):
+        next_period_start_ms(last_seen_ms=True, now_ms=100)  # type: ignore[arg-type]
+
+
+# ----- end-to-end deterministic example ---------------------------------
+
+
+def test_v2_full_envelope_round_trips_through_sign_observer_verify() -> None:
+    """End-to-end: build → sign worker → attach observer → verify the
+    whole envelope. All deterministic; if this breaks, something in the
+    canonical pre-image, key derivation, or sig flow regressed."""
+    body = build_record_v2(
+        worker_id="worker-e2e-001",
+        tenant_id="tenant-e2e",
+        period_start_ms=1_700_000_000_000,
+        period_end_ms=1_700_000_060_000,
+        metrics={
+            "cpu_seconds": 60,
+            "ram_gb_hours": 0.25,
+            "disk_gb_hours": 0.0,
+            "net_bytes_in": 1024,
+            "net_bytes_out": 512,
+            "gpu_seconds": 0,
+        },
+        hardware_spec=sign_hardware_spec(
+            worker_id="worker-e2e-001",
+            cpu_cores=8,
+            ram_gb=32,
+            gpu_type="none",
+            gpu_count=0,
+            issued_ms=1_699_000_000_000,
+            fleet_operator_keypair=_fleet_kp(),
+        ),
+    )
+    sealed = sign_record_v2(body, _worker_kp())
+    co = attach_observer_signature_v2(sealed, _observer_kp())
+    assert verify_record_v2(co) is True
+    # And the embedded fleet-op sig also verifies:
+    spec_dict = co["hardware_spec"]
+    spec = HardwareSpec(
+        cpu_cores=spec_dict["cpu_cores"],
+        ram_gb=spec_dict["ram_gb"],
+        gpu_type=spec_dict["gpu_type"],
+        gpu_count=spec_dict["gpu_count"],
+        fleet_operator_pubkey=spec_dict["fleet_operator_pubkey"],
+        fleet_operator_signature=spec_dict["fleet_operator_signature"],
+        issued_ms=spec_dict["issued_ms"],
+    )
+    assert spec.verify("worker-e2e-001") is True

--- a/packages/compute-meter-sdk/tests/test_submit_v2_unit.py
+++ b/packages/compute-meter-sdk/tests/test_submit_v2_unit.py
@@ -1,0 +1,459 @@
+"""Unit tests for submit_v2 — wire format, retry, error mapping, replay,
+content-hash cross-check.
+
+Mock httpx transport throughout. NO live network access in this file —
+see test_v2_e2e_preprod.py for the live preprod test.
+
+REAL sr25519 signatures are used (no mocked crypto) so the SDK's
+canonical content_hash is computed on actual signed bytes.
+"""
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import httpx
+import pytest
+
+from materios_compute_meter.canonical import (
+    SCHEMA_VERSION_V2,
+    canonical_content_hash_v2,
+)
+from materios_compute_meter.exceptions import (
+    GatewayError,
+    ReplayRejectedError,
+    SubmitError,
+)
+from materios_compute_meter.hardware_spec import sign_hardware_spec
+from materios_compute_meter.keypair import ObserverKeypair, WorkerKeypair
+from materios_compute_meter.record import (
+    attach_observer_signature_v2,
+    build_record_v2,
+    sign_record_v2,
+)
+from materios_compute_meter.submit import (
+    SubmissionResult,
+    submit_v2,
+)
+
+
+_FLEET_SEED = "0x" + "10" * 32
+_WORKER_SEED = "0x" + "20" * 32
+_OBSERVER_SEED = "0x" + "30" * 32
+
+
+def _fleet_kp() -> WorkerKeypair:
+    return WorkerKeypair.from_seed_hex(_FLEET_SEED)
+
+
+def _worker_kp() -> WorkerKeypair:
+    return WorkerKeypair.from_seed_hex(_WORKER_SEED)
+
+
+def _observer_kp() -> ObserverKeypair:
+    return ObserverKeypair.from_seed_hex(_OBSERVER_SEED)
+
+
+def _make_sealed_record(
+    *,
+    worker_id: str = "worker-v2-001",
+    period_start_ms: int = 1_700_000_000_000,
+    period_end_ms: Optional[int] = None,
+    with_observer: bool = False,
+) -> dict:
+    if period_end_ms is None:
+        period_end_ms = period_start_ms + 60_000
+    spec = sign_hardware_spec(
+        worker_id=worker_id,
+        cpu_cores=8,
+        ram_gb=32,
+        gpu_type="none",
+        gpu_count=0,
+        issued_ms=1_699_000_000_000,
+        fleet_operator_keypair=_fleet_kp(),
+    )
+    body = build_record_v2(
+        worker_id=worker_id,
+        tenant_id="tenant-test",
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+        metrics={
+            "cpu_seconds": 60,
+            "ram_gb_hours": 0.25,
+            "disk_gb_hours": 0.0,
+            "net_bytes_in": 1024,
+            "net_bytes_out": 512,
+            "gpu_seconds": 0,
+        },
+        hardware_spec=spec,
+    )
+    sealed = sign_record_v2(body, _worker_kp())
+    if with_observer:
+        sealed = attach_observer_signature_v2(sealed, _observer_kp())
+    return sealed
+
+
+def _mock_transport(handler):
+    return httpx.MockTransport(handler)
+
+
+# ---- happy path ----------------------------------------------------------
+
+
+def test_submit_v2_happy_path_posts_correct_wire_format() -> None:
+    rec = _make_sealed_record()
+    expected_hash = canonical_content_hash_v2(rec)
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["method"] = request.method
+        captured["body"] = json.loads(request.content)
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0xrcpt_v2_001",
+                "content_hash": expected_hash,
+                "accepted_at": 1_700_000_999,
+            },
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    res = submit_v2(
+        rec,
+        gateway_url="https://example.com/gw",
+        bearer="matra_v2_token",
+        _client=client,
+    )
+    assert isinstance(res, SubmissionResult)
+    assert res.receipt_id == "0xrcpt_v2_001"
+    assert res.content_hash == expected_hash
+    assert res.status_code == 200
+    assert res.accepted_at == 1_700_000_999
+
+    # Wire format checks:
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/metering/submit")
+    assert captured["headers"]["authorization"] == "Bearer matra_v2_token"
+    assert captured["headers"]["x-schema-version"] == SCHEMA_VERSION_V2
+    body = captured["body"]
+    # v2-shape fields:
+    assert body["schema_version"] == SCHEMA_VERSION_V2
+    assert body["worker_id"] == "worker-v2-001"
+    assert body["tenant_id"] == "tenant-test"
+    assert body["period_start_ms"] == 1_700_000_000_000
+    assert body["period_end_ms"] == 1_700_000_060_000
+    assert body["metrics"]["cpu_seconds"] == 60
+    assert body["hardware_spec"]["cpu_cores"] == 8
+    # Bytes are hex-on-the-wire.
+    assert isinstance(body["worker_pubkey_hex"], str)
+    assert len(body["worker_pubkey_hex"]) == 64
+    assert isinstance(body["worker_signature_hex"], str)
+    assert len(body["worker_signature_hex"]) == 128
+    assert len(body["hardware_spec"]["fleet_operator_pubkey_hex"]) == 64
+    assert len(body["hardware_spec"]["fleet_operator_signature_hex"]) == 128
+    # No observer block in this run.
+    assert "observer" not in body
+
+
+def test_submit_v2_with_observer_block_posts_observer_in_body() -> None:
+    rec = _make_sealed_record(with_observer=True)
+    expected_hash = canonical_content_hash_v2(rec)
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0xrcpt_v2_obs",
+                "content_hash": expected_hash,
+                "accepted_at": 1,
+            },
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    submit_v2(
+        rec,
+        gateway_url="https://example.com/gw",
+        bearer="t",
+        _client=client,
+    )
+    body = captured["body"]
+    assert "observer" in body
+    assert len(body["observer"]["observer_pubkey_hex"]) == 64
+    assert len(body["observer"]["observer_signature_hex"]) == 128
+
+
+def test_submit_v2_accepts_api_key_alias_for_bearer() -> None:
+    rec = _make_sealed_record()
+    expected_hash = canonical_content_hash_v2(rec)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer alias_token"
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "x",
+                "content_hash": expected_hash,
+                "accepted_at": 1,
+            },
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    submit_v2(
+        rec,
+        gateway_url="https://x/gw",
+        api_key="alias_token",  # alias of bearer
+        _client=client,
+    )
+
+
+# ---- error mapping (4xx) -------------------------------------------------
+
+
+def test_submit_v2_403_maps_to_fleet_operator_unknown() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_000_000)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={"error": "fleet_operator pubkey not registered"},
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    with pytest.raises(GatewayError) as exc:
+        submit_v2(
+            rec,
+            gateway_url="https://x/gw",
+            bearer="t",
+            _client=client,
+            _retry_backoff_seconds=0.0,
+        )
+    assert exc.value.status == 403
+    assert "fleet_operator unknown" in str(exc.value)
+
+
+def test_submit_v2_422_maps_to_hardware_bound_violated() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_001_000)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            422,
+            json={"error": "cpu_seconds exceeds cap (8 cores * 60s)"},
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    with pytest.raises(GatewayError) as exc:
+        submit_v2(
+            rec,
+            gateway_url="https://x/gw",
+            bearer="t",
+            _client=client,
+            _retry_backoff_seconds=0.0,
+        )
+    assert exc.value.status == 422
+    assert "hardware bound violated" in str(exc.value)
+
+
+def test_submit_v2_401_maps_to_unauthorized() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_002_000)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "bad token"})
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    with pytest.raises(GatewayError) as exc:
+        submit_v2(
+            rec,
+            gateway_url="https://x/gw",
+            bearer="t",
+            _client=client,
+            _retry_backoff_seconds=0.0,
+        )
+    assert exc.value.status == 401
+
+
+# ---- retry / network -----------------------------------------------------
+
+
+def test_submit_v2_retries_once_on_5xx_then_succeeds() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_003_000)
+    expected_hash = canonical_content_hash_v2(rec)
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return httpx.Response(503, json={"error": "service unavailable"})
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0xok",
+                "content_hash": expected_hash,
+                "accepted_at": 0,
+            },
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    res = submit_v2(
+        rec,
+        gateway_url="https://x/gw",
+        bearer="t",
+        _client=client,
+        _retry_backoff_seconds=0.0,
+    )
+    assert calls["count"] == 2
+    assert res.receipt_id == "0xok"
+
+
+def test_submit_v2_does_not_retry_on_4xx() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_004_000)
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(400, json={"error": "bad"})
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    with pytest.raises(GatewayError):
+        submit_v2(
+            rec,
+            gateway_url="https://x/gw",
+            bearer="t",
+            _client=client,
+            _retry_backoff_seconds=0.0,
+        )
+    assert calls["count"] == 1
+
+
+def test_submit_v2_raises_on_network_error() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_005_000)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("DNS fail")
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    with pytest.raises(SubmitError):
+        submit_v2(
+            rec,
+            gateway_url="https://x/gw",
+            bearer="t",
+            _client=client,
+            _retry_backoff_seconds=0.0,
+        )
+
+
+# ---- replay --------------------------------------------------------------
+
+
+def test_submit_v2_replay_rejection_on_duplicate_period_start_ms() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_006_000)
+    expected_hash = canonical_content_hash_v2(rec)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0x",
+                "content_hash": expected_hash,
+                "accepted_at": 0,
+            },
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    submit_v2(rec, gateway_url="https://x/gw", bearer="t", _client=client)
+    with pytest.raises(ReplayRejectedError):
+        submit_v2(rec, gateway_url="https://x/gw", bearer="t", _client=client)
+
+
+# ---- content_hash cross-check -------------------------------------------
+
+
+def test_submit_v2_rejects_server_substituted_content_hash() -> None:
+    """If the server returns a content_hash that doesn't match the SDK's
+    locally-recomputed canonical digest, the SDK MUST refuse to trust it."""
+    rec = _make_sealed_record(period_start_ms=2_000_000_007_000)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0x",
+                "content_hash": "00" * 32,  # bogus
+                "accepted_at": 0,
+            },
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    with pytest.raises(SubmitError) as exc:
+        submit_v2(
+            rec,
+            gateway_url="https://x/gw",
+            bearer="t",
+            _client=client,
+        )
+    assert "content_hash" in str(exc.value)
+
+
+# ---- input validation ---------------------------------------------------
+
+
+def test_submit_v2_rejects_empty_bearer_and_api_key() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_008_000)
+    with pytest.raises(SubmitError):
+        submit_v2(rec, gateway_url="https://x/gw")
+
+
+def test_submit_v2_rejects_conflicting_bearer_and_api_key() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_009_000)
+    with pytest.raises(SubmitError):
+        submit_v2(
+            rec,
+            gateway_url="https://x/gw",
+            api_key="A",
+            bearer="B",
+        )
+
+
+def test_submit_v2_url_strips_trailing_slash() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_010_000)
+    expected_hash = canonical_content_hash_v2(rec)
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "receipt_id": "0x",
+                "content_hash": expected_hash,
+                "accepted_at": 0,
+            },
+        )
+
+    client = httpx.Client(transport=_mock_transport(handler))
+    submit_v2(
+        rec,
+        gateway_url="https://x/gw/",
+        bearer="t",
+        _client=client,
+    )
+    assert "//" not in captured["url"].split("https://")[1]
+
+
+def test_submit_v2_rejects_record_missing_required_fields() -> None:
+    """If the record dict is missing worker_signature, surface a SubmitError
+    with a clear message — don't crash the encoder."""
+    rec = _make_sealed_record(period_start_ms=2_000_000_011_000)
+    rec.pop("worker_signature")
+    with pytest.raises(SubmitError):
+        submit_v2(rec, gateway_url="https://x/gw", bearer="t")
+
+
+def test_submit_v2_rejects_record_with_wrong_pubkey_byte_length() -> None:
+    rec = _make_sealed_record(period_start_ms=2_000_000_012_000)
+    rec["worker_pubkey"] = b"\x00" * 16  # too short
+    with pytest.raises(SubmitError):
+        submit_v2(rec, gateway_url="https://x/gw", bearer="t")

--- a/packages/compute-meter-sdk/tests/test_v2_e2e_preprod.py
+++ b/packages/compute-meter-sdk/tests/test_v2_e2e_preprod.py
@@ -1,0 +1,350 @@
+"""LIVE preprod E2E test for compute_metering_v2 envelopes.
+
+Gated by `MATERIOS_E2E_BEARER` AND `MATERIOS_E2E_HARDWARE_SPEC` per the
+team-3 brief. Skips gracefully (with a clear reason) when either is unset
+or when the gateway hasn't shipped the v2 route yet.
+
+Manual setup:
+
+    export MATERIOS_E2E_BEARER="matra_<your_token>"
+
+    # OPTION A — hardware spec bound to a single fixed worker_id
+    export MATERIOS_E2E_HARDWARE_SPEC="/path/to/fleet-signed-hardware.json"
+    export MATERIOS_E2E_WORKER_ID="<the worker_id baked into the spec>"
+
+    # OPTION B — fleet operator key on disk; tests will generate per-run
+    # specs so each test gets a unique worker_id without re-issuing.
+    # (Same env var, set BOTH:)
+    export MATERIOS_E2E_HARDWARE_SPEC="/path/to/fleet-signed-hardware.json"
+    export MATERIOS_E2E_FLEET_OPERATOR_KEY="/path/to/fleet-operator-key.json"
+
+    # Optional:
+    export MATERIOS_E2E_GATEWAY="https://materios.fluxpointstudios.com/preprod-blobs"
+    export MATERIOS_E2E_WORKER_KEY="/path/to/worker-key.json"
+    export MATERIOS_E2E_OBSERVER_KEY="/path/to/observer-key.json"
+    export MATERIOS_E2E_TENANT_ID="tenant-acme"
+
+    .venv/bin/pytest tests/test_v2_e2e_preprod.py -v -m e2e
+
+If MATERIOS_E2E_WORKER_KEY is unset, a fresh keypair is generated for the
+run (the gateway should accept any sr25519 pubkey because the hardware
+spec is what binds identity in v2).
+"""
+from __future__ import annotations
+
+import os
+import time
+
+import httpx
+import pytest
+
+from materios_compute_meter.canonical import canonical_content_hash_v2
+from materios_compute_meter.exceptions import GatewayError
+from materios_compute_meter.hardware_spec import HardwareSpec, sign_hardware_spec
+from materios_compute_meter.keypair import ObserverKeypair, WorkerKeypair
+from materios_compute_meter.record import (
+    attach_observer_signature_v2,
+    build_record_v2,
+    sign_record_v2,
+    verify_record_v2,
+)
+from materios_compute_meter.submit import SubmissionResult, submit_v2
+
+pytestmark = pytest.mark.e2e
+
+
+GATEWAY_URL = os.environ.get(
+    "MATERIOS_E2E_GATEWAY",
+    "https://materios.fluxpointstudios.com/preprod-blobs",
+)
+BEARER = os.environ.get("MATERIOS_E2E_BEARER", "")
+HARDWARE_SPEC_PATH = os.environ.get("MATERIOS_E2E_HARDWARE_SPEC", "")
+FLEET_OPERATOR_KEY_PATH = os.environ.get("MATERIOS_E2E_FLEET_OPERATOR_KEY", "")
+WORKER_KEY_PATH = os.environ.get("MATERIOS_E2E_WORKER_KEY", "")
+OBSERVER_KEY_PATH = os.environ.get("MATERIOS_E2E_OBSERVER_KEY", "")
+TENANT_ID = os.environ.get("MATERIOS_E2E_TENANT_ID", "tenant-e2e")
+WORKER_ID_PREFIX = os.environ.get("MATERIOS_E2E_WORKER_ID", "worker-e2e")
+
+
+def _gateway_route_ready() -> str:
+    """Probe the v2 metering route. Returns one of:
+
+      * "ready"           — gateway returns a 4xx (not 404) for an empty
+                            POST. Means route exists and accepts our shape.
+      * "v1-only"         — gateway accepts /metering/submit but rejects
+                            schema_version=compute_metering_v2 with
+                            WRONG_SCHEMA_VERSION; Team 2 hasn't shipped.
+      * "404"             — route doesn't exist yet.
+      * "unreachable"     — network / DNS / TLS error.
+    """
+    try:
+        with httpx.Client(timeout=8.0) as c:
+            # Probe with a v2 schema_version to detect v1-only validators.
+            r = c.post(
+                f"{GATEWAY_URL}/metering/submit",
+                json={"schema_version": "compute_metering_v2"},
+                headers={"authorization": "Bearer probe"},
+            )
+            if r.status_code == 404:
+                return "404"
+            try:
+                body = r.json()
+            except Exception:
+                body = None
+            if (
+                isinstance(body, dict)
+                and body.get("code") == "WRONG_SCHEMA_VERSION"
+                and "compute_metering_v1" in str(body.get("message", ""))
+            ):
+                return "v1-only"
+            return "ready"
+    except httpx.HTTPError:
+        return "unreachable"
+
+
+@pytest.fixture(scope="module")
+def env_ready() -> None:
+    if not BEARER:
+        pytest.skip(
+            "MATERIOS_E2E_BEARER not set — see test_v2_e2e_preprod.py "
+            "module docstring for setup."
+        )
+    if not HARDWARE_SPEC_PATH:
+        pytest.skip(
+            "MATERIOS_E2E_HARDWARE_SPEC not set — pass the path to a "
+            "fleet-operator-signed hardware spec JSON."
+        )
+    if not os.path.isfile(HARDWARE_SPEC_PATH):
+        pytest.skip(
+            f"MATERIOS_E2E_HARDWARE_SPEC={HARDWARE_SPEC_PATH!r} does not "
+            "exist. Cannot run live E2E."
+        )
+
+
+@pytest.fixture(scope="module")
+def gateway_ready() -> None:
+    status = _gateway_route_ready()
+    if status == "unreachable":
+        pytest.skip(
+            f"Gateway {GATEWAY_URL} is unreachable from this host."
+        )
+    if status == "404":
+        pytest.skip(
+            f"Gateway {GATEWAY_URL}/metering/submit is 404 — neither v1 "
+            "nor v2 metering routes are deployed."
+        )
+    if status == "v1-only":
+        pytest.skip(
+            f"Gateway {GATEWAY_URL}/metering/submit accepts only "
+            "compute_metering_v1 — Team 2's v2 validator hasn't shipped "
+            "yet. The SDK's wire format is correct (verified by the "
+            "cross-language test); re-run this E2E after the gateway "
+            "v2 route deploys."
+        )
+
+
+@pytest.fixture(scope="module")
+def hardware_spec(env_ready) -> HardwareSpec:
+    return HardwareSpec.load(HARDWARE_SPEC_PATH)
+
+
+@pytest.fixture(scope="module")
+def fleet_operator_kp() -> WorkerKeypair:
+    """If MATERIOS_E2E_FLEET_OPERATOR_KEY is set, load that key. Otherwise
+    return None — tests that need per-run hw spec generation will skip
+    if this fixture is None."""
+    if FLEET_OPERATOR_KEY_PATH and os.path.isfile(FLEET_OPERATOR_KEY_PATH):
+        return WorkerKeypair.load(FLEET_OPERATOR_KEY_PATH)
+    return None
+
+
+def _per_run_hw_spec(
+    fleet_kp: WorkerKeypair, base_spec: HardwareSpec, worker_id: str
+) -> HardwareSpec:
+    """Re-issue the hardware spec for `worker_id` using the fleet operator
+    key. Used by E2E tests so each run gets a unique worker_id."""
+    return sign_hardware_spec(
+        worker_id=worker_id,
+        cpu_cores=base_spec.cpu_cores,
+        ram_gb=base_spec.ram_gb,
+        gpu_type=base_spec.gpu_type,
+        gpu_count=base_spec.gpu_count,
+        issued_ms=int(time.time() * 1000),
+        fleet_operator_keypair=fleet_kp,
+    )
+
+
+@pytest.fixture(scope="module")
+def worker_kp() -> WorkerKeypair:
+    if WORKER_KEY_PATH and os.path.isfile(WORKER_KEY_PATH):
+        return WorkerKeypair.load(WORKER_KEY_PATH)
+    return WorkerKeypair.generate()
+
+
+@pytest.fixture(scope="module")
+def observer_kp() -> ObserverKeypair:
+    if OBSERVER_KEY_PATH and os.path.isfile(OBSERVER_KEY_PATH):
+        return ObserverKeypair.load(OBSERVER_KEY_PATH)
+    return ObserverKeypair.generate()
+
+
+def _make_v2_envelope(
+    *,
+    spec: HardwareSpec,
+    worker_kp: WorkerKeypair,
+    observer_kp: ObserverKeypair = None,
+    worker_id: str,
+    period_start_ms: int,
+    period_end_ms: int,
+) -> dict:
+    body = build_record_v2(
+        worker_id=worker_id,
+        tenant_id=TENANT_ID,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+        metrics={
+            "cpu_seconds": 30,
+            "ram_gb_hours": 0.05,
+            "disk_gb_hours": 0.0,
+            "net_bytes_in": 4096,
+            "net_bytes_out": 2048,
+            "gpu_seconds": 0,
+        },
+        hardware_spec=spec,
+    )
+    sealed = sign_record_v2(body, worker_kp)
+    if observer_kp is not None:
+        sealed = attach_observer_signature_v2(sealed, observer_kp)
+    return sealed
+
+
+def _resolve_spec_for_worker(
+    base_spec: HardwareSpec,
+    fleet_operator_kp,
+    worker_id: str,
+) -> HardwareSpec:
+    """If the base spec verifies for `worker_id`, use it. Otherwise, if a
+    fleet operator key is available, re-issue. Otherwise skip the test."""
+    if base_spec.verify(worker_id):
+        return base_spec
+    if fleet_operator_kp is not None:
+        return _per_run_hw_spec(fleet_operator_kp, base_spec, worker_id)
+    pytest.skip(
+        f"hardware_spec at {HARDWARE_SPEC_PATH} does not verify for "
+        f"worker_id={worker_id!r}. Either set MATERIOS_E2E_WORKER_ID "
+        "to the worker_id baked into the spec, OR set "
+        "MATERIOS_E2E_FLEET_OPERATOR_KEY so the test can re-issue per run."
+    )
+
+
+def test_live_v2_submit_no_observer_round_trips(
+    env_ready,
+    gateway_ready,
+    hardware_spec: HardwareSpec,
+    worker_kp: WorkerKeypair,
+    fleet_operator_kp,
+) -> None:
+    """End-to-end: build → sign → submit → assert gateway echoes the SAME
+    canonical content_hash the SDK computed locally."""
+    period_start_ms = int(time.time() * 1000)
+    period_end_ms = period_start_ms + 60_000
+    worker_id = f"{WORKER_ID_PREFIX}-noobs-{period_start_ms}"
+
+    spec = _resolve_spec_for_worker(hardware_spec, fleet_operator_kp, worker_id)
+
+    sealed = _make_v2_envelope(
+        spec=spec,
+        worker_kp=worker_kp,
+        observer_kp=None,
+        worker_id=worker_id,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+    )
+    # Local verify before submit — defense in depth.
+    assert verify_record_v2(sealed) is True
+    expected_hash = canonical_content_hash_v2(sealed)
+
+    res = submit_v2(sealed, gateway_url=GATEWAY_URL, bearer=BEARER)
+    assert isinstance(res, SubmissionResult)
+    assert 200 <= res.status_code < 300
+    assert res.content_hash == expected_hash
+    assert isinstance(res.receipt_id, str) and len(res.receipt_id) > 0
+
+
+def test_live_v2_submit_with_observer_round_trips(
+    env_ready,
+    gateway_ready,
+    hardware_spec: HardwareSpec,
+    worker_kp: WorkerKeypair,
+    observer_kp: ObserverKeypair,
+    fleet_operator_kp,
+) -> None:
+    """Wave 2 path: observer co-sig present. The gateway should still
+    return a content_hash matching the worker's pre-image (observer
+    doesn't change the content_hash)."""
+    period_start_ms = int(time.time() * 1000) + 1_000  # +1s vs no-observer
+    period_end_ms = period_start_ms + 60_000
+    worker_id = f"{WORKER_ID_PREFIX}-obs-{period_start_ms}"
+
+    spec = _resolve_spec_for_worker(hardware_spec, fleet_operator_kp, worker_id)
+
+    sealed = _make_v2_envelope(
+        spec=spec,
+        worker_kp=worker_kp,
+        observer_kp=observer_kp,
+        worker_id=worker_id,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+    )
+    assert verify_record_v2(sealed) is True
+    expected_hash = canonical_content_hash_v2(sealed)
+
+    res = submit_v2(sealed, gateway_url=GATEWAY_URL, bearer=BEARER)
+    assert 200 <= res.status_code < 300
+    assert res.content_hash == expected_hash
+
+
+def test_live_v2_replay_rejected_by_gateway(
+    env_ready,
+    gateway_ready,
+    hardware_spec: HardwareSpec,
+    worker_kp: WorkerKeypair,
+    fleet_operator_kp,
+) -> None:
+    """Submit twice with the SAME (worker_id, period_start_ms). The SECOND
+    submit must be rejected — by the SDK's local cache OR by the gateway's
+    server-side de-dupe at the (worker_pubkey, period_start_ms) tuple."""
+    from materios_compute_meter.exceptions import ReplayRejectedError
+
+    period_start_ms = int(time.time() * 1000) + 2_000
+    period_end_ms = period_start_ms + 60_000
+    worker_id = f"{WORKER_ID_PREFIX}-replay-{period_start_ms}"
+
+    spec = _resolve_spec_for_worker(hardware_spec, fleet_operator_kp, worker_id)
+
+    sealed = _make_v2_envelope(
+        spec=spec,
+        worker_kp=worker_kp,
+        observer_kp=None,
+        worker_id=worker_id,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+    )
+    submit_v2(sealed, gateway_url=GATEWAY_URL, bearer=BEARER)
+
+    # Second submit: same record. Either the SDK's local cache rejects
+    # (preferred — saves a network round trip) OR the gateway returns 409.
+    try:
+        submit_v2(sealed, gateway_url=GATEWAY_URL, bearer=BEARER)
+    except ReplayRejectedError:
+        pass  # local cache caught it — perfect.
+    except GatewayError as e:
+        # Gateway-side de-dupe: 409 conflict is the expected status.
+        assert e.status in (409, 422), (
+            f"expected 409 (or 422) on duplicate, got {e.status}"
+        )
+    else:
+        pytest.fail(
+            "duplicate submit was accepted by both SDK and gateway — "
+            "replay protection regressed"
+        )


### PR DESCRIPTION
Wave 1+2 Team 3 of 3: extends `materios-compute-meter` Python SDK to build, sign, and submit `compute_metering_v2` envelopes with hardware-spec attestation and optional observer co-signature.

## ⚠️ canonical.py overlap with Team 1 (#26)

Team 3 extended `packages/compute-meter-sdk/src/materios_compute_meter/canonical.py` (+349 LoC for v2 helpers). Team 1's PR #26 also extends the same file (+345 LoC). Both teams independently arrived at the same approach (custom Python encoder mirroring the v1 TS encoder byte-for-byte; both resolved the `Number.isInteger(0.0) === true` JS quirk and the `cbor2(canonical=True)` float16 shortening trap).

**Merge order:** merge #26 first (sets the byte-exact canonical contract), then this PR rebases on top — the canonical.py extensions need reconciliation but the byte-pinned contract should be unchanged. I'll handle the rebase here once #26 lands.

## Files (20 files, +5689 / -13 LoC)

**New source:**
- `hardware_spec.py` (432) — `HardwareSpec` frozen dataclass, JSON load/save, fleet-operator-sig verification
- `cli.py` (298) — `submit-v2` CLI subcommand

**Extended source:**
- `canonical.py` (+349) — v2 canonical encoder (overlaps with #26)
- `record.py` (+481) — `build_record_v2`, `sign_record_v2`, `attach_observer_signature_v2`
- `submit.py` (+329) — `submit_v2` HTTP client w/ v2 error mapping
- `keypair.py` (+82) — `ObserverKeypair` subclass

**Tests (all new, 8 files):** `test_canonical_v2.py` (291), `test_hardware_spec.py` (415), `test_record_v2.py` (601), `test_observer_keypair.py` (152), `test_submit_v2_unit.py` (459), `test_cli.py` (545), `test_v2_cross_language_bytes.py` (222), `test_v2_e2e_preprod.py` (350) + `_v2_ts_encoder.mjs` (307) byte-pinning harness.

**Docs:** `README.md` (+193), `tests/E2E.md` (+67).

**Build:** `pyproject.toml` bumped `0.1.1 → 0.2.0-rc1` (in-flight v2 marker, NOT publishing yet).

## Tests

- **148 brand-new v2 tests all green:** 27 canonical_v2 + 28 hardware_spec + 44 record_v2 + 14 observer_keypair + 16 submit_v2 + 9 CLI + 10 cross-language byte-pinning
- **42 v1 tests still pass** (backward compat verified)
- **3 v2 E2E tests** (`MATERIOS_E2E_BEARER` + `MATERIOS_E2E_HARDWARE_SPEC` env-gated) skip cleanly when env unset OR when gateway is v1-only (probe via `WRONG_SCHEMA_VERSION` response)

## Cross-language byte-pinning: PASSING

Python's `canonical_cbor_v2` produces byte-identical output to the Node TS encoder (`_v2_ts_encoder.mjs`) across 3 vectors × 3 pre-images + schema hash = 10 assertions. Same gotchas that bit Team 1 — both teams independently fixed them the same way.

## AST class-body integrity

15 classes parsed cleanly. `HardwareSpec` (frozen dataclass, 13 members), `WorkerKeypair`, `ObserverKeypair(WorkerKeypair)`, all 9 exception classes. No method got declassed by indentation.

## Live preprod test result: SKIPPED with informative reason

Probe correctly detects v1-only gateway (Team 2's v2 validator hasn't shipped yet) and skips with clear pointer. After #27 merges, run with real bearer + spec; the wire format already reaches gateway.

## Self-review

- v1 functionality untouched; 42 v1 tests pass
- `pyproject.toml` bumped to `0.2.0-rc1` (not 0.2.0)
- Real sr25519 signatures (deterministic seeds, no mocked crypto)
- Real on-disk JSON for hardware_spec round-trips
- `from __future__ import annotations` for Python 3.9 compat
- No TODO/FIXME/XXX/HACK
- AST class-body check passes
- **Did NOT test:** live cert-daemon → on-chain anchor for v2 receipts (gateway v2 validator must ship first); HSM-backed fleet operator key flow (only deterministic seed-based keys exercised).

## Trace

`b8a993d0-dd50-47ac-8b2a-76195d662c1d` (finalized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)