### PR TITLE
fix(blob-gateway): metering_v2 notify must include rootHash

### DIFF
--- a/services/blob-gateway/src/__tests__/metering_v2_route.test.ts
+++ b/services/blob-gateway/src/__tests__/metering_v2_route.test.ts
@@ -389,6 +389,25 @@ describe("POST /metering/submit v2 — happy path", () => {
     expect(body.contentHash).toBe((res.body as { content_hash: string }).content_hash);
   });
 
+  // Regression: chain-of-custody break shipped in Wave 1+2. The submitter
+  // refuses to sign on-chain (503 unverifiable) when its manifest fetch
+  // fails AND the notification body has no rootHash. The v2 manifest is
+  // self-rooted (chunks=[], rootHash=content_hash), so the route MUST pass
+  // rootHash explicitly — same contract the blob path already honours.
+  test("submitter_notified_with_v2_rootHash_for_self_rooted_manifest", async () => {
+    const rec = buildV2({ worker_id: "worker-roothash-test" });
+    const res = await postJson(ctx.app, "/metering/submit", rec);
+    expect(res.status).toBe(200);
+    await waitFor(() => ctx.fake.captured.length === 1, {
+      deadlineMs: 2000,
+      what: "submitter notify",
+    });
+    const captured = ctx.fake.captured[0]!;
+    const body = JSON.parse(captured.body) as Record<string, unknown>;
+    const contentHash = (res.body as { content_hash: string }).content_hash;
+    expect(body.rootHash).toBe(contentHash);
+  });
+
   test("valid_v2_record_with_observer_returns_200_observer_present_true", async () => {
     const rec = buildV2({
       worker_id: "worker-observer-test",

--- a/services/blob-gateway/src/routes/metering_v2.ts
+++ b/services/blob-gateway/src/routes/metering_v2.ts
@@ -394,12 +394,18 @@ export async function handleV2Submit(
     submitted_at_ms: nowMs,
   });
 
+  // The v2 manifest is self-rooted (chunks=[], rootHash=content_hash). The
+  // submitter's safety check refuses to sign on-chain (503 unverifiable)
+  // when its manifest fetch fails AND the notification has no rootHash, so
+  // we MUST surface the root explicitly here — same contract the blob path
+  // already honours (services/blob-gateway/src/routes/blobs.ts).
   void notifySponsoredReceiptSubmitter({
     contentHash: content_hash,
     operator: operatorSs58,
     authTier: "bearer",
     schemaHash: schema_hash,
     source: METERING_V2_SOURCE,
+    rootHash: content_hash,
   });
 
   res.status(200).json({


### PR DESCRIPTION
## Summary

The v2 manifest is self-rooted (`chunks: [], rootHash: content_hash`). The
sponsored-receipt-submitter's safety check (post-task #60) refuses to sign
on-chain (503 unverifiable) when its manifest fetch fails AND the
notification body has no rootHash. The blob path already passes rootHash;
the metering_v2 path didn't.

Without this, every `compute_metering_v2` record was stranded in the
gateway's local sqlite — never landed on Materios chain, never certified,
never anchored to Cardano. Submitter logs show **87 records** affected
since v2 went live, including the cross-org E2E with Hetzner-Claude.

## Test plan

- [x] New regression: `submitter_notified_with_v2_rootHash_for_self_rooted_manifest`
  asserts `body.rootHash === content_hash` on the captured notification.
- [x] Full gateway suite: 330 passed, 2 skipped (no other tests broke).
- [x] Built docker image `b70a6905b5ea824cbad3af7f001c514a486950c4` and
  deployed to local preprod gateway.
- [x] Live smoke: fresh fleet-op + worker, submitted one v2 record. Submitter
  logged `200 submitted ... tx=0x60a84e34... block=88287 receipt_id=0x130d8766...`
  Receipt now lands on chain. Pre-fix: `503 unverifiable + no caller-provided rootHash`.

## Follow-ups (filed separately)

1. **cert-daemon doesn't handle self-rooted manifests** — its blob_verifier
   computes Merkle over zero chunks → sentinel zero mismatch → REJECTED.
   Compute_metering records will land on chain but never get attested
   without a v2-aware path in cert-daemon.
2. **Submitter manifest fetch returns 401**; submitter falls back to
   "synthesised placeholder hash". This causes a *gateway-vs-submitter*
   receipt_id divergence — the billing API can't resolve attestation
   status because it queries the wrong receipt_id. Auth fix unblocks both
   the synth-fallback and (1) above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)