### PR TITLE
fix(compute-meter-sdk): drop _hex suffix from v2 wire field names

### DIFF
--- a/packages/compute-meter-sdk/pyproject.toml
+++ b/packages/compute-meter-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "materios-compute-meter"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 description = "Worker signing identity SDK for Materios verifiable compute metering (compute_metering_v1 + v2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/compute-meter-sdk/src/materios_compute_meter/submit.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/submit.py
@@ -369,13 +369,18 @@ def _v2_record_to_wire(record: Mapping[str, Any]) -> Dict[str, Any]:
     if not isinstance(worker_sig, (bytes, bytearray)) or len(worker_sig) != 64:
         raise SubmitError("worker_signature must be 64-byte bytes")
 
+    # Wire field names match the gateway-side validator's spec exactly — bare
+    # `*_pubkey` / `*_signature`, no `_hex` suffix. The bytes are still
+    # serialized as hex strings; the suffix in the field NAME was a stylistic
+    # divergence from the spec that broke gateway acceptance (gateway reads
+    # `hardware_spec.fleet_operator_pubkey`, not `..._pubkey_hex`).
     wire_hw = {
         "cpu_cores": hardware_spec["cpu_cores"],
         "ram_gb": hardware_spec["ram_gb"],
         "gpu_type": hardware_spec["gpu_type"],
         "gpu_count": hardware_spec["gpu_count"],
-        "fleet_operator_pubkey_hex": bytes(hw_pub).hex(),
-        "fleet_operator_signature_hex": bytes(hw_sig).hex(),
+        "fleet_operator_pubkey": bytes(hw_pub).hex(),
+        "fleet_operator_signature": bytes(hw_sig).hex(),
         "issued_ms": hardware_spec["issued_ms"],
     }
 
@@ -387,8 +392,8 @@ def _v2_record_to_wire(record: Mapping[str, Any]) -> Dict[str, Any]:
         "period_end_ms": record["period_end_ms"],
         "metrics": dict(record["metrics"]),
         "hardware_spec": wire_hw,
-        "worker_pubkey_hex": bytes(worker_pub).hex(),
-        "worker_signature_hex": bytes(worker_sig).hex(),
+        "worker_pubkey": bytes(worker_pub).hex(),
+        "worker_signature": bytes(worker_sig).hex(),
     }
 
     obs = record.get("observer")
@@ -402,8 +407,8 @@ def _v2_record_to_wire(record: Mapping[str, Any]) -> Dict[str, Any]:
         if not isinstance(obs_sig, (bytes, bytearray)) or len(obs_sig) != 64:
             raise SubmitError("observer.observer_signature must be 64-byte bytes")
         wire["observer"] = {
-            "observer_pubkey_hex": bytes(obs_pub).hex(),
-            "observer_signature_hex": bytes(obs_sig).hex(),
+            "observer_pubkey": bytes(obs_pub).hex(),
+            "observer_signature": bytes(obs_sig).hex(),
         }
 
     return wire

--- a/packages/compute-meter-sdk/tests/test_cli.py
+++ b/packages/compute-meter-sdk/tests/test_cli.py
@@ -145,15 +145,15 @@ def test_cli_v2_submit_happy_path_no_observer(
                 "gpu_type": body["hardware_spec"]["gpu_type"],
                 "gpu_count": body["hardware_spec"]["gpu_count"],
                 "fleet_operator_pubkey": bytes.fromhex(
-                    body["hardware_spec"]["fleet_operator_pubkey_hex"]
+                    body["hardware_spec"]["fleet_operator_pubkey"]
                 ),
                 "fleet_operator_signature": bytes.fromhex(
-                    body["hardware_spec"]["fleet_operator_signature_hex"]
+                    body["hardware_spec"]["fleet_operator_signature"]
                 ),
                 "issued_ms": body["hardware_spec"]["issued_ms"],
             },
-            "worker_pubkey": bytes.fromhex(body["worker_pubkey_hex"]),
-            "worker_signature": bytes.fromhex(body["worker_signature_hex"]),
+            "worker_pubkey": bytes.fromhex(body["worker_pubkey"]),
+            "worker_signature": bytes.fromhex(body["worker_signature"]),
         }
         ch = canonical_content_hash_v2(rec)
         return httpx.Response(
@@ -234,15 +234,15 @@ def test_cli_v2_submit_with_observer_attaches_block(
                 "gpu_type": body["hardware_spec"]["gpu_type"],
                 "gpu_count": body["hardware_spec"]["gpu_count"],
                 "fleet_operator_pubkey": bytes.fromhex(
-                    body["hardware_spec"]["fleet_operator_pubkey_hex"]
+                    body["hardware_spec"]["fleet_operator_pubkey"]
                 ),
                 "fleet_operator_signature": bytes.fromhex(
-                    body["hardware_spec"]["fleet_operator_signature_hex"]
+                    body["hardware_spec"]["fleet_operator_signature"]
                 ),
                 "issued_ms": body["hardware_spec"]["issued_ms"],
             },
-            "worker_pubkey": bytes.fromhex(body["worker_pubkey_hex"]),
-            "worker_signature": bytes.fromhex(body["worker_signature_hex"]),
+            "worker_pubkey": bytes.fromhex(body["worker_pubkey"]),
+            "worker_signature": bytes.fromhex(body["worker_signature"]),
         }
         # Observer doesn't change worker pre-image.
         ch = canonical_content_hash_v2(rec)
@@ -285,8 +285,8 @@ def test_cli_v2_submit_with_observer_attaches_block(
     assert rc == 0
     body = captured["body"]
     assert "observer" in body
-    assert "observer_pubkey_hex" in body["observer"]
-    assert "observer_signature_hex" in body["observer"]
+    assert "observer_pubkey" in body["observer"]
+    assert "observer_signature" in body["observer"]
 
     out = capsys.readouterr().out
     parsed = json.loads(out)
@@ -370,15 +370,15 @@ def test_cli_v2_skip_spec_verify_bypasses_check(
                 "gpu_type": body["hardware_spec"]["gpu_type"],
                 "gpu_count": body["hardware_spec"]["gpu_count"],
                 "fleet_operator_pubkey": bytes.fromhex(
-                    body["hardware_spec"]["fleet_operator_pubkey_hex"]
+                    body["hardware_spec"]["fleet_operator_pubkey"]
                 ),
                 "fleet_operator_signature": bytes.fromhex(
-                    body["hardware_spec"]["fleet_operator_signature_hex"]
+                    body["hardware_spec"]["fleet_operator_signature"]
                 ),
                 "issued_ms": body["hardware_spec"]["issued_ms"],
             },
-            "worker_pubkey": bytes.fromhex(body["worker_pubkey_hex"]),
-            "worker_signature": bytes.fromhex(body["worker_signature_hex"]),
+            "worker_pubkey": bytes.fromhex(body["worker_pubkey"]),
+            "worker_signature": bytes.fromhex(body["worker_signature"]),
         }
         ch = canonical_content_hash_v2(rec)
         return httpx.Response(

--- a/packages/compute-meter-sdk/tests/test_submit_v2_unit.py
+++ b/packages/compute-meter-sdk/tests/test_submit_v2_unit.py
@@ -147,12 +147,12 @@ def test_submit_v2_happy_path_posts_correct_wire_format() -> None:
     assert body["metrics"]["cpu_seconds"] == 60
     assert body["hardware_spec"]["cpu_cores"] == 8
     # Bytes are hex-on-the-wire.
-    assert isinstance(body["worker_pubkey_hex"], str)
-    assert len(body["worker_pubkey_hex"]) == 64
-    assert isinstance(body["worker_signature_hex"], str)
-    assert len(body["worker_signature_hex"]) == 128
-    assert len(body["hardware_spec"]["fleet_operator_pubkey_hex"]) == 64
-    assert len(body["hardware_spec"]["fleet_operator_signature_hex"]) == 128
+    assert isinstance(body["worker_pubkey"], str)
+    assert len(body["worker_pubkey"]) == 64
+    assert isinstance(body["worker_signature"], str)
+    assert len(body["worker_signature"]) == 128
+    assert len(body["hardware_spec"]["fleet_operator_pubkey"]) == 64
+    assert len(body["hardware_spec"]["fleet_operator_signature"]) == 128
     # No observer block in this run.
     assert "observer" not in body
 
@@ -182,8 +182,8 @@ def test_submit_v2_with_observer_block_posts_observer_in_body() -> None:
     )
     body = captured["body"]
     assert "observer" in body
-    assert len(body["observer"]["observer_pubkey_hex"]) == 64
-    assert len(body["observer"]["observer_signature_hex"]) == 128
+    assert len(body["observer"]["observer_pubkey"]) == 64
+    assert len(body["observer"]["observer_signature"]) == 128
 
 
 def test_submit_v2_accepts_api_key_alias_for_bearer() -> None:


### PR DESCRIPTION
Caught at first cross-org E2E with Hetzner Compute Portal: SDK 0.2.0-rc1 sent `fleet_operator_pubkey_hex`, gateway expects bare `fleet_operator_pubkey` per spec. Fix matches wire to spec.

```
HTTP 400 MISSING_FIELD: hardware_spec.fleet_operator_pubkey is required
```

- Drop `_hex` suffix from 6 wire fields in `_v2_record_to_wire()`
- Update 5 test assertions in test_submit_v2_unit.py + test_cli.py
- On-disk JSON format unchanged (`HardwareSpec.load` still reads `_hex` suffix — separate concern)
- Version bump 0.2.0-rc1 → 0.2.0-rc2

193/204 tests pass (11 skips are E2E + integration gates as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)