### PR TITLE
ci(blob-gateway): drop pnpm version pin (collides with packageManager)

### DIFF
--- a/.github/workflows/blob-gateway.yml
+++ b/.github/workflows/blob-gateway.yml
@@ -28,8 +28,10 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
+        # Don't pin a `version:` here — pnpm/action-setup auto-reads
+        # `packageManager` from package.json (currently pnpm@8.14.0).
+        # Setting `version:` AND `packageManager:` errors with
+        # ERR_PNPM_BAD_PM_VERSION ("Multiple versions of pnpm specified").
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Fix the auto-build workflow added in #24 that's been failing on every Wave 1+2 merge (#26/#27/#28). Drop the `version: 9` pin; let pnpm/action-setup read from `package.json` (`pnpm@8.14.0`). Comment block explains the constraint so we don't re-add it.

After this lands, the next push to main that touches `services/blob-gateway/**` should auto-publish without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)