### PR TITLE
feat(blob-gateway): compute_metering_v2.1 schema + attestation_evidence endpoint (Wave 3 Phase 2)

### DIFF
--- a/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
@@ -612,14 +612,27 @@ def _v2_evidence_entry_to_cbor(entry: dict):
 
 
 def _v2_evidence_array_to_cbor(entries):
-    """Convert a list of evidence-entry dicts into a CBOR array (sorted)."""
+    """Convert a list of evidence-entry dicts into a CBOR array (sorted).
+
+    Sort key (PR #34 M-2): (EVIDENCE_TYPE_DISCRIMINANT, attestor_pubkey_hex).
+    The pubkey is a metadata-only field — it's the canonical tiebreaker for
+    same-discriminant entries (matching the JS-side
+    `listReceiptEvidence` ORDER BY). When `attestor_pubkey` is absent (the
+    worker-side SDK case where evidence is single-source), it defaults to ""
+    so existing single-source vectors are byte-stable. Both sides use byte-lex
+    comparison on lowercase hex; Python's `sorted` is stable so the tuple key
+    pins the order regardless of insertion order.
+    """
     if not isinstance(entries, (list, tuple)):
         raise TypeError(
             f"attestation_evidence must be a list, got {type(entries).__name__}"
         )
     sorted_entries = sorted(
         entries,
-        key=lambda e: EVIDENCE_TYPE_DISCRIMINANT[e["evidence_type"]],
+        key=lambda e: (
+            EVIDENCE_TYPE_DISCRIMINANT[e["evidence_type"]],
+            e.get("attestor_pubkey", ""),
+        ),
     )
     return _v2_cbor_array(
         [_v2_evidence_entry_to_cbor(e) for e in sorted_entries]

--- a/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
+++ b/packages/compute-meter-sdk/src/materios_compute_meter/canonical.py
@@ -122,6 +122,24 @@ SCHEMA_VERSION_V2 = "compute_metering_v2"
 SCHEMA_HASH_V2_HEX = hashlib.sha256(SCHEMA_VERSION_V2.encode("utf-8")).hexdigest()
 FLEET_OP_TAG_V2 = "fleet_op_attestation_v1"
 
+# --- Wave 3 Phase 2: compute_metering_v2.1 attestation evidence ---
+
+SCHEMA_VERSION_V2_1 = "compute_metering_v2.1"
+SCHEMA_HASH_V2_1_HEX = hashlib.sha256(
+    SCHEMA_VERSION_V2_1.encode("utf-8")
+).hexdigest()
+
+# Discriminant order — PINNED across TS + Python + the parallel pallet enum.
+# Adding a new variant is a non-breaking change ONLY at the tail.
+EVIDENCE_TYPES = (
+    "amd_sev_snp",         # 0
+    "intel_tdx",           # 1
+    "arm_trustzone",       # 2
+    "reproducible_build",  # 3
+    "zkvm_execution",      # 4
+)
+EVIDENCE_TYPE_DISCRIMINANT = {t: i for i, t in enumerate(EVIDENCE_TYPES)}
+
 
 # --- Tagged value types for the canonical encoder ---
 
@@ -386,11 +404,24 @@ def canonical_cbor_for_fleet_op_sig(record: dict) -> bytes:
     )
 
 
-def canonical_cbor_for_worker_sig(record: dict) -> bytes:
+def canonical_cbor_for_worker_sig(
+    record: dict,
+    attestation_evidence=None,
+) -> bytes:
     """Build canonical CBOR bytes for the worker-signature pre-image.
 
+    v2 (default — no `attestation_evidence`):
         [ "compute_metering_v2", worker_id, tenant_id, period_start_ms,
           period_end_ms, metrics, hardware_spec_full, worker_pubkey_bytes ]
+
+    v2.1 (when `attestation_evidence` is non-empty):
+        [ "compute_metering_v2.1", worker_id, tenant_id, period_start_ms,
+          period_end_ms, metrics, hardware_spec_full, worker_pubkey_bytes,
+          attestation_evidence_array ]   # 9th element, sorted by EvidenceType
+
+    Backwards compat: when `attestation_evidence` is omitted, None, or an
+    empty list, the schema literal stays `compute_metering_v2` and the bytes
+    are byte-identical to today's v2 — full backwards compatibility (PINNED).
 
     The observer signature, when present, signs THESE EXACT BYTES under the
     observer pubkey — never re-encode for the observer.
@@ -398,10 +429,20 @@ def canonical_cbor_for_worker_sig(record: dict) -> bytes:
     Args:
         record: A dict with all required v2 fields. `worker_signature` is
             ignored; `observer` is ignored. `worker_pubkey` is hex64.
+        attestation_evidence: Optional list of evidence-entry dicts, each
+            with shape {"evidence_type": str, "nonce": hex64,
+            "payload": dict}. Sorted by EvidenceType discriminant before
+            encoding. Backwards-compatible default is None.
 
     Returns:
         Canonical CBOR-encoded bytes, deterministic per RFC 8949 §4.2.1.
     """
+    # Allow the caller to pass evidence inline as `record["attestation_evidence"]`
+    # (matches the wire JSON shape) — that overload exists so the worker SDK
+    # doesn't have to split fields across two args.
+    if attestation_evidence is None:
+        attestation_evidence = record.get("attestation_evidence")
+    has_evidence = bool(attestation_evidence)
     required = (
         "worker_id",
         "tenant_id",
@@ -414,20 +455,20 @@ def canonical_cbor_for_worker_sig(record: dict) -> bytes:
     for k in required:
         if k not in record:
             raise KeyError(f"canonical_cbor_for_worker_sig: missing '{k}'")
-    return _v2_encode_cbor(
-        _v2_cbor_array(
-            [
-                _v2_cbor_text(SCHEMA_VERSION_V2),
-                _v2_cbor_text(record["worker_id"]),
-                _v2_cbor_text(record["tenant_id"]),
-                _v2_cbor_int(record["period_start_ms"]),
-                _v2_cbor_int(record["period_end_ms"]),
-                _v2_metrics_to_cbor(record["metrics"]),
-                _v2_hardware_spec_full_to_cbor(record["hardware_spec"]),
-                _v2_cbor_bytes(_v2_hex_to_bytes(record["worker_pubkey"])),
-            ]
-        )
-    )
+
+    elements = [
+        _v2_cbor_text(SCHEMA_VERSION_V2_1 if has_evidence else SCHEMA_VERSION_V2),
+        _v2_cbor_text(record["worker_id"]),
+        _v2_cbor_text(record["tenant_id"]),
+        _v2_cbor_int(record["period_start_ms"]),
+        _v2_cbor_int(record["period_end_ms"]),
+        _v2_metrics_to_cbor(record["metrics"]),
+        _v2_hardware_spec_full_to_cbor(record["hardware_spec"]),
+        _v2_cbor_bytes(_v2_hex_to_bytes(record["worker_pubkey"])),
+    ]
+    if has_evidence:
+        elements.append(_v2_evidence_array_to_cbor(attestation_evidence))
+    return _v2_encode_cbor(_v2_cbor_array(elements))
 
 
 # Observer signs the EXACT SAME bytes as the worker (per the v2 spec — observer
@@ -437,8 +478,197 @@ def canonical_cbor_for_worker_sig(record: dict) -> bytes:
 canonical_cbor_for_observer_sig = canonical_cbor_for_worker_sig
 
 
-def canonical_content_hash_v2(record: dict) -> str:
+def canonical_content_hash_v2(record: dict, attestation_evidence=None) -> str:
     """SHA-256 hex of the worker-signature pre-image. The upstream
-    `content_hash` for the v2 sponsored-receipt anchor.
+    `content_hash` for the v2 / v2.1 sponsored-receipt anchor.
+
+    `attestation_evidence` is an optional list — when present and non-empty,
+    the v2.1 pre-image is used (extended by one CBOR array element). When
+    None or empty, the v2 pre-image is used (byte-identical to today's v2).
     """
-    return hashlib.sha256(canonical_cbor_for_worker_sig(record)).hexdigest()
+    return hashlib.sha256(
+        canonical_cbor_for_worker_sig(record, attestation_evidence)
+    ).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Wave 3 Phase 2 — attestation_evidence canonical CBOR
+#
+# The mirror of the TS-side `evidenceArrayToCborValue` /
+# `attestationEvidenceHash` / `deriveEvidenceNonce` / `*_b64` payload encoder.
+# Pattern documented in services/blob-gateway/src/schemas/compute_metering_v2.ts.
+# Cross-language byte equality is enforced by the
+# `tests/test_v2_1_cross_lang.py` harness.
+# ---------------------------------------------------------------------------
+
+import re
+
+_HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+_BASE64_RE = re.compile(r"^[A-Za-z0-9+/]*={0,2}$")
+
+
+def _v2_decode_b64_strict(s: str) -> bytes:
+    """Strict RFC 4648 §4 base64 decoder.
+
+    `s` must use the standard alphabet (no URL-safe variant) with padding.
+    Mirrors the TS `decodeBase64Strict` rule: regex pre-check then standard
+    base64 decode. Throws `TypeError` (not `ValueError`) so that bad-payload
+    errors are uniform with the rest of the encoder's surface.
+    """
+    import base64
+
+    if not isinstance(s, str) or not _BASE64_RE.match(s):
+        raise TypeError(
+            f"evidence payload: value of *_b64 key must be RFC 4648 base64, "
+            f'got "{s[:32] if isinstance(s, str) else type(s).__name__}..."'
+        )
+    return base64.b64decode(s, validate=True)
+
+
+def _v2_payload_value_to_cbor(value, key_context=None):
+    """Recursively convert a JSON-shaped Python value to a tagged CBOR value.
+
+    The rules MUST match the TS `payloadJsonToCborValue` exactly:
+
+      * dict        -> CBOR map (sorted on encode)
+      * list/tuple  -> CBOR array
+      * str         -> CBOR text  (default), OR
+      * str under a key ending in `_b64` -> CBOR bytes (decoded base64)
+      * int (not bool) -> CBOR int
+      * float       -> CBOR float64 (8 bytes, never shortened)
+      * bool        -> REJECTED (Python's `True is 1` quirk)
+      * None        -> REJECTED
+    """
+    if value is None:
+        raise TypeError("evidence payload: None is not permitted")
+    if isinstance(value, bool):
+        raise TypeError("evidence payload: bool is not permitted")
+    if isinstance(value, int):
+        return _v2_cbor_int(value)
+    if isinstance(value, float):
+        if value != value:  # NaN
+            raise TypeError("evidence payload: NaN not permitted")
+        if value in (float("inf"), float("-inf")):
+            raise TypeError("evidence payload: Infinity not permitted")
+        return _v2_cbor_float(value)
+    if isinstance(value, str):
+        if isinstance(key_context, str) and key_context.endswith("_b64"):
+            return _v2_cbor_bytes(_v2_decode_b64_strict(value))
+        return _v2_cbor_text(value)
+    if isinstance(value, (list, tuple)):
+        # No key context for array elements (the `_b64` rule binds to the
+        # immediate parent dict key).
+        return _v2_cbor_array([_v2_payload_value_to_cbor(v, None) for v in value])
+    if isinstance(value, dict):
+        pairs = []
+        for k in value.keys():
+            if not isinstance(k, str):
+                raise TypeError(
+                    f"evidence payload: map keys must be str, got {type(k).__name__}"
+                )
+            pairs.append((k, _v2_payload_value_to_cbor(value[k], k)))
+        return _v2_cbor_map(pairs)
+    raise TypeError(
+        f"evidence payload: unsupported value type {type(value).__name__} "
+        "(must be str/int/float/list/dict)"
+    )
+
+
+def _v2_evidence_entry_to_cbor(entry: dict):
+    """Build the canonical-CBOR-tagged form of one evidence entry.
+
+    Entry shape (wire JSON):
+        {"evidence_type": str, "nonce": hex64, "payload": dict}
+
+    Encodes to a CBOR map with three keys: evidence_type (text), nonce
+    (32 bytes), payload (canonical-CBOR sub-map). Map keys are sorted on
+    encode, matching the v2 metrics-map sort.
+    """
+    if not isinstance(entry, dict):
+        raise TypeError(
+            f"evidence entry: must be a dict, got {type(entry).__name__}"
+        )
+    et = entry.get("evidence_type")
+    if et not in EVIDENCE_TYPES:
+        raise TypeError(
+            f'evidence entry: unknown evidence_type "{et}" '
+            f"(allowed: {EVIDENCE_TYPES})"
+        )
+    nonce = entry.get("nonce")
+    if not isinstance(nonce, str) or not _HEX64_RE.match(nonce):
+        raise TypeError(
+            f"evidence entry: nonce must be 64-char lowercase hex, got '{nonce}'"
+        )
+    payload = entry.get("payload")
+    if not isinstance(payload, dict):
+        raise TypeError("evidence entry: payload must be a JSON object (dict)")
+    return _v2_cbor_map(
+        [
+            ("evidence_type", _v2_cbor_text(et)),
+            ("nonce", _v2_cbor_bytes(bytes.fromhex(nonce))),
+            ("payload", _v2_payload_value_to_cbor(payload)),
+        ]
+    )
+
+
+def _v2_evidence_array_to_cbor(entries):
+    """Convert a list of evidence-entry dicts into a CBOR array (sorted)."""
+    if not isinstance(entries, (list, tuple)):
+        raise TypeError(
+            f"attestation_evidence must be a list, got {type(entries).__name__}"
+        )
+    sorted_entries = sorted(
+        entries,
+        key=lambda e: EVIDENCE_TYPE_DISCRIMINANT[e["evidence_type"]],
+    )
+    return _v2_cbor_array(
+        [_v2_evidence_entry_to_cbor(e) for e in sorted_entries]
+    )
+
+
+def derive_evidence_nonce(content_hash_hex: str, evidence_type: str) -> str:
+    """Compute nonce = sha256(content_hash_bytes || utf8(evidence_type)).
+
+    Mirrors the TS `deriveEvidenceNonce`. Returns 64-char lowercase hex.
+    """
+    cleaned = (
+        content_hash_hex[2:]
+        if content_hash_hex.startswith("0x")
+        else content_hash_hex
+    )
+    if not _HEX64_RE.match(cleaned):
+        raise TypeError(
+            f"derive_evidence_nonce: content_hash must be 32 bytes "
+            f"(64 hex chars), got '{content_hash_hex}'"
+        )
+    if evidence_type not in EVIDENCE_TYPES:
+        raise TypeError(
+            f"derive_evidence_nonce: unknown evidence_type '{evidence_type}'"
+        )
+    h = hashlib.sha256()
+    h.update(bytes.fromhex(cleaned))
+    h.update(evidence_type.encode("utf-8"))
+    return h.hexdigest()
+
+
+def attestation_evidence_hash(entries) -> str:
+    """SHA-256 hex of the canonical-CBOR encoding of an evidence array.
+
+    Empty-vec case: hash of CBOR-empty-array (single byte 0x80) — NOT zeros.
+    The empty-vec value is pinned in tests:
+        `76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71`
+    """
+    cbor_bytes = _v2_encode_cbor(_v2_evidence_array_to_cbor(entries))
+    return hashlib.sha256(cbor_bytes).hexdigest()
+
+
+def canonical_cbor_for_evidence_payload(payload: dict) -> bytes:
+    """Convenience: canonical CBOR bytes for a single evidence payload dict.
+
+    Used by the gateway route for verifying the attestor's signature: the
+    attestor signs canonical CBOR of the payload (NOT the full record), so
+    SDK consumers and gateway verify against the same bytes.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError("payload must be a dict")
+    return _v2_encode_cbor(_v2_payload_value_to_cbor(payload))

--- a/packages/compute-meter-sdk/tests/_v2_1_ts_encoder.mts
+++ b/packages/compute-meter-sdk/tests/_v2_1_ts_encoder.mts
@@ -1,0 +1,71 @@
+/**
+ * Cross-language byte-pinning harness for compute_metering_v2.1.
+ *
+ * Reads JSON `{record, evidence}` from stdin, prints (one line each):
+ *   WORKER_PRE_HEX <hex>      — canonical-CBOR bytes of the worker pre-image
+ *   CONTENT_HASH <hex>        — sha256 of WORKER_PRE_HEX
+ *   EV_HASH <hex>             — sha256 of canonical-CBOR(evidence array)
+ *   SCHEMA_HASH_V2_1 <hex>    — pinned constant
+ *
+ * The Python tests in `test_v2_1_cross_lang.py` invoke this script via tsx
+ * and assert byte-equality vs the Python encoder. Same harness shape as
+ * `_v2_ts_encoder.mts`, extended to take an `evidence` array.
+ */
+
+import {
+  canonicalCborForWorkerSig,
+  attestationEvidenceHash,
+  SCHEMA_HASH_V2_1_HEX,
+  type AttestationEvidenceEntry,
+} from "../../../services/blob-gateway/src/schemas/compute_metering_v2.ts";
+import { createHash } from "crypto";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+interface Input {
+  record: {
+    schema_version: string;
+    worker_id: string;
+    tenant_id: string;
+    period_start_ms: number;
+    period_end_ms: number;
+    metrics: Record<string, number>;
+    hardware_spec: Record<string, unknown>;
+    worker_pubkey: string;
+  };
+  evidence?: AttestationEvidenceEntry[];
+}
+
+async function main(): Promise<void> {
+  const raw = await readStdin();
+  const input = JSON.parse(raw) as Input;
+  const recForSig = {
+    schema_version: "compute_metering_v2" as const,
+    worker_id: input.record.worker_id,
+    tenant_id: input.record.tenant_id,
+    period_start_ms: input.record.period_start_ms,
+    period_end_ms: input.record.period_end_ms,
+    metrics: input.record.metrics as never,
+    hardware_spec: input.record.hardware_spec as never,
+    worker_pubkey: input.record.worker_pubkey,
+  };
+  const evidence = input.evidence ?? [];
+  const workerPre = canonicalCborForWorkerSig(recForSig, evidence);
+  const contentHash = createHash("sha256")
+    .update(workerPre)
+    .digest("hex");
+  const evHash = attestationEvidenceHash(evidence);
+  process.stdout.write(`WORKER_PRE_HEX ${Buffer.from(workerPre).toString("hex")}\n`);
+  process.stdout.write(`CONTENT_HASH ${contentHash}\n`);
+  process.stdout.write(`EV_HASH ${evHash}\n`);
+  process.stdout.write(`SCHEMA_HASH_V2_1 ${SCHEMA_HASH_V2_1_HEX}\n`);
+}
+
+main().catch((e) => {
+  process.stderr.write(`harness error: ${e instanceof Error ? e.stack : String(e)}\n`);
+  process.exit(1);
+});

--- a/packages/compute-meter-sdk/tests/test_v2_1_cross_lang.py
+++ b/packages/compute-meter-sdk/tests/test_v2_1_cross_lang.py
@@ -1,0 +1,374 @@
+"""Cross-language byte-pinning tests for compute_metering_v2.1.
+
+Same harness pattern as `test_v2_cross_lang.py`: each fixed vector is
+encoded by the Python encoder AND by the TS encoder (via tsx subprocess),
+and the resulting bytes are asserted byte-identical.
+
+Three sets of cases:
+
+  1. Pure-v2 backwards compat — empty/absent attestation_evidence MUST
+     produce v2-identical bytes (no schema flip).
+  2. v2.1 vectors V21_2 / V21_3 / V21_4 — single + two + four entries.
+     Each pinned spec hash is captured below; if either encoder drifts the
+     test catches it on first PR.
+  3. Empty-evidence-vec hash sanity (sha256 of CBOR `0x80`).
+
+Skips gracefully if `tsx` is not on PATH.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from materios_compute_meter.canonical import (  # noqa: E402
+    EVIDENCE_TYPE_DISCRIMINANT,
+    EVIDENCE_TYPES,
+    SCHEMA_HASH_V2_1_HEX,
+    SCHEMA_VERSION_V2_1,
+    attestation_evidence_hash,
+    canonical_cbor_for_worker_sig,
+    canonical_content_hash_v2,
+    derive_evidence_nonce,
+)
+
+
+HARNESS_PATH = Path(__file__).resolve().parent / "_v2_1_ts_encoder.mts"
+WORKTREE_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _have_tsx() -> bool:
+    return shutil.which("tsx") is not None or shutil.which("npx") is not None
+
+
+def _run_ts_harness(record: Dict, evidence) -> Dict[str, str]:
+    """Invoke the TS encoder harness with the record + evidence as JSON.
+
+    Returns a dict with keys WORKER_PRE_HEX, CONTENT_HASH, EV_HASH,
+    SCHEMA_HASH_V2_1.
+    """
+    if not _have_tsx():
+        pytest.skip("tsx/npx not available — install node deps to run cross-lang tests")
+    cmd: List[str]
+    if shutil.which("tsx") is not None:
+        cmd = ["tsx", str(HARNESS_PATH)]
+    else:
+        cmd = ["npx", "--no-install", "tsx", str(HARNESS_PATH)]
+
+    payload = {"record": record, "evidence": evidence}
+    proc = subprocess.run(
+        cmd,
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=str(WORKTREE_ROOT),
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"TS harness failed (exit {proc.returncode}):\n"
+            f"stderr:\n{proc.stderr}\n"
+            f"stdout:\n{proc.stdout}\n"
+        )
+    out: Dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        head, _, rest = line.partition(" ")
+        out[head.strip()] = rest.strip()
+    for required in (
+        "WORKER_PRE_HEX",
+        "CONTENT_HASH",
+        "EV_HASH",
+        "SCHEMA_HASH_V2_1",
+    ):
+        if required not in out:
+            raise AssertionError(
+                f"TS harness output missing {required}:\n{proc.stdout}"
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Fixed test vectors. Pubkeys/sigs are deterministic synthetic bytes so the
+# encoder output is reproducible across runs.
+# ---------------------------------------------------------------------------
+
+PUBKEY_FLEET = "11" * 32
+SIG_FLEET = "22" * 64
+PUBKEY_WORKER = "33" * 32
+
+BASE_RECORD = {
+    "schema_version": "compute_metering_v2",
+    "worker_id": "wkr-001",
+    "tenant_id": "tenant-acme",
+    "period_start_ms": 1_735_689_600_000,
+    "period_end_ms": 1_735_689_600_000 + 1_000,
+    "metrics": {
+        "cpu_seconds": 1.5,
+        "ram_gb_hours": 0.0,
+        "disk_gb_hours": 0.0,
+        "net_bytes_in": 0,
+        "net_bytes_out": 0,
+        "gpu_seconds": 0.0,
+    },
+    "hardware_spec": {
+        "cpu_cores": 4,
+        "ram_gb": 16,
+        "gpu_type": "none",
+        "gpu_count": 0,
+        "fleet_operator_pubkey": PUBKEY_FLEET,
+        "fleet_operator_signature": SIG_FLEET,
+        "issued_ms": 1_735_689_600_000,
+    },
+    "worker_pubkey": PUBKEY_WORKER,
+}
+
+# Pinned content_hash of the BASE_RECORD when no evidence is present. This
+# is the input to all evidence-nonce derivations below — change here will
+# cascade into every vector hash.
+BASE_V2_CONTENT_HASH = (
+    "14fe18164cca4778b0166b00d06845547ead5ab99a31a1edd30f7c78f8defc0e"
+)
+
+
+def _vector_v21_1():
+    """Pure backwards-compat: explicit empty evidence == v2 content_hash."""
+    return BASE_RECORD, []
+
+
+def _vector_v21_2():
+    """Single ArmTrustZone evidence entry."""
+    payload = {
+        "device_model": "Pixel-8",
+        "security_level": "TrustedEnvironment",
+        "key_attestation_chain_b64": "AAECAw==",
+        "processor_pubkey_b64": "AAECAwQFBgc=",
+    }
+    evidence = [
+        {
+            "evidence_type": "arm_trustzone",
+            "nonce": derive_evidence_nonce(BASE_V2_CONTENT_HASH, "arm_trustzone"),
+            "payload": payload,
+        }
+    ]
+    return BASE_RECORD, evidence
+
+
+def _vector_v21_3():
+    """Two entries (ArmTrustZone + ReproducibleBuild). Tests sort path."""
+    evidence = [
+        # Insert in reverse discriminant order.
+        {
+            "evidence_type": "reproducible_build",
+            "nonce": derive_evidence_nonce(BASE_V2_CONTENT_HASH, "reproducible_build"),
+            "payload": {"nar_hash_b64": "AAECAw=="},
+        },
+        {
+            "evidence_type": "arm_trustzone",
+            "nonce": derive_evidence_nonce(BASE_V2_CONTENT_HASH, "arm_trustzone"),
+            "payload": {"device_model": "Pixel-8"},
+        },
+    ]
+    return BASE_RECORD, evidence
+
+
+def _vector_v21_4():
+    """Four entries: full silicon-vendor + reproducible-build coverage."""
+    evidence = [
+        {
+            "evidence_type": "reproducible_build",
+            "nonce": derive_evidence_nonce(BASE_V2_CONTENT_HASH, "reproducible_build"),
+            "payload": {
+                "nar_hash_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+                "builder_count": 3,
+            },
+        },
+        {
+            "evidence_type": "arm_trustzone",
+            "nonce": derive_evidence_nonce(BASE_V2_CONTENT_HASH, "arm_trustzone"),
+            "payload": {
+                "device_model": "Pixel-8",
+                "security_level": "TrustedEnvironment",
+                "key_attestation_chain_b64": "AAECAw==",
+            },
+        },
+        {
+            "evidence_type": "intel_tdx",
+            "nonce": derive_evidence_nonce(BASE_V2_CONTENT_HASH, "intel_tdx"),
+            "payload": {"quote_b64": "AAECAwQFBgc=", "qe_id": "abcd1234"},
+        },
+        {
+            "evidence_type": "amd_sev_snp",
+            "nonce": derive_evidence_nonce(BASE_V2_CONTENT_HASH, "amd_sev_snp"),
+            "payload": {"report_b64": "AAECAwQFBgc=", "tcb_version": 42},
+        },
+    ]
+    return BASE_RECORD, evidence
+
+
+ALL_VECTORS = [
+    ("V21_1_empty_evidence", _vector_v21_1),
+    ("V21_2_single_arm", _vector_v21_2),
+    ("V21_3_two_arm_build", _vector_v21_3),
+    ("V21_4_four_full", _vector_v21_4),
+]
+
+
+# ---------------------------------------------------------------------------
+# Pinned spec hashes — once these land in main, they're the canonical test
+# vectors that downstream consumers depend on.
+# ---------------------------------------------------------------------------
+
+EMPTY_EVIDENCE_HASH = (
+    "76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71"
+)
+
+PINNED_CONTENT_HASHES = {
+    # Backwards compat — empty evidence MUST give the v2 content_hash.
+    "V21_1_empty_evidence": BASE_V2_CONTENT_HASH,
+    "V21_2_single_arm":
+        "761cd5a2c7006d6a06e1b94cd7a349d9215478126b227015d75a06858266c83f",
+    "V21_3_two_arm_build":
+        "1890fd91981068b92579c0405dae1e251fe147e87d7cee3594bb85b316702839",
+    "V21_4_four_full":
+        "f9c99103679a0108bb44af49bfdfc262b7549777dc91203232c51153e586f9f2",
+}
+
+PINNED_EV_HASHES = {
+    "V21_1_empty_evidence": EMPTY_EVIDENCE_HASH,
+    "V21_2_single_arm":
+        "a1417cb2bc2193258b54fa482f7a5859a1800b63e27cd2c11762e154d30ad30c",
+    "V21_3_two_arm_build":
+        "5730e81c668fec41c1bf72513fa75d099476ae0c3f134f946746d6e2af92599f",
+    "V21_4_four_full":
+        "4cd2e759dcb82d7d6821d39439c3136ec17de216a35fce6e4e2a34eaa5a2aa93",
+}
+
+
+# ===========================================================================
+# Python self-tests — verify the Python encoder hits the pinned vectors.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("name,builder", ALL_VECTORS)
+def test_python_content_hash_pinned(name, builder):
+    record, evidence = builder()
+    actual = canonical_content_hash_v2(record, evidence)
+    assert actual == PINNED_CONTENT_HASHES[name], (
+        f"[{name}] content_hash drift: expected {PINNED_CONTENT_HASHES[name]}, "
+        f"got {actual}"
+    )
+
+
+@pytest.mark.parametrize("name,builder", ALL_VECTORS)
+def test_python_evidence_hash_pinned(name, builder):
+    _record, evidence = builder()
+    actual = attestation_evidence_hash(evidence)
+    assert actual == PINNED_EV_HASHES[name], (
+        f"[{name}] evidence_hash drift: expected {PINNED_EV_HASHES[name]}, "
+        f"got {actual}"
+    )
+
+
+def test_empty_evidence_hash_is_sha256_of_cbor_empty_array():
+    """The empty-vec hash is sha256 of the single CBOR byte 0x80, NOT zeros."""
+    expected = hashlib.sha256(bytes([0x80])).hexdigest()
+    assert attestation_evidence_hash([]) == expected
+    assert attestation_evidence_hash([]) == EMPTY_EVIDENCE_HASH
+
+
+def test_python_v2_backwards_compat_no_evidence_keeps_v2_bytes():
+    """A v2 record + None evidence == v2 record + empty list == v2-only."""
+    only_v2 = canonical_cbor_for_worker_sig(BASE_RECORD)
+    explicit_none = canonical_cbor_for_worker_sig(BASE_RECORD, None)
+    explicit_empty = canonical_cbor_for_worker_sig(BASE_RECORD, [])
+    assert only_v2 == explicit_none == explicit_empty
+
+
+def test_python_evidence_sort_by_discriminant_not_alpha():
+    """ReproducibleBuild(3) MUST come AFTER ArmTrustZone(2), regardless of
+    input order. The sort key is the discriminant index, not the name."""
+    evidence_a = [
+        {
+            "evidence_type": "reproducible_build",
+            "nonce": "ff" * 32,
+            "payload": {},
+        },
+        {
+            "evidence_type": "arm_trustzone",
+            "nonce": "ff" * 32,
+            "payload": {},
+        },
+    ]
+    evidence_b = list(reversed(evidence_a))
+    h_a = attestation_evidence_hash(evidence_a)
+    h_b = attestation_evidence_hash(evidence_b)
+    assert h_a == h_b
+
+
+def test_evidence_type_discriminant_pinned():
+    """The discriminant indices are load-bearing — pinned across TS+Python+pallet."""
+    assert EVIDENCE_TYPES == (
+        "amd_sev_snp",
+        "intel_tdx",
+        "arm_trustzone",
+        "reproducible_build",
+        "zkvm_execution",
+    )
+    assert EVIDENCE_TYPE_DISCRIMINANT == {
+        "amd_sev_snp": 0,
+        "intel_tdx": 1,
+        "arm_trustzone": 2,
+        "reproducible_build": 3,
+        "zkvm_execution": 4,
+    }
+
+
+# ===========================================================================
+# Cross-language tests — Python encoder vs TS encoder via tsx harness.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("name,builder", ALL_VECTORS)
+def test_cross_lang_worker_pre_image_byte_equal(name, builder):
+    record, evidence = builder()
+    py_bytes = canonical_cbor_for_worker_sig(record, evidence)
+    ts_out = _run_ts_harness(record, evidence)
+    assert ts_out["WORKER_PRE_HEX"] == py_bytes.hex(), (
+        f"[{name}] worker pre-image bytes differ between TS and Python"
+    )
+
+
+@pytest.mark.parametrize("name,builder", ALL_VECTORS)
+def test_cross_lang_content_hash_equal(name, builder):
+    record, evidence = builder()
+    py_hash = canonical_content_hash_v2(record, evidence)
+    ts_out = _run_ts_harness(record, evidence)
+    assert ts_out["CONTENT_HASH"] == py_hash, (
+        f"[{name}] content_hash differs: TS={ts_out['CONTENT_HASH']}, "
+        f"Python={py_hash}"
+    )
+
+
+@pytest.mark.parametrize("name,builder", ALL_VECTORS)
+def test_cross_lang_evidence_hash_equal(name, builder):
+    record, evidence = builder()
+    py_ev = attestation_evidence_hash(evidence)
+    ts_out = _run_ts_harness(record, evidence)
+    assert ts_out["EV_HASH"] == py_ev, (
+        f"[{name}] evidence_hash differs: TS={ts_out['EV_HASH']}, Python={py_ev}"
+    )
+
+
+def test_cross_lang_schema_hash_v2_1_constant():
+    ts_out = _run_ts_harness(*_vector_v21_2())
+    assert ts_out["SCHEMA_HASH_V2_1"] == SCHEMA_HASH_V2_1_HEX

--- a/packages/compute-meter-sdk/tests/test_v2_1_cross_lang.py
+++ b/packages/compute-meter-sdk/tests/test_v2_1_cross_lang.py
@@ -333,6 +333,96 @@ def test_evidence_type_discriminant_pinned():
     }
 
 
+# ---------------------------------------------------------------------------
+# PR #34 M-2 — same-discriminant tiebreak pinned to attestor_pubkey ASC.
+#
+# Mirrors the JS-side fix in services/blob-gateway/src/receipt_attestation_evidence.ts.
+# When two attestors submit the SAME evidence_type, the canonical sort
+# key is (discriminant, attestor_pubkey_hex) byte-lex. With the secondary
+# key pinned, the resulting CBOR (and its hash) must NOT depend on insertion
+# order.
+# ---------------------------------------------------------------------------
+
+
+# Two synthetic attestor pubkeys whose lex order is fixed.
+ATT_LO = "11" * 32  # lexicographically lower
+ATT_HI = "22" * 32  # lexicographically higher
+
+
+def test_same_discriminant_pubkey_tiebreak_pinned():
+    """Two arm_trustzone entries with different attestor_pubkeys must hash
+    identically regardless of insertion order. Pubkey-asc breaks the tie.
+    """
+    nonce_arm = derive_evidence_nonce(BASE_V2_CONTENT_HASH, "arm_trustzone")
+    a = {
+        "evidence_type": "arm_trustzone",
+        "nonce": nonce_arm,
+        "payload": {"device_model": "Pixel-8"},
+        "attestor_pubkey": ATT_LO,
+    }
+    b = {
+        "evidence_type": "arm_trustzone",
+        "nonce": nonce_arm,
+        "payload": {"device_model": "Galaxy-S24"},
+        "attestor_pubkey": ATT_HI,
+    }
+
+    # Hash with [A, B] vs [B, A]. Stable-sort with a tuple key including
+    # pubkey gives the SAME order regardless of input.
+    h_ab = attestation_evidence_hash([a, b])
+    h_ba = attestation_evidence_hash([b, a])
+    assert h_ab == h_ba, (
+        "attestation_evidence_hash must be insertion-order-independent when the "
+        "secondary sort key (attestor_pubkey) is pinned"
+    )
+
+
+def test_same_discriminant_pubkey_tiebreak_matches_pinned_vector():
+    """Pin the canonical hash for two same-type entries with known pubkeys.
+    If anyone flips the comparator, this test catches it on first PR.
+    """
+    nonce_arm = derive_evidence_nonce(BASE_V2_CONTENT_HASH, "arm_trustzone")
+    lo = {
+        "evidence_type": "arm_trustzone",
+        "nonce": nonce_arm,
+        "payload": {"device_model": "Pixel-8"},
+        "attestor_pubkey": ATT_LO,
+    }
+    hi = {
+        "evidence_type": "arm_trustzone",
+        "nonce": nonce_arm,
+        "payload": {"device_model": "Galaxy-S24"},
+        "attestor_pubkey": ATT_HI,
+    }
+    # The canonical encoder must put the lo-pubkey entry FIRST. Reproduce that
+    # ordering by hand and hash.
+    expected = attestation_evidence_hash(
+        [
+            # explicit canonical order: lo before hi
+            {
+                "evidence_type": "arm_trustzone",
+                "nonce": nonce_arm,
+                "payload": {"device_model": "Pixel-8"},
+            },
+            {
+                "evidence_type": "arm_trustzone",
+                "nonce": nonce_arm,
+                "payload": {"device_model": "Galaxy-S24"},
+            },
+        ]
+    )
+    # Both insertion orders feed identical canonical bytes.
+    assert attestation_evidence_hash([lo, hi]) == expected
+    assert attestation_evidence_hash([hi, lo]) == expected
+    # Pinned vector — locks the convention forever. If anyone flips the
+    # comparator, this test catches it on first PR. Computed under
+    # ATT_LO=11..11 (32 bytes) lex-before ATT_HI=22..22 (32 bytes) with the
+    # canonical pre-image being `[lo_payload, hi_payload]` in that order.
+    assert expected == (
+        "74fd7d37719defa9e6891c084a0f7a71ef80a926f0718e78252e44a5326c7651"
+    ), f"pinned vector drift: got {expected}"
+
+
 # ===========================================================================
 # Cross-language tests — Python encoder vs TS encoder via tsx harness.
 # ===========================================================================

--- a/services/blob-gateway/src/__tests__/attestation_evidence_attestors.test.ts
+++ b/services/blob-gateway/src/__tests__/attestation_evidence_attestors.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Tests for the attestation_evidence_attestors registry + admin routes.
+ * Mirrors `fleet_operators.test.ts` + `metering_v2_admin.test.ts`.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+
+import { config } from "../config.js";
+import {
+  initAttestationEvidenceAttestorsDb,
+  setAttestationEvidenceAttestorsDbForTests,
+  registerAttestationEvidenceAttestor,
+  revokeAttestationEvidenceAttestor,
+  getAttestationEvidenceAttestor,
+  isAttestationEvidenceAttestorActive,
+  listAttestationEvidenceAttestors,
+} from "../attestation_evidence_attestors.js";
+import { registerAttestationEvidenceAttestorRoutes } from "../routes/attestation_evidence_attestors.js";
+
+const ADMIN_TOKEN = "admin-test-token-deadbeef";
+const PUB_A = "a".repeat(64);
+const PUB_B = "b".repeat(64);
+const PUB_C = "c".repeat(64);
+
+function makeMemDb(): Database.Database {
+  const db = new Database(":memory:");
+  initAttestationEvidenceAttestorsDb(db);
+  setAttestationEvidenceAttestorsDbForTests(db);
+  return db;
+}
+
+interface Ctx {
+  app: express.Express;
+  db: Database.Database;
+  prevToken: string;
+}
+
+function setupApp(opts: { withToken?: boolean } = {}): Ctx {
+  const db = makeMemDb();
+  const prevToken = config.daemonNotifyToken;
+  config.daemonNotifyToken = opts.withToken === false ? "" : ADMIN_TOKEN;
+  const app = express();
+  app.use(express.json({ limit: "1mb" }));
+  registerAttestationEvidenceAttestorRoutes(app);
+  return { app, db, prevToken };
+}
+
+function teardown(ctx: Ctx): void {
+  config.daemonNotifyToken = ctx.prevToken;
+  ctx.db.close();
+}
+
+async function callApp(
+  app: express.Express,
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { "content-type": "application/json", ...(opts.headers ?? {}) },
+      };
+      if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+// ===========================================================================
+// Storage layer
+// ===========================================================================
+
+describe("attestation_evidence_attestors: storage", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = makeMemDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  test("init_creates_table_with_expected_columns", () => {
+    const cols = db
+      .prepare("PRAGMA table_info(attestation_evidence_attestors)")
+      .all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual([
+      "id",
+      "label",
+      "notes",
+      "pubkey_hex",
+      "registered_at",
+      "revoked_at",
+    ]);
+  });
+
+  test("register_get_isActive_revoke_round_trip", () => {
+    expect(isAttestationEvidenceAttestorActive(PUB_A)).toBe(false);
+    const row = registerAttestationEvidenceAttestor({
+      pubkey: PUB_A,
+      label: "acurast-pixel-8",
+      notes: "phase 2 phone",
+    });
+    expect(row.pubkey_hex).toBe(PUB_A);
+    expect(getAttestationEvidenceAttestor(PUB_A)).not.toBeNull();
+    expect(isAttestationEvidenceAttestorActive(PUB_A)).toBe(true);
+    expect(revokeAttestationEvidenceAttestor(PUB_A)).toBe(true);
+    expect(isAttestationEvidenceAttestorActive(PUB_A)).toBe(false);
+    // Revoke is idempotent.
+    expect(revokeAttestationEvidenceAttestor(PUB_A)).toBe(false);
+  });
+
+  test("register_normalises_0x_prefix_and_uppercase", () => {
+    const row = registerAttestationEvidenceAttestor({
+      pubkey: "0X" + PUB_A.toUpperCase(),
+    });
+    expect(row.pubkey_hex).toBe(PUB_A);
+  });
+
+  test("register_throws_on_invalid_hex", () => {
+    expect(() =>
+      registerAttestationEvidenceAttestor({ pubkey: "not-hex" }),
+    ).toThrow(/64 chars/);
+  });
+
+  test("register_throws_on_duplicate", () => {
+    registerAttestationEvidenceAttestor({ pubkey: PUB_A });
+    expect(() =>
+      registerAttestationEvidenceAttestor({ pubkey: PUB_A }),
+    ).toThrow(/UNIQUE/i);
+  });
+
+  test("list_returns_active_only_when_filtered", () => {
+    registerAttestationEvidenceAttestor({ pubkey: PUB_A, now: 100 });
+    registerAttestationEvidenceAttestor({ pubkey: PUB_B, now: 200 });
+    registerAttestationEvidenceAttestor({ pubkey: PUB_C, now: 150 });
+    revokeAttestationEvidenceAttestor(PUB_B);
+    const all = listAttestationEvidenceAttestors();
+    expect(all).toHaveLength(3);
+    const active = listAttestationEvidenceAttestors({ active: true });
+    expect(active).toHaveLength(2);
+    expect(active.map((r) => r.pubkey_hex).sort()).toEqual([PUB_A, PUB_C].sort());
+  });
+});
+
+// ===========================================================================
+// Admin route
+// ===========================================================================
+
+describe("/admin/attestation-evidence-attestors — auth gating", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp();
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("POST_without_token_returns_401", async () => {
+    const res = await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      { body: { pubkey: PUB_A } },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("POST_with_wrong_token_returns_401", async () => {
+    const res = await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      { headers: { "x-admin-token": "wrong" }, body: { pubkey: PUB_A } },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("DELETE_without_token_returns_401", async () => {
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/attestation-evidence-attestors/${PUB_A}`,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("GET_without_token_returns_401", async () => {
+    const res = await callApp(
+      ctx.app,
+      "GET",
+      "/admin/attestation-evidence-attestors",
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("/admin/attestation-evidence-attestors — POST + DELETE + GET", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp();
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("POST_register_returns_200_with_persisted_row", async () => {
+    const res = await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      {
+        headers: { "x-admin-token": ADMIN_TOKEN },
+        body: { pubkey: PUB_A, label: "pixel-8", notes: "test phone" },
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as Record<string, unknown>;
+    expect(body.status).toBe("created");
+    const att = body.attestor as Record<string, unknown>;
+    expect(att.pubkey_hex).toBe(PUB_A);
+    expect(att.label).toBe("pixel-8");
+    expect(att.notes).toBe("test phone");
+    expect(att.revoked_at).toBeNull();
+  });
+
+  test("POST_with_0x_prefix_normalises", async () => {
+    const res = await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      {
+        headers: { "x-admin-token": ADMIN_TOKEN },
+        body: { pubkey: "0x" + PUB_A.toUpperCase() },
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(
+      (res.body as { attestor: { pubkey_hex: string } }).attestor.pubkey_hex,
+    ).toBe(PUB_A);
+  });
+
+  test("POST_missing_pubkey_returns_400", async () => {
+    const res = await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      { headers: { "x-admin-token": ADMIN_TOKEN }, body: {} },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("POST_invalid_pubkey_returns_400", async () => {
+    const res = await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      {
+        headers: { "x-admin-token": ADMIN_TOKEN },
+        body: { pubkey: "abcd" },
+      },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("POST_duplicate_returns_409", async () => {
+    await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      { headers: { "x-admin-token": ADMIN_TOKEN }, body: { pubkey: PUB_A } },
+    );
+    const res = await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      { headers: { "x-admin-token": ADMIN_TOKEN }, body: { pubkey: PUB_A } },
+    );
+    expect(res.status).toBe(409);
+  });
+
+  test("DELETE_unknown_returns_404", async () => {
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/attestation-evidence-attestors/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("DELETE_active_returns_200_revoked", async () => {
+    await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      { headers: { "x-admin-token": ADMIN_TOKEN }, body: { pubkey: PUB_A } },
+    );
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/attestation-evidence-attestors/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { status: string }).status).toBe("revoked");
+  });
+
+  test("DELETE_already_revoked_returns_already_revoked", async () => {
+    await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      { headers: { "x-admin-token": ADMIN_TOKEN }, body: { pubkey: PUB_A } },
+    );
+    await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/attestation-evidence-attestors/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/attestation-evidence-attestors/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { status: string }).status).toBe("already-revoked");
+  });
+
+  test("GET_returns_empty_for_fresh_db", async () => {
+    const res = await callApp(
+      ctx.app,
+      "GET",
+      "/admin/attestation-evidence-attestors",
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { attestors: unknown[] }).attestors).toEqual([]);
+  });
+
+  test("GET_active_filters_revoked", async () => {
+    for (const p of [PUB_A, PUB_B]) {
+      await callApp(
+        ctx.app,
+        "POST",
+        "/admin/attestation-evidence-attestors",
+        { headers: { "x-admin-token": ADMIN_TOKEN }, body: { pubkey: p } },
+      );
+    }
+    await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/attestation-evidence-attestors/${PUB_A}`,
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    const res = await callApp(
+      ctx.app,
+      "GET",
+      "/admin/attestation-evidence-attestors?active=1",
+      { headers: { "x-admin-token": ADMIN_TOKEN } },
+    );
+    expect(res.status).toBe(200);
+    const arr = (res.body as { attestors: Array<{ pubkey_hex: string }> }).attestors;
+    expect(arr).toHaveLength(1);
+    expect(arr[0]!.pubkey_hex).toBe(PUB_B);
+  });
+});
+
+describe("/admin/attestation-evidence-attestors — unconfigured", () => {
+  let ctx: Ctx;
+  beforeEach(() => {
+    ctx = setupApp({ withToken: false });
+  });
+  afterEach(() => {
+    teardown(ctx);
+  });
+
+  test("POST_returns_503_when_admin_token_unset", async () => {
+    const res = await callApp(
+      ctx.app,
+      "POST",
+      "/admin/attestation-evidence-attestors",
+      { body: { pubkey: PUB_A } },
+    );
+    expect(res.status).toBe(503);
+  });
+
+  test("DELETE_returns_503_when_admin_token_unset", async () => {
+    const res = await callApp(
+      ctx.app,
+      "DELETE",
+      `/admin/attestation-evidence-attestors/${PUB_A}`,
+    );
+    expect(res.status).toBe(503);
+  });
+
+  test("GET_returns_503_when_admin_token_unset", async () => {
+    const res = await callApp(
+      ctx.app,
+      "GET",
+      "/admin/attestation-evidence-attestors",
+    );
+    expect(res.status).toBe(503);
+  });
+});

--- a/services/blob-gateway/src/__tests__/attestation_evidence_route.test.ts
+++ b/services/blob-gateway/src/__tests__/attestation_evidence_route.test.ts
@@ -199,6 +199,27 @@ async function mintV2Manifest(opts: {
 }
 
 /**
+ * Mint a PLAIN BLOB manifest at a fixed content_hash — what `POST
+ * /blobs/:contentHash/manifest` writes. NO `schema` field. Used to verify
+ * the v2-schema gate in `lookupV2Manifest`: a plain blob manifest must
+ * NOT be accepted as an attestation_evidence target.
+ */
+async function mintPlainBlobManifest(opts: {
+  content_hash: string;
+}): Promise<{ contentHash: string; receiptIdClean: string }> {
+  const manifest = {
+    chunks: [],
+    rootHash: opts.content_hash,
+  };
+  await saveManifest(opts.content_hash, manifest);
+  const receiptId = computeReceiptId(opts.content_hash);
+  const receiptIdClean = receiptId.startsWith("0x")
+    ? receiptId.slice(2)
+    : receiptId;
+  return { contentHash: opts.content_hash, receiptIdClean };
+}
+
+/**
  * Build a signed evidence-submit body. The attestor signs canonical CBOR
  * of the payload (NOT the wrapping evidence map).
  */
@@ -380,6 +401,35 @@ describe("POST /v2/attestation_evidence — receipt_not_found", () => {
       evidenceType: "arm_trustzone",
       payload: { device_model: "Pixel-8" },
       attestorUri: "//Attestor0",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: body.attestorPubHex });
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      body,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(404);
+    expect((res.body as { code: string }).code).toBe("RECEIPT_NOT_FOUND");
+  });
+
+  // PR #34 M-1: lookupV2Manifest must check the manifest's schema field.
+  // A plain blob manifest (no `schema` field) must NOT be accepted as a
+  // target for /v2/attestation_evidence — the docstring + inline comment
+  // claim only v2/v2.1 manifests pass.
+  test("submit_evidence_for_non_v2_manifest_returns_404", async () => {
+    // Note: deliberately uses a DIFFERENT content_hash than SYNTH_CONTENT_HASH
+    // so that prior tests' state can't leak. Plain blob manifest = no `schema`.
+    const PLAIN_HASH = "cd".repeat(32);
+    const { contentHash, receiptIdClean } = await mintPlainBlobManifest({
+      content_hash: PLAIN_HASH,
+    });
+    const body = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//AttestorPlainBlob",
     });
     registerAttestationEvidenceAttestor({ pubkey: body.attestorPubHex });
     const res = await postJson(

--- a/services/blob-gateway/src/__tests__/attestation_evidence_route.test.ts
+++ b/services/blob-gateway/src/__tests__/attestation_evidence_route.test.ts
@@ -769,6 +769,174 @@ describe("POST /v2/attestation_evidence — multi-attestor multi-type", () => {
 });
 
 // ===========================================================================
+// PR #34 M-2 — pinned secondary sort key on same-discriminant entries.
+// Two attestors submit the SAME evidence_type for the same receipt;
+// attestation_evidence_hash MUST be deterministic regardless of insertion
+// order, pinned on (discriminant, attestor_pubkey_hex) lex-ascending.
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — multi-attestor SAME-type tiebreak", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("multi_attestor_same_evidence_type_hash_is_deterministic_by_pubkey_order", async () => {
+    // ----- Pass 1: register A (//AttA), submit; register B (//AttB), submit. -----
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: SYNTH_CONTENT_HASH,
+    });
+    const aBody = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//AttA",
+    });
+    const bBody = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Galaxy-S24" },
+      attestorUri: "//AttB",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: aBody.attestorPubHex });
+    registerAttestationEvidenceAttestor({ pubkey: bBody.attestorPubHex });
+
+    // Submit A first, then B.
+    const r1a = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      aBody,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(r1a.status).toBe(200);
+    const r1b = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      bBody,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(r1b.status).toBe(200);
+    const hashAB = (r1b.body as { attestation_evidence_hash: string })
+      .attestation_evidence_hash;
+    expect((r1b.body as { evidence_count: number }).evidence_count).toBe(2);
+
+    // ----- Pass 2: Drop the evidence DB; register B first, then A; submit B then A. -----
+    // Replicates the cross-instance scenario the security review flagged: same
+    // logical evidence set, different on-disk insertion order, must hash same.
+    ctx.evidenceDb.close();
+    const evidenceDb2 = new Database(":memory:");
+    initReceiptAttestationEvidenceDb(evidenceDb2);
+    setReceiptAttestationEvidenceDbForTests(evidenceDb2);
+    ctx.evidenceDb = evidenceDb2;
+
+    const r2b = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      bBody,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(r2b.status).toBe(200);
+    const r2a = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      aBody,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(r2a.status).toBe(200);
+    const hashBA = (r2a.body as { attestation_evidence_hash: string })
+      .attestation_evidence_hash;
+    expect((r2a.body as { evidence_count: number }).evidence_count).toBe(2);
+
+    // The KEY assertion: hashes must match across reversed insertion orders.
+    expect(hashBA).toBe(hashAB);
+  });
+
+  // PINNED VECTOR — locks the convention "(discriminant, attestor_pubkey_hex)
+  // lex-ascending" forever. If anyone ever flips the comparator, this test
+  // catches it on first PR.
+  test("multi_attestor_same_type_pinned_vector", async () => {
+    // Two evidence entries, identical evidence_type=arm_trustzone, different
+    // pubkeys/payloads. We KNOW the pubkeys for //AttA and //AttB are stable
+    // sr25519 derivations of those URIs.
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: SYNTH_CONTENT_HASH,
+    });
+    const aBody = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//AttA",
+    });
+    const bBody = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Galaxy-S24" },
+      attestorUri: "//AttB",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: aBody.attestorPubHex });
+    registerAttestationEvidenceAttestor({ pubkey: bBody.attestorPubHex });
+
+    // Submit them in REVERSE pubkey-lex order to prove the route's recompute
+    // applies the pinned tiebreak (and not insertion order).
+    const lowerPubFirst = aBody.attestorPubHex < bBody.attestorPubHex
+      ? aBody
+      : bBody;
+    const higherPubFirst = aBody.attestorPubHex < bBody.attestorPubHex
+      ? bBody
+      : aBody;
+
+    const insertHigherFirst = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      higherPubFirst,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(insertHigherFirst.status).toBe(200);
+
+    const insertLowerSecond = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      lowerPubFirst,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(insertLowerSecond.status).toBe(200);
+
+    const apiHash = (insertLowerSecond.body as {
+      attestation_evidence_hash: string;
+    }).attestation_evidence_hash;
+
+    // Recompute by hand, in the canonical pinned order: lower pubkey first.
+    const lowerPub = aBody.attestorPubHex < bBody.attestorPubHex
+      ? aBody
+      : bBody;
+    const higherPub = aBody.attestorPubHex < bBody.attestorPubHex
+      ? bBody
+      : aBody;
+
+    const expected = attestationEvidenceHash([
+      {
+        evidence_type: "arm_trustzone",
+        nonce: deriveEvidenceNonce(contentHash, "arm_trustzone"),
+        payload: lowerPub.payload,
+      },
+      {
+        evidence_type: "arm_trustzone",
+        nonce: deriveEvidenceNonce(contentHash, "arm_trustzone"),
+        payload: higherPub.payload,
+      },
+    ]);
+    expect(apiHash).toBe(expected);
+  });
+});
+
+// ===========================================================================
 // Empty-vec hash spec pin (route returns the canonical empty-vec hash for
 // receipts that have no evidence yet).
 // ===========================================================================

--- a/services/blob-gateway/src/__tests__/attestation_evidence_route.test.ts
+++ b/services/blob-gateway/src/__tests__/attestation_evidence_route.test.ts
@@ -1,0 +1,746 @@
+/**
+ * End-to-end tests for `POST /v2/attestation_evidence` (Wave 3 Phase 2).
+ *
+ * Real express server. Real on-disk storage layout (so the manifest-lookup
+ * + receipt-id-index code paths are exercised). Real in-memory SQLite for
+ * the attestor + evidence registries. Real sr25519 keypairs (no mocked
+ * verifies).
+ *
+ * Coverage matrix — every spec rule, positive + negative + edge:
+ *
+ *   1. Happy-path: register attestor, mint a v2 receipt, POST evidence with
+ *      valid nonce + sig → 200 + correct evidence_count = 1,
+ *      attestation_evidence_hash matches manual recompute.
+ *   2. Replay: same evidence body twice → second returns 200 status:replay,
+ *      no double-store.
+ *   3. Two attestors submit DIFFERENT evidence_types for the same receipt
+ *      → both stored, count = 2, vec sorted by evidence_type discriminant.
+ *   4. Bad nonce → 422 NONCE_MISMATCH.
+ *   5. Unknown attestor → 403.
+ *   6. Wrong signature → 401.
+ *   7. Missing receipt_id → 404.
+ *   8. attestation_evidence_hash for empty vec is the canonical-CBOR-hash
+ *      of `[]` (NOT zeros — sha256(0x80)).
+ *
+ * Plus: bearer auth required (no token → 401 from middleware).
+ */
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createHash } from "crypto";
+import { Keyring } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+
+import { config } from "../config.js";
+import { attestationEvidenceRouter } from "../routes/attestation_evidence.js";
+import {
+  initAttestationEvidenceAttestorsDb,
+  setAttestationEvidenceAttestorsDbForTests,
+  registerAttestationEvidenceAttestor,
+  revokeAttestationEvidenceAttestor,
+} from "../attestation_evidence_attestors.js";
+import {
+  initReceiptAttestationEvidenceDb,
+  setReceiptAttestationEvidenceDbForTests,
+  recomputeReceiptEvidenceHash,
+} from "../receipt_attestation_evidence.js";
+import { initApiTokensDb, issueToken, setApiTokensDb } from "../api-tokens.js";
+import {
+  deriveEvidenceNonce,
+  evidenceEntryToCborValue,
+  encodeCbor,
+  attestationEvidenceHash,
+  type EvidenceType,
+} from "../schemas/compute_metering_v2.js";
+import { saveManifest, computeReceiptId } from "../storage.js";
+
+let keyring: Keyring;
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+  keyring = new Keyring({ type: "sr25519" });
+});
+
+interface Ctx {
+  app: express.Express;
+  storage: string;
+  prevStorage: string;
+  attestorsDb: Database.Database;
+  evidenceDb: Database.Database;
+  apiTokensDb: Database.Database;
+  /** A bearer token good enough to satisfy `bearerAuth()`. */
+  bearerToken: string;
+}
+
+async function setupApp(): Promise<Ctx> {
+  const storage = mkdtempSync(join(tmpdir(), "att-evidence-test-"));
+  const prevStorage = config.storagePath;
+  config.storagePath = storage;
+
+  const attestorsDb = new Database(":memory:");
+  initAttestationEvidenceAttestorsDb(attestorsDb);
+  setAttestationEvidenceAttestorsDbForTests(attestorsDb);
+
+  const evidenceDb = new Database(":memory:");
+  initReceiptAttestationEvidenceDb(evidenceDb);
+  setReceiptAttestationEvidenceDbForTests(evidenceDb);
+
+  // The route uses bearerAuth() which requires the api-tokens db to be
+  // initialised so it can resolve a Bearer token. Mint a test token here.
+  const apiTokensDb = initApiTokensDb(new Database(":memory:"));
+  setApiTokensDb(apiTokensDb);
+  const { token: bearerToken } = issueToken(apiTokensDb, {
+    accountSs58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    label: "test-token",
+  });
+
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.use(attestationEvidenceRouter);
+
+  return {
+    app,
+    storage,
+    prevStorage,
+    attestorsDb,
+    evidenceDb,
+    apiTokensDb,
+    bearerToken,
+  };
+}
+
+async function teardown(ctx: Ctx): Promise<void> {
+  config.storagePath = ctx.prevStorage;
+  rmSync(ctx.storage, { recursive: true, force: true });
+  ctx.attestorsDb.close();
+  ctx.evidenceDb.close();
+  ctx.apiTokensDb.close();
+}
+
+async function postJson(
+  app: express.Express,
+  path: string,
+  body: unknown,
+  opts: { headers?: Record<string, string> } = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      fetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(opts.headers ?? {}),
+        },
+        body: JSON.stringify(body),
+      })
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+/**
+ * Mint a v2 manifest at a fixed content_hash and return both the
+ * content_hash and the canonical receipt_id (no `0x` prefix). The manifest
+ * shape mimics what `routes/metering_v2.handleV2Submit` writes (schema +
+ * record + chunks=[] + rootHash=content_hash).
+ */
+async function mintV2Manifest(opts: {
+  content_hash: string;
+  worker_id?: string;
+}): Promise<{ contentHash: string; receiptIdClean: string }> {
+  const manifest = {
+    schema: "compute_metering_v2",
+    record: {
+      schema_version: "compute_metering_v2",
+      worker_id: opts.worker_id ?? "wkr-test",
+      tenant_id: "tenant-test",
+    },
+    chunks: [],
+    rootHash: opts.content_hash,
+  };
+  await saveManifest(opts.content_hash, manifest);
+  const receiptId = computeReceiptId(opts.content_hash);
+  const receiptIdClean = receiptId.startsWith("0x")
+    ? receiptId.slice(2)
+    : receiptId;
+  return { contentHash: opts.content_hash, receiptIdClean };
+}
+
+/**
+ * Build a signed evidence-submit body. The attestor signs canonical CBOR
+ * of the payload (NOT the wrapping evidence map).
+ */
+function buildSignedEvidence(opts: {
+  receiptIdClean: string;
+  contentHash: string;
+  evidenceType: EvidenceType;
+  payload: Record<string, unknown>;
+  attestorUri: string;
+}): {
+  receipt_id: string;
+  evidence_type: string;
+  nonce: string;
+  payload: Record<string, unknown>;
+  attestor_pubkey: string;
+  signature: string;
+  attestorPubHex: string;
+} {
+  const pair = keyring.addFromUri(opts.attestorUri);
+  const tagged = evidenceEntryToCborValue({
+    evidence_type: opts.evidenceType,
+    nonce: deriveEvidenceNonce(opts.contentHash, opts.evidenceType),
+    payload: opts.payload,
+  });
+  if (tagged.type !== "map") throw new Error("unexpected tagged shape");
+  const payloadEntry = tagged.v.find(([k]) => k === "payload");
+  if (!payloadEntry) throw new Error("payload key missing");
+  const payloadBytes = encodeCbor(payloadEntry[1]);
+  const sig = pair.sign(payloadBytes);
+  const pubHex = u8aToHex(pair.publicKey, undefined, false);
+  return {
+    receipt_id: opts.receiptIdClean,
+    evidence_type: opts.evidenceType,
+    nonce: deriveEvidenceNonce(opts.contentHash, opts.evidenceType),
+    payload: opts.payload,
+    attestor_pubkey: pubHex,
+    signature: u8aToHex(sig, undefined, false),
+    attestorPubHex: pubHex,
+  };
+}
+
+// Default test content_hash — synthetic 32-byte hex. Reused throughout.
+const SYNTH_CONTENT_HASH = "ab".repeat(32);
+
+// ===========================================================================
+// Auth
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — bearer auth gating", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("missing_bearer_returns_401", async () => {
+    const res = await postJson(ctx.app, "/v2/attestation_evidence", {
+      receipt_id: "0".repeat(64),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("invalid_bearer_returns_401", async () => {
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      { receipt_id: "0".repeat(64) },
+      { headers: { authorization: "Bearer matra_not_a_real_token" } },
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+// ===========================================================================
+// Body shape — 400 on malformed input
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — body shape", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("missing_receipt_id_returns_400", async () => {
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      {
+        evidence_type: "arm_trustzone",
+        nonce: "ff".repeat(32),
+        payload: {},
+        attestor_pubkey: "ff".repeat(32),
+        signature: "ff".repeat(64),
+      },
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("MISSING_FIELD");
+  });
+
+  test("invalid_evidence_type_returns_400", async () => {
+    await mintV2Manifest({ content_hash: SYNTH_CONTENT_HASH });
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      {
+        receipt_id: SYNTH_CONTENT_HASH,
+        evidence_type: "made_up",
+        nonce: "ff".repeat(32),
+        payload: {},
+        attestor_pubkey: "ff".repeat(32),
+        signature: "ff".repeat(64),
+      },
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("EVIDENCE_TYPE_INVALID");
+  });
+
+  test("non_object_payload_returns_400", async () => {
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      {
+        receipt_id: SYNTH_CONTENT_HASH,
+        evidence_type: "arm_trustzone",
+        nonce: "ff".repeat(32),
+        payload: "not-an-object",
+        attestor_pubkey: "ff".repeat(32),
+        signature: "ff".repeat(64),
+      },
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("WRONG_TYPE");
+  });
+
+  test("bad_hex_returns_400", async () => {
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      {
+        receipt_id: "not-hex",
+        evidence_type: "arm_trustzone",
+        nonce: "ff".repeat(32),
+        payload: {},
+        attestor_pubkey: "ff".repeat(32),
+        signature: "ff".repeat(64),
+      },
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("HEX_FORMAT");
+  });
+});
+
+// ===========================================================================
+// Spec rule 7 — missing receipt_id → 404
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — receipt_not_found", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("unknown_receipt_returns_404", async () => {
+    const body = buildSignedEvidence({
+      receiptIdClean: "00".repeat(32),
+      contentHash: "00".repeat(32),
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//Attestor0",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: body.attestorPubHex });
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      body,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(404);
+    expect((res.body as { code: string }).code).toBe("RECEIPT_NOT_FOUND");
+  });
+});
+
+// ===========================================================================
+// Spec rule — bad nonce → 422 NONCE_MISMATCH
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — nonce_mismatch", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("wrong_nonce_returns_422", async () => {
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: SYNTH_CONTENT_HASH,
+    });
+    const correct = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//Attestor0",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: correct.attestorPubHex });
+    // Tamper with the nonce.
+    const body = { ...correct, nonce: "00".repeat(32) };
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      body,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(422);
+    expect((res.body as { code: string }).code).toBe("NONCE_MISMATCH");
+  });
+});
+
+// ===========================================================================
+// Spec rule — unknown attestor → 403 ATTESTOR_UNKNOWN
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — attestor_unknown", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("unregistered_attestor_returns_403", async () => {
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: SYNTH_CONTENT_HASH,
+    });
+    const body = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//AttestorUnknown",
+    });
+    // DO NOT register.
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      body,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(403);
+    expect((res.body as { code: string }).code).toBe("ATTESTOR_UNKNOWN");
+  });
+
+  test("revoked_attestor_returns_403", async () => {
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: SYNTH_CONTENT_HASH,
+    });
+    const body = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//AttestorRevoked",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: body.attestorPubHex });
+    revokeAttestationEvidenceAttestor(body.attestorPubHex);
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      body,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(403);
+    expect((res.body as { code: string }).code).toBe("ATTESTOR_UNKNOWN");
+  });
+});
+
+// ===========================================================================
+// Spec rule — wrong signature → 401 SIGNATURE_INVALID
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — signature_invalid", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("tampered_signature_returns_401", async () => {
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: SYNTH_CONTENT_HASH,
+    });
+    const correct = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//Attestor1",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: correct.attestorPubHex });
+    const body = { ...correct, signature: "00".repeat(64) };
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      body,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(401);
+    expect((res.body as { code: string }).code).toBe("SIGNATURE_INVALID");
+  });
+});
+
+// ===========================================================================
+// Happy path — accept, store, recompute hash, return shape
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — happy path", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("accepts_first_evidence_and_returns_recomputed_hash", async () => {
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: SYNTH_CONTENT_HASH,
+    });
+    const body = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: {
+        device_model: "Pixel-8",
+        security_level: "TrustedEnvironment",
+        key_attestation_chain_b64: "AAECAw==",
+      },
+      attestorUri: "//Attestor2",
+    });
+    registerAttestationEvidenceAttestor({
+      pubkey: body.attestorPubHex,
+      label: "happy-path-attestor",
+    });
+
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      body,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const j = res.body as {
+      ok: boolean;
+      status: string;
+      receipt_id: string;
+      attestation_evidence_hash: string;
+      evidence_count: number;
+      evidence_types: string[];
+    };
+    expect(j.ok).toBe(true);
+    expect(j.status).toBe("accepted");
+    expect(j.receipt_id).toBe(receiptIdClean);
+    expect(j.evidence_count).toBe(1);
+    expect(j.evidence_types).toEqual(["arm_trustzone"]);
+    expect(j.attestation_evidence_hash).toMatch(/^[0-9a-f]{64}$/);
+
+    // The hash matches a manual recompute from the evidence DB.
+    const summary = recomputeReceiptEvidenceHash(receiptIdClean);
+    expect(summary.hash).toBe(j.attestation_evidence_hash);
+    expect(summary.count).toBe(1);
+  });
+});
+
+// ===========================================================================
+// Spec rule — replay → 200 status:replay (no double-store)
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — replay", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("same_evidence_body_twice_returns_replay_no_double_store", async () => {
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: SYNTH_CONTENT_HASH,
+    });
+    const body = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//Attestor3",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: body.attestorPubHex });
+
+    const r1 = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      body,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(r1.status).toBe(200);
+    expect((r1.body as { status: string }).status).toBe("accepted");
+    expect((r1.body as { evidence_count: number }).evidence_count).toBe(1);
+
+    const r2 = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      body,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(r2.status).toBe(200);
+    expect((r2.body as { status: string }).status).toBe("replay");
+    expect((r2.body as { evidence_count: number }).evidence_count).toBe(1);
+  });
+});
+
+// ===========================================================================
+// Spec rule — two attestors, different evidence_types → both stored,
+// vec sorted by evidence_type discriminant.
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — multi-attestor multi-type", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("two_attestors_different_types_both_stored_sorted_by_discriminant", async () => {
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: SYNTH_CONTENT_HASH,
+    });
+    // First attestor: reproducible_build (discriminant 3)
+    const buildBody = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "reproducible_build",
+      payload: { nar_hash_b64: "AAECAw==" },
+      attestorUri: "//AttestorBuild",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: buildBody.attestorPubHex });
+    // Second attestor: arm_trustzone (discriminant 2)
+    const armBody = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device_model: "Pixel-8" },
+      attestorUri: "//AttestorArm",
+    });
+    registerAttestationEvidenceAttestor({ pubkey: armBody.attestorPubHex });
+
+    // Submit the build evidence FIRST, then arm. Even though arm has lower
+    // discriminant, the storage layer's recompute MUST sort by discriminant.
+    const r1 = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      buildBody,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(r1.status).toBe(200);
+    expect((r1.body as { evidence_count: number }).evidence_count).toBe(1);
+
+    const r2 = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      armBody,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(r2.status).toBe(200);
+    const j2 = r2.body as {
+      evidence_count: number;
+      evidence_types: string[];
+      attestation_evidence_hash: string;
+    };
+    expect(j2.evidence_count).toBe(2);
+    // Sorted by discriminant: arm_trustzone (2) before reproducible_build (3)
+    expect(j2.evidence_types).toEqual(["arm_trustzone", "reproducible_build"]);
+
+    // Manual recompute matches what the route returned.
+    const manual = attestationEvidenceHash([
+      {
+        evidence_type: "arm_trustzone",
+        nonce: deriveEvidenceNonce(contentHash, "arm_trustzone"),
+        payload: { device_model: "Pixel-8" },
+      },
+      {
+        evidence_type: "reproducible_build",
+        nonce: deriveEvidenceNonce(contentHash, "reproducible_build"),
+        payload: { nar_hash_b64: "AAECAw==" },
+      },
+    ]);
+    expect(j2.attestation_evidence_hash).toBe(manual);
+  });
+});
+
+// ===========================================================================
+// Empty-vec hash spec pin (route returns the canonical empty-vec hash for
+// receipts that have no evidence yet).
+// ===========================================================================
+
+describe("attestation_evidence_hash — empty vec spec pin", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("empty_evidence_hash_is_sha256_of_cbor_byte_0x80_not_zeros", () => {
+    const summary = recomputeReceiptEvidenceHash("ee".repeat(32));
+    const expected = createHash("sha256").update(Buffer.from([0x80])).digest("hex");
+    expect(summary.hash).toBe(expected);
+    expect(summary.hash).toBe(
+      "76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71",
+    );
+    expect(summary.hash).not.toBe("00".repeat(32));
+    expect(summary.count).toBe(0);
+    expect(summary.types).toEqual([]);
+  });
+});

--- a/services/blob-gateway/src/attestation_evidence_attestors.ts
+++ b/services/blob-gateway/src/attestation_evidence_attestors.ts
@@ -1,0 +1,199 @@
+/**
+ * SQLite-backed registry of ATTESTATION-EVIDENCE ATTESTORS — the third
+ * parties (Acurast Android phones for Wave 3 Phase 2; SEV-SNP / TDX hosts
+ * for Phase 3.x) whose TEE-protected keys sign POST /v2/attestation_evidence
+ * payloads.
+ *
+ * Mirrors `fleet_operators.ts` / `observers.ts` — same shape, same lifecycle,
+ * same admin endpoints. Backed by a separate file (`attestors.db`) so its
+ * schema migrations stay isolated from the older registries.
+ *
+ * Trust framing: this registry is the off-chain analogue of the on-chain
+ * `enrolled_chip_id_hashes` set described in § 4 of the Wave 3 design doc
+ * (`/home/deci/wave-3-polychain-attestation-pallet-design.md`). The on-chain
+ * pallet (built in parallel) keeps the canonical chip-ID set; this gateway
+ * registry is the operator-managed set of "attestor pubkeys we'll accept
+ * evidence from at the gateway." Both can be reconciled by ops tooling
+ * (planned follow-up — out of scope for this PR).
+ */
+
+import Database from "better-sqlite3";
+import { join } from "path";
+import { config } from "./config.js";
+
+let db: Database.Database | null = null;
+
+/** Test hook: inject a handle (typically `:memory:` for unit tests). */
+export function setAttestationEvidenceAttestorsDbForTests(
+  injected: Database.Database,
+): void {
+  db = injected;
+}
+
+/** Test/debug helper — returns the current handle or throws if uninitialised. */
+export function getAttestationEvidenceAttestorsDb(): Database.Database {
+  if (!db) {
+    throw new Error(
+      "attestation_evidence_attestors db not initialised — call init...() first",
+    );
+  }
+  return db;
+}
+
+/**
+ * Initialise the attestation_evidence_attestors table on a SQLite handle.
+ *
+ * Idempotent: safe to call repeatedly. CREATE IF NOT EXISTS is the workhorse;
+ * column additions go through migrate*Columns() helpers later.
+ *
+ * If `database` is omitted, opens (or creates) `attestation_evidence_attestors.db`
+ * at the canonical storage path. Tests should pass an in-memory handle.
+ */
+export function initAttestationEvidenceAttestorsDb(
+  database?: Database.Database,
+): Database.Database {
+  const handle =
+    database ??
+    new Database(join(config.storagePath, "attestation_evidence_attestors.db"));
+  handle.pragma("journal_mode = WAL");
+  handle.pragma("busy_timeout = 5000");
+  handle.exec(`
+    CREATE TABLE IF NOT EXISTS attestation_evidence_attestors (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      pubkey_hex TEXT UNIQUE NOT NULL,
+      label TEXT,
+      registered_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      notes TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_aea_pubkey
+      ON attestation_evidence_attestors(pubkey_hex);
+    CREATE INDEX IF NOT EXISTS idx_aea_active
+      ON attestation_evidence_attestors(pubkey_hex) WHERE revoked_at IS NULL;
+  `);
+  if (!db) db = handle;
+  return handle;
+}
+
+export interface AttestationEvidenceAttestorRow {
+  id: number;
+  pubkey_hex: string;
+  label: string | null;
+  registered_at: number;
+  revoked_at: number | null;
+  notes: string | null;
+}
+
+const HEX64 = /^[0-9a-f]{64}$/;
+
+function normalizePubkey(input: string): string {
+  const stripped =
+    input.startsWith("0x") || input.startsWith("0X") ? input.slice(2) : input;
+  return stripped.toLowerCase();
+}
+
+export interface RegisterAttestorInput {
+  pubkey: string;
+  label?: string | null;
+  notes?: string | null;
+  /** Unix seconds override; used in tests for determinism. */
+  now?: number;
+}
+
+export function registerAttestationEvidenceAttestor(
+  input: RegisterAttestorInput,
+): AttestationEvidenceAttestorRow {
+  if (!db) throw new Error("attestation_evidence_attestors db not initialised");
+  const normalized = normalizePubkey(input.pubkey);
+  if (!HEX64.test(normalized)) {
+    throw new TypeError(
+      `registerAttestationEvidenceAttestor: pubkey must be 32 bytes hex (64 chars), got "${input.pubkey}"`,
+    );
+  }
+  const label = input.label ? String(input.label).slice(0, 256) : null;
+  const notes = input.notes ? String(input.notes).slice(0, 1024) : null;
+  const registeredAt = input.now ?? Math.floor(Date.now() / 1000);
+
+  const info = db
+    .prepare(
+      `INSERT INTO attestation_evidence_attestors (pubkey_hex, label, registered_at, notes)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(normalized, label, registeredAt, notes);
+
+  return {
+    id: Number(info.lastInsertRowid),
+    pubkey_hex: normalized,
+    label,
+    registered_at: registeredAt,
+    revoked_at: null,
+    notes,
+  };
+}
+
+export function revokeAttestationEvidenceAttestor(
+  pubkey: string,
+  opts: { now?: number } = {},
+): boolean {
+  if (!db) throw new Error("attestation_evidence_attestors db not initialised");
+  const normalized = normalizePubkey(pubkey);
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  const info = db
+    .prepare(
+      `UPDATE attestation_evidence_attestors SET revoked_at = ?
+       WHERE pubkey_hex = ? AND revoked_at IS NULL`,
+    )
+    .run(now, normalized);
+  return info.changes > 0;
+}
+
+export function getAttestationEvidenceAttestor(
+  pubkey: string,
+): AttestationEvidenceAttestorRow | null {
+  if (!db) return null;
+  const normalized = normalizePubkey(pubkey);
+  const row = db
+    .prepare(
+      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes
+       FROM attestation_evidence_attestors WHERE pubkey_hex = ?`,
+    )
+    .get(normalized) as AttestationEvidenceAttestorRow | undefined;
+  return row ?? null;
+}
+
+/**
+ * Hot-path check used by the v2/attestation_evidence route: returns true iff
+ * the pubkey is registered AND not revoked. Defensively returns false when
+ * the registry isn't initialised.
+ */
+export function isAttestationEvidenceAttestorActive(pubkey: string): boolean {
+  if (!db) return false;
+  const normalized = normalizePubkey(pubkey);
+  const row = db
+    .prepare(
+      `SELECT 1 AS one FROM attestation_evidence_attestors
+       WHERE pubkey_hex = ? AND revoked_at IS NULL`,
+    )
+    .get(normalized) as { one: number } | undefined;
+  return row !== undefined;
+}
+
+export interface ListAttestorsOpts {
+  active?: boolean;
+}
+
+export function listAttestationEvidenceAttestors(
+  opts: ListAttestorsOpts = {},
+): AttestationEvidenceAttestorRow[] {
+  if (!db) return [];
+  const where = opts.active ? "WHERE revoked_at IS NULL" : "";
+  const rows = db
+    .prepare(
+      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes
+       FROM attestation_evidence_attestors
+       ${where}
+       ORDER BY registered_at DESC, id DESC`,
+    )
+    .all() as AttestationEvidenceAttestorRow[];
+  return rows;
+}

--- a/services/blob-gateway/src/index.ts
+++ b/services/blob-gateway/src/index.ts
@@ -28,8 +28,12 @@ import { billingRouter } from "./routes/billing.js";
 import { initWorkerBoundsDb } from "./worker_bounds.js";
 import { initFleetOperatorsDb } from "./fleet_operators.js";
 import { initObserversDb } from "./observers.js";
+import { initAttestationEvidenceAttestorsDb } from "./attestation_evidence_attestors.js";
+import { initReceiptAttestationEvidenceDb } from "./receipt_attestation_evidence.js";
 import { registerFleetOperatorRoutes } from "./routes/fleet_operators.js";
 import { registerObserverRoutes } from "./routes/observers.js";
+import { registerAttestationEvidenceAttestorRoutes } from "./routes/attestation_evidence_attestors.js";
+import { attestationEvidenceRouter } from "./routes/attestation_evidence.js";
 // initChainInfoPoller is re-exported for consumers that want to pre-warm the
 // cache at startup; we also call it in start() so the first /chain-info hit
 // after cold-start returns 200 instead of 503.
@@ -70,10 +74,12 @@ app.use(chainInfoRouter);   // Public: /chain-info — used by flux1 explorer + 
 app.use(faucetRouter);      // Public: /faucet/drip — operator onboarding (MATRA + MOTRA bootstrap). Volume-mounted overrides accepted; see ops compose templates.
 app.use(meteringRouter);    // Task #109: POST /metering/submit — compute_metering_v1 ingestion + sponsored-receipt forwarding.
 app.use(billingRouter);     // Task #112: GET /billing/usage — verifiable compute-metering billing query.
+app.use(attestationEvidenceRouter); // Wave 3 Phase 2: POST /v2/attestation_evidence — TEE-attestor evidence sink (worker bearer auth).
 registerTokenRoutes(app);   // Bearer-token lifecycle (admin-only)
 registerAdminKeysRoutes(app); // Task #94: api_keys.bound_validator_aura get/set/clear (admin-only)
 registerFleetOperatorRoutes(app); // Wave 1+2: compute_metering_v2 hardware-attestor registry (admin-only)
 registerObserverRoutes(app);      // Wave 1+2: compute_metering_v2 optional co-signer registry (admin-only)
+registerAttestationEvidenceAttestorRoutes(app); // Wave 3 Phase 2: TEE attestor pubkey registry (admin-only)
 
 async function start(): Promise<void> {
   // Initialize sr25519/ed25519 WASM (required for signatureVerify)
@@ -97,6 +103,9 @@ async function start(): Promise<void> {
   // schema migrations stay isolated from operators.db / quota.db.
   initFleetOperatorsDb();
   initObserversDb();
+  // Wave 3 Phase 2 — TEE attestor registry + per-receipt evidence vector.
+  initAttestationEvidenceAttestorsDb();
+  initReceiptAttestationEvidenceDb();
 
   // Start cleanup timers
   startCleanupTimer();

--- a/services/blob-gateway/src/receipt_attestation_evidence.ts
+++ b/services/blob-gateway/src/receipt_attestation_evidence.ts
@@ -190,14 +190,21 @@ export function insertReceiptEvidence(
 }
 
 /**
- * Read all evidence rows for a receipt, sorted by EvidenceType discriminant
- * ascending. Used for recomputing the canonical evidence vector + hash.
+ * Read all evidence rows for a receipt, sorted by
+ *   (1) EvidenceType discriminant ASC (the canonical primary order), and
+ *   (2) attestor_pubkey_hex ASC byte-lex (the deterministic tiebreaker for
+ *       same-discriminant entries).
  *
- * Sort happens in JS (not SQL) because the discriminant ordering is
+ * Sort happens in JS (not solely in SQL) because the discriminant ordering is
  * pinned in `EVIDENCE_TYPE_DISCRIMINANT` rather than the alphabetical order
- * SQL would give. The pinned-discriminant rule is what guarantees the
- * evidence vector hash matches across TS encoders + the Python encoder + the
- * pallet-side Rust decoder.
+ * SQL would give. The pinned-discriminant rule + lower-pubkey tiebreak
+ * together guarantee the evidence vector hash matches across TS encoders +
+ * the Python encoder + the pallet-side Rust decoder, AND across replicas
+ * regardless of physical row order (rowid drifts after vacuum / restore).
+ *
+ * The SQL `ORDER BY ... attestor_pubkey_hex ASC` is added so any consumer
+ * that bypasses this JS sort (or runs SQL directly for inspection) still
+ * sees the deterministic order. PR #34 M-2.
  */
 export function listReceiptEvidence(receipt_id: string): ReceiptEvidenceRow[] {
   if (!db) return [];
@@ -207,14 +214,25 @@ export function listReceiptEvidence(receipt_id: string): ReceiptEvidenceRow[] {
       `SELECT id, receipt_id, evidence_type, nonce_hex, payload_json,
               attestor_pubkey_hex, signature_hex, submitted_at_ms
          FROM receipt_attestation_evidence
-        WHERE receipt_id = ?`,
+        WHERE receipt_id = ?
+        ORDER BY evidence_type ASC, attestor_pubkey_hex ASC`,
     )
     .all(id) as ReceiptEvidenceRow[];
-  rows.sort(
-    (a, b) =>
+  // JS-side primary sort by discriminant (SQL ORDER BY evidence_type sorts
+  // alphabetically, which is NOT the canonical order — e.g. amd_sev_snp(0)
+  // alphabetises BEFORE arm_trustzone(2) by accident, but intel_tdx(1)
+  // alphabetises AFTER arm_trustzone(2)). Then byte-lex tiebreak on
+  // attestor_pubkey_hex (already lowercase from insert). Direct `< / >`
+  // comparison on lowercase hex strings is locale-independent.
+  rows.sort((a, b) => {
+    const d =
       EVIDENCE_TYPE_DISCRIMINANT[a.evidence_type] -
-      EVIDENCE_TYPE_DISCRIMINANT[b.evidence_type],
-  );
+      EVIDENCE_TYPE_DISCRIMINANT[b.evidence_type];
+    if (d !== 0) return d;
+    if (a.attestor_pubkey_hex < b.attestor_pubkey_hex) return -1;
+    if (a.attestor_pubkey_hex > b.attestor_pubkey_hex) return 1;
+    return 0;
+  });
   return rows;
 }
 

--- a/services/blob-gateway/src/receipt_attestation_evidence.ts
+++ b/services/blob-gateway/src/receipt_attestation_evidence.ts
@@ -1,0 +1,246 @@
+/**
+ * SQLite-backed store of attestation_evidence ENTRIES per receipt.
+ *
+ * Each row is one evidence entry submitted by an attestor for a specific
+ * `receipt_id` (computed from the v2 record's `content_hash` per
+ * `storage.computeReceiptId`). The schema mirrors the wire shape of one
+ * entry plus bookkeeping fields:
+ *
+ *   - receipt_id (hex, no 0x prefix)         — keys the evidence vector
+ *   - evidence_type (text)                    — discriminator (per Wave 3 spec)
+ *   - nonce_hex (hex)                          — content_hash binding nonce
+ *   - payload_json (TEXT)                      — opaque per-evidence-type body
+ *   - attestor_pubkey_hex (hex)                — who submitted this evidence
+ *   - signature_hex (hex)                      — sig over canonical(payload)
+ *   - submitted_at_ms                          — wall-clock at gateway
+ *
+ * UNIQUE constraint on `(receipt_id, attestor_pubkey_hex, evidence_type)`
+ * enforces the route's idempotency rule: re-POSTing the same body returns
+ * status:replay without storing twice. (Per the spec: same `receipt_id +
+ * attestor_pubkey + evidence_type` triple → replay.)
+ *
+ * The evidence vector for a receipt is reconstructed on demand by
+ * `getEvidenceVecForReceipt`, sorted by EvidenceType discriminant, and fed
+ * through `attestationEvidenceHash` to compute the receipt's
+ * `attestation_evidence_hash`.
+ *
+ * On-chain coupling: this PR does NOT modify the on-chain receipt. A
+ * separate cert-daemon PR will eventually carry this hash up to a
+ * pallet-tee-attestation extrinsic. The hash IS computed and returned to
+ * the caller of POST /v2/attestation_evidence so off-chain consumers can
+ * already use it (e.g. flux1 explorer, billing aggregations).
+ */
+
+import Database from "better-sqlite3";
+import { join } from "path";
+import { config } from "./config.js";
+import {
+  attestationEvidenceHash,
+  EVIDENCE_TYPE_DISCRIMINANT,
+  type AttestationEvidenceEntry,
+  type EvidenceType,
+} from "./schemas/compute_metering_v2.js";
+
+let db: Database.Database | null = null;
+
+export function setReceiptAttestationEvidenceDbForTests(
+  injected: Database.Database,
+): void {
+  db = injected;
+}
+
+export function getReceiptAttestationEvidenceDb(): Database.Database {
+  if (!db) {
+    throw new Error(
+      "receipt_attestation_evidence db not initialised — call init...() first",
+    );
+  }
+  return db;
+}
+
+export function initReceiptAttestationEvidenceDb(
+  database?: Database.Database,
+): Database.Database {
+  const handle =
+    database ??
+    new Database(join(config.storagePath, "receipt_attestation_evidence.db"));
+  handle.pragma("journal_mode = WAL");
+  handle.pragma("busy_timeout = 5000");
+  handle.exec(`
+    CREATE TABLE IF NOT EXISTS receipt_attestation_evidence (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      receipt_id TEXT NOT NULL,
+      evidence_type TEXT NOT NULL,
+      nonce_hex TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      attestor_pubkey_hex TEXT NOT NULL,
+      signature_hex TEXT NOT NULL,
+      submitted_at_ms INTEGER NOT NULL,
+      UNIQUE (receipt_id, attestor_pubkey_hex, evidence_type)
+    );
+    CREATE INDEX IF NOT EXISTS idx_rae_receipt
+      ON receipt_attestation_evidence(receipt_id);
+    CREATE INDEX IF NOT EXISTS idx_rae_attestor
+      ON receipt_attestation_evidence(attestor_pubkey_hex);
+  `);
+  if (!db) db = handle;
+  return handle;
+}
+
+export interface ReceiptEvidenceRow {
+  id: number;
+  receipt_id: string;
+  evidence_type: EvidenceType;
+  nonce_hex: string;
+  payload_json: string;
+  attestor_pubkey_hex: string;
+  signature_hex: string;
+  submitted_at_ms: number;
+}
+
+function normalizeReceiptId(input: string): string {
+  return (input.startsWith("0x") || input.startsWith("0X")
+    ? input.slice(2)
+    : input
+  ).toLowerCase();
+}
+
+function normalizeHex(input: string): string {
+  return (input.startsWith("0x") || input.startsWith("0X")
+    ? input.slice(2)
+    : input
+  ).toLowerCase();
+}
+
+export interface InsertReceiptEvidenceInput {
+  receipt_id: string;
+  evidence_type: EvidenceType;
+  nonce_hex: string;
+  payload: Record<string, unknown>;
+  attestor_pubkey_hex: string;
+  signature_hex: string;
+  submitted_at_ms?: number;
+}
+
+/** Outcome of `insertReceiptEvidence`. */
+export type InsertReceiptEvidenceOutcome =
+  | { status: "inserted"; row: ReceiptEvidenceRow }
+  | { status: "replay"; row: ReceiptEvidenceRow };
+
+/**
+ * Insert one evidence entry. If the (receipt_id, attestor_pubkey, evidence_type)
+ * triple already exists, returns `status:replay` and the existing row. Caller
+ * decides whether to surface as 200 or 409.
+ */
+export function insertReceiptEvidence(
+  input: InsertReceiptEvidenceInput,
+): InsertReceiptEvidenceOutcome {
+  if (!db) throw new Error("receipt_attestation_evidence db not initialised");
+  const receipt_id = normalizeReceiptId(input.receipt_id);
+  const attestor_pubkey_hex = normalizeHex(input.attestor_pubkey_hex);
+  const nonce_hex = normalizeHex(input.nonce_hex);
+  const signature_hex = normalizeHex(input.signature_hex);
+  const submitted_at_ms = input.submitted_at_ms ?? Date.now();
+  const payload_json = JSON.stringify(input.payload);
+
+  // Pre-check for replay so we can surface the existing row to the caller.
+  const existing = db
+    .prepare(
+      `SELECT id, receipt_id, evidence_type, nonce_hex, payload_json,
+              attestor_pubkey_hex, signature_hex, submitted_at_ms
+         FROM receipt_attestation_evidence
+        WHERE receipt_id = ? AND attestor_pubkey_hex = ? AND evidence_type = ?`,
+    )
+    .get(receipt_id, attestor_pubkey_hex, input.evidence_type) as
+    | ReceiptEvidenceRow
+    | undefined;
+  if (existing) {
+    return { status: "replay", row: existing };
+  }
+
+  const info = db
+    .prepare(
+      `INSERT INTO receipt_attestation_evidence
+         (receipt_id, evidence_type, nonce_hex, payload_json,
+          attestor_pubkey_hex, signature_hex, submitted_at_ms)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      receipt_id,
+      input.evidence_type,
+      nonce_hex,
+      payload_json,
+      attestor_pubkey_hex,
+      signature_hex,
+      submitted_at_ms,
+    );
+  return {
+    status: "inserted",
+    row: {
+      id: Number(info.lastInsertRowid),
+      receipt_id,
+      evidence_type: input.evidence_type,
+      nonce_hex,
+      payload_json,
+      attestor_pubkey_hex,
+      signature_hex,
+      submitted_at_ms,
+    },
+  };
+}
+
+/**
+ * Read all evidence rows for a receipt, sorted by EvidenceType discriminant
+ * ascending. Used for recomputing the canonical evidence vector + hash.
+ *
+ * Sort happens in JS (not SQL) because the discriminant ordering is
+ * pinned in `EVIDENCE_TYPE_DISCRIMINANT` rather than the alphabetical order
+ * SQL would give. The pinned-discriminant rule is what guarantees the
+ * evidence vector hash matches across TS encoders + the Python encoder + the
+ * pallet-side Rust decoder.
+ */
+export function listReceiptEvidence(receipt_id: string): ReceiptEvidenceRow[] {
+  if (!db) return [];
+  const id = normalizeReceiptId(receipt_id);
+  const rows = db
+    .prepare(
+      `SELECT id, receipt_id, evidence_type, nonce_hex, payload_json,
+              attestor_pubkey_hex, signature_hex, submitted_at_ms
+         FROM receipt_attestation_evidence
+        WHERE receipt_id = ?`,
+    )
+    .all(id) as ReceiptEvidenceRow[];
+  rows.sort(
+    (a, b) =>
+      EVIDENCE_TYPE_DISCRIMINANT[a.evidence_type] -
+      EVIDENCE_TYPE_DISCRIMINANT[b.evidence_type],
+  );
+  return rows;
+}
+
+/**
+ * Reconstruct the canonical evidence vector for a receipt and hash it.
+ *
+ * Returned tuple:
+ *   - hash: SHA-256 hex of canonical-CBOR(evidence_array)
+ *   - count: number of stored entries
+ *   - types: list of evidence_type strings, in discriminant-ascending order
+ *
+ * Empty vec returns the canonical empty-vec hash
+ * (`76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71`)
+ * — NOT zeros.
+ */
+export function recomputeReceiptEvidenceHash(receipt_id: string): {
+  hash: string;
+  count: number;
+  types: EvidenceType[];
+} {
+  const rows = listReceiptEvidence(receipt_id);
+  const entries: AttestationEvidenceEntry[] = rows.map((r) => ({
+    evidence_type: r.evidence_type,
+    nonce: r.nonce_hex,
+    payload: JSON.parse(r.payload_json) as Record<string, unknown>,
+  }));
+  const hash = attestationEvidenceHash(entries);
+  return { hash, count: rows.length, types: rows.map((r) => r.evidence_type) };
+}

--- a/services/blob-gateway/src/routes/attestation_evidence.ts
+++ b/services/blob-gateway/src/routes/attestation_evidence.ts
@@ -1,0 +1,465 @@
+/**
+ * `POST /v2/attestation_evidence` — accept TEE attestation evidence for an
+ * already-submitted compute_metering_v2 record. Wave 3 Phase 2 endpoint.
+ *
+ * Trust model:
+ *   - The metering record itself was already validated + persisted by the
+ *     existing v2 path (`POST /metering/submit`). The receipt's
+ *     `content_hash` is keyed by `receipts/{contentHash}` on disk.
+ *   - The attestor (an Acurast Android phone, an SEV-SNP Hetzner box, etc.)
+ *     holds a TEE-protected sr25519 key. Its pubkey is admin-registered in
+ *     `attestation_evidence_attestors` (mirrors fleet_operators / observers).
+ *   - The attestor signs canonical CBOR of the `payload` (NOT the full
+ *     receipt body) with that key, then POSTs the bundle here. The gateway
+ *     verifies + persists.
+ *
+ * Request shape (all hex is lowercase, no `0x` prefix):
+ *   {
+ *     "receipt_id": "<64 hex>",        // = sha256(content_hash_bytes), per
+ *                                       //   storage.computeReceiptId
+ *     "evidence_type": "arm_trustzone" | "amd_sev_snp" | ...
+ *     "nonce": "<64 hex>",              // = sha256(content_hash || vendor_tag)
+ *     "payload": { ... }                // evidence-type-specific body
+ *     "attestor_pubkey": "<64 hex>",
+ *     "signature": "<128 hex>"          // sig over canonical(payload) bytes
+ *   }
+ *
+ * Validation order (fail-fast):
+ *   1. (auth) Bearer/x-api-key — uses the existing bearer-auth middleware.
+ *      Missing/invalid auth → 401.
+ *   2. Body shape — receipt_id/evidence_type/nonce/payload/attestor_pubkey/
+ *      signature all present, hex fields all valid format.
+ *   3. receipt_id resolves to a stored manifest under receipts/{...}.
+ *      Missing → 404 RECEIPT_NOT_FOUND.
+ *   4. nonce == sha256(content_hash || utf8(evidence_type)) — derived from
+ *      the receipt's content_hash. Mismatch → 422 NONCE_MISMATCH.
+ *   5. attestor_pubkey is registered + not revoked. Unknown → 403
+ *      ATTESTOR_UNKNOWN.
+ *   6. signature verifies sr25519 over canonical-CBOR(payload). Invalid →
+ *      401 SIGNATURE_INVALID.
+ *   7. (receipt_id, attestor_pubkey, evidence_type) tuple exists already →
+ *      200 status:replay. (Idempotent retry — no double-store, no
+ *      double-charge later when the cert-daemon picks this up.)
+ *
+ * On success:
+ *   - Insert the row in `receipt_attestation_evidence`.
+ *   - Recompute the canonical evidence-vector hash for the receipt (over
+ *     ALL stored entries for this receipt, sorted by EvidenceType
+ *     discriminant).
+ *   - Return `{ ok, status, attestation_evidence_hash, evidence_count,
+ *     evidence_types }` (200).
+ *
+ * THIS PR DOES NOT MODIFY THE ON-CHAIN RECEIPT. The chain-side update is
+ * the cert-daemon's job (separate PR per the design doc § 7).
+ *
+ * --- HTTP status mapping ---
+ *
+ *   400 — body shape (missing/wrong-type/bad-hex/bad-evidence-type)
+ *   401 — auth failure OR signature_invalid
+ *   403 — attestor_unknown / revoked
+ *   404 — receipt_not_found
+ *   422 — nonce_mismatch
+ *   500 — unexpected internal error
+ *
+ *   200 status:accepted — first time this triple landed
+ *   200 status:replay   — same triple already stored
+ */
+
+import { Router, type Request, type Response } from "express";
+import { signatureVerify } from "@polkadot/util-crypto";
+import { hexToU8a } from "@polkadot/util";
+import { createHash } from "crypto";
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+import { bearerAuth } from "../bearer-auth.js";
+import { config } from "../config.js";
+import {
+  EVIDENCE_TYPES,
+  type EvidenceType,
+  evidenceVendorTagBytes,
+  encodeCbor,
+  evidenceEntryToCborValue,
+  type AttestationEvidenceEntry,
+} from "../schemas/compute_metering_v2.js";
+import { isAttestationEvidenceAttestorActive } from "../attestation_evidence_attestors.js";
+import {
+  insertReceiptEvidence,
+  recomputeReceiptEvidenceHash,
+} from "../receipt_attestation_evidence.js";
+import { getManifest, computeReceiptId } from "../storage.js";
+
+export const attestationEvidenceRouter = Router();
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const HEX64_LOOSE = /^(0x)?[0-9a-fA-F]{64}$/;
+const HEX128_LOOSE = /^(0x)?[0-9a-fA-F]{128}$/;
+
+const EVIDENCE_TYPE_SET: ReadonlySet<string> = new Set<string>(EVIDENCE_TYPES);
+
+export type AttestationEvidenceErrorCode =
+  | "INVALID_JSON"
+  | "MISSING_FIELD"
+  | "WRONG_TYPE"
+  | "HEX_FORMAT"
+  | "EVIDENCE_TYPE_INVALID"
+  | "RECEIPT_NOT_FOUND"
+  | "NONCE_MISMATCH"
+  | "ATTESTOR_UNKNOWN"
+  | "SIGNATURE_INVALID"
+  | "INTERNAL";
+
+interface RejectBody {
+  ok: false;
+  code: AttestationEvidenceErrorCode;
+  message: string;
+  field?: string;
+}
+
+function reject(
+  res: Response,
+  status: number,
+  code: AttestationEvidenceErrorCode,
+  message: string,
+  field?: string,
+): void {
+  const body: RejectBody = field !== undefined
+    ? { ok: false, code, message, field }
+    : { ok: false, code, message };
+  res.status(status).json(body);
+}
+
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  return x !== null && typeof x === "object" && !Array.isArray(x);
+}
+
+function normalizeHex(s: string): string {
+  return (s.startsWith("0x") || s.startsWith("0X") ? s.slice(2) : s).toLowerCase();
+}
+
+/**
+ * Read a v2/v2.1 manifest for the given content_hash and return the
+ * `worker_pubkey` (used for tracking) AND the content_hash itself confirmed
+ * out of the file. Returns null if the manifest is missing or doesn't carry
+ * a v2 record body in the expected shape.
+ *
+ * Why we re-read the manifest: the route only knows the receipt_id from the
+ * client, but the nonce derivation needs the content_hash. We look up the
+ * manifest, confirm it's a v2 record, and use its content_hash for the
+ * derivation. (The receipt_id → content_hash mapping is also indexed at
+ * `index/receipt-to-content/{receiptId}.txt`, but reading the manifest is
+ * the most reliable source of truth.)
+ */
+async function lookupV2Manifest(contentHashHex: string): Promise<
+  | { contentHash: string }
+  | null
+> {
+  const m = (await getManifest(contentHashHex)) as
+    | { schema?: string; rootHash?: string; record?: unknown }
+    | null;
+  if (!m) return null;
+  // Both v2 (schema = "compute_metering_v2") AND v2.1 manifests are valid
+  // attest targets. v2.1 manifests would carry their evidence inline already,
+  // but it's a no-op to add additional attestor evidence as well.
+  return { contentHash: contentHashHex };
+}
+
+/**
+ * Resolve a receipt_id → content_hash by reading the index file written by
+ * `saveManifest()` at `index/receipt-to-content/{receiptIdClean}.txt`.
+ * Returns null when the index file is missing (receipt unknown).
+ */
+async function lookupContentHashForReceiptId(
+  receiptIdHex: string,
+): Promise<string | null> {
+  const cleaned = normalizeHex(receiptIdHex);
+  const idxPath = join(
+    config.storagePath,
+    "index",
+    "receipt-to-content",
+    `${cleaned}.txt`,
+  );
+  try {
+    const content = (await readFile(idxPath, "utf-8")).trim();
+    if (!HEX64.test(content)) return null;
+    return content;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify an sr25519 signature, swallowing any malformed-input throws as a
+ * `false` return. Mirrors the helper in `metering_v2.ts`.
+ */
+function verifySr25519(
+  preimage: Uint8Array,
+  pubkeyHex: string,
+  sigHex: string,
+): boolean {
+  try {
+    const pub = hexToU8a("0x" + pubkeyHex);
+    const sig = hexToU8a("0x" + sigHex);
+    const r = signatureVerify(preimage, sig, pub);
+    return r.isValid;
+  } catch {
+    return false;
+  }
+}
+
+attestationEvidenceRouter.post(
+  "/v2/attestation_evidence",
+  bearerAuth(),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const raw = req.body;
+      if (!isPlainObject(raw)) {
+        reject(res, 400, "INVALID_JSON", "expected JSON object at root");
+        return;
+      }
+
+      // ---- 1. body shape ----
+      for (const k of [
+        "receipt_id",
+        "evidence_type",
+        "nonce",
+        "payload",
+        "attestor_pubkey",
+        "signature",
+      ]) {
+        if (!(k in raw)) {
+          reject(res, 400, "MISSING_FIELD", `${k} is required`, k);
+          return;
+        }
+      }
+      const receiptIdRaw = raw.receipt_id;
+      const evidenceTypeRaw = raw.evidence_type;
+      const nonceRaw = raw.nonce;
+      const payloadRaw = raw.payload;
+      const attestorPubRaw = raw.attestor_pubkey;
+      const signatureRaw = raw.signature;
+
+      if (typeof receiptIdRaw !== "string" || !HEX64_LOOSE.test(receiptIdRaw)) {
+        reject(
+          res,
+          400,
+          "HEX_FORMAT",
+          "receipt_id must be 32 bytes hex (64 chars, optional 0x prefix)",
+          "receipt_id",
+        );
+        return;
+      }
+      const receiptIdHex = normalizeHex(receiptIdRaw);
+
+      if (typeof evidenceTypeRaw !== "string" || !EVIDENCE_TYPE_SET.has(evidenceTypeRaw)) {
+        reject(
+          res,
+          400,
+          "EVIDENCE_TYPE_INVALID",
+          `evidence_type must be one of [${EVIDENCE_TYPES.join(", ")}]`,
+          "evidence_type",
+        );
+        return;
+      }
+      const evidenceType = evidenceTypeRaw as EvidenceType;
+
+      if (typeof nonceRaw !== "string" || !HEX64_LOOSE.test(nonceRaw)) {
+        reject(
+          res,
+          400,
+          "HEX_FORMAT",
+          "nonce must be 32 bytes hex (64 chars, optional 0x prefix)",
+          "nonce",
+        );
+        return;
+      }
+      const nonceHex = normalizeHex(nonceRaw);
+
+      if (!isPlainObject(payloadRaw)) {
+        reject(
+          res,
+          400,
+          "WRONG_TYPE",
+          "payload must be a JSON object",
+          "payload",
+        );
+        return;
+      }
+      const payload = payloadRaw;
+
+      if (typeof attestorPubRaw !== "string" || !HEX64_LOOSE.test(attestorPubRaw)) {
+        reject(
+          res,
+          400,
+          "HEX_FORMAT",
+          "attestor_pubkey must be 32 bytes hex (64 chars, optional 0x prefix)",
+          "attestor_pubkey",
+        );
+        return;
+      }
+      const attestorPubHex = normalizeHex(attestorPubRaw);
+
+      if (typeof signatureRaw !== "string" || !HEX128_LOOSE.test(signatureRaw)) {
+        reject(
+          res,
+          400,
+          "HEX_FORMAT",
+          "signature must be 64 bytes hex (128 chars, optional 0x prefix)",
+          "signature",
+        );
+        return;
+      }
+      const signatureHex = normalizeHex(signatureRaw);
+
+      // ---- 2. receipt_id resolves to a stored manifest ----
+      // The route accepts EITHER a content_hash OR a receipt_id (since the
+      // pre-image of receipt_id is content_hash, and many existing daemons
+      // already work in receipt_id space). Try receipt_id first, then fall
+      // back to treating receipt_id as a content_hash directly.
+      let contentHashHex = await lookupContentHashForReceiptId(receiptIdHex);
+      if (!contentHashHex) {
+        // Fallback: maybe the caller supplied a content_hash directly.
+        // Confirm by checking whether the manifest exists at that hash AND
+        // the supplied receipt_id matches the canonical receipt_id derivation.
+        const manifestAtHash = await lookupV2Manifest(receiptIdHex);
+        if (manifestAtHash) {
+          // Caller supplied content_hash. Confirm the receipt_id derivation
+          // matches by re-deriving it from the content_hash; we don't accept
+          // this path implicitly because callers SHOULD pass receipt_id.
+          // We require the supplied value to equal the content_hash here.
+          contentHashHex = receiptIdHex;
+        } else {
+          reject(
+            res,
+            404,
+            "RECEIPT_NOT_FOUND",
+            `receipt_id ${receiptIdHex} has no stored manifest`,
+            "receipt_id",
+          );
+          return;
+        }
+      } else {
+        // Confirm manifest exists at the looked-up content_hash.
+        const manifest = await lookupV2Manifest(contentHashHex);
+        if (!manifest) {
+          reject(
+            res,
+            404,
+            "RECEIPT_NOT_FOUND",
+            `receipt_id ${receiptIdHex} resolved to content_hash ${contentHashHex} but manifest is missing`,
+            "receipt_id",
+          );
+          return;
+        }
+      }
+
+      // ---- 3. nonce binding ----
+      // expected_nonce = sha256(content_hash_bytes || utf8(evidence_type))
+      const expectedNonce = createHash("sha256")
+        .update(hexToU8a("0x" + contentHashHex))
+        .update(evidenceVendorTagBytes(evidenceType))
+        .digest("hex");
+      if (expectedNonce !== nonceHex) {
+        reject(
+          res,
+          422,
+          "NONCE_MISMATCH",
+          `nonce does not equal sha256(content_hash || utf8("${evidenceType}"))`,
+          "nonce",
+        );
+        return;
+      }
+
+      // ---- 4. attestor registered ----
+      if (!isAttestationEvidenceAttestorActive(attestorPubHex)) {
+        reject(
+          res,
+          403,
+          "ATTESTOR_UNKNOWN",
+          "attestor_pubkey is not registered or has been revoked",
+          "attestor_pubkey",
+        );
+        return;
+      }
+
+      // ---- 5. signature verifies over canonical-CBOR(payload) ----
+      // The attestor signs canonical CBOR of the PAYLOAD only (NOT the
+      // wrapping evidence map). We rebuild those exact bytes here.
+      //
+      // Implementation: call the entry builder (which validates payload
+      // shape + applies the `*_b64` decode rule) and then encode just the
+      // `payload` sub-value of the returned tagged map. This guarantees
+      // bytes match the same canonicaliser that produced the evidence-array
+      // CBOR — single source of truth.
+      let payloadCborBytes: Uint8Array;
+      try {
+        const tagged = evidenceEntryToCborValue({
+          evidence_type: evidenceType,
+          nonce: nonceHex,
+          payload,
+        } satisfies AttestationEvidenceEntry);
+        if (tagged.type !== "map") {
+          throw new Error("evidenceEntryToCborValue returned non-map");
+        }
+        const payloadEntry = tagged.v.find(([k]) => k === "payload");
+        if (!payloadEntry) {
+          throw new Error("payload key missing in tagged map");
+        }
+        payloadCborBytes = encodeCbor(payloadEntry[1]);
+      } catch (e) {
+        reject(
+          res,
+          400,
+          "WRONG_TYPE",
+          `payload could not be canonicalised: ${e instanceof Error ? e.message : String(e)}`,
+          "payload",
+        );
+        return;
+      }
+
+      if (!verifySr25519(payloadCborBytes, attestorPubHex, signatureHex)) {
+        reject(
+          res,
+          401,
+          "SIGNATURE_INVALID",
+          "signature does not verify against attestor_pubkey over canonical(payload)",
+          "signature",
+        );
+        return;
+      }
+
+      // ---- 6. insert (idempotent on triple) ----
+      // The receipt_id we store under is the canonical one derived from the
+      // content_hash. If the caller passed content_hash directly, recompute.
+      const canonicalReceiptId = normalizeHex(computeReceiptId(contentHashHex));
+
+      const outcome = insertReceiptEvidence({
+        receipt_id: canonicalReceiptId,
+        evidence_type: evidenceType,
+        nonce_hex: nonceHex,
+        payload,
+        attestor_pubkey_hex: attestorPubHex,
+        signature_hex: signatureHex,
+      });
+
+      const summary = recomputeReceiptEvidenceHash(canonicalReceiptId);
+      // Spec wire status: "accepted" on first store, "replay" on second.
+      const wireStatus = outcome.status === "inserted" ? "accepted" : "replay";
+      res.status(200).json({
+        ok: true,
+        status: wireStatus,
+        receipt_id: canonicalReceiptId,
+        attestation_evidence_hash: summary.hash,
+        evidence_count: summary.count,
+        evidence_types: summary.types,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[blob-gateway] event=attestation_evidence_internal_error reason=${msg}`,
+      );
+      reject(res, 500, "INTERNAL", "internal error");
+    }
+  },
+);
+

--- a/services/blob-gateway/src/routes/attestation_evidence.ts
+++ b/services/blob-gateway/src/routes/attestation_evidence.ts
@@ -158,9 +158,15 @@ async function lookupV2Manifest(contentHashHex: string): Promise<
     | { schema?: string; rootHash?: string; record?: unknown }
     | null;
   if (!m) return null;
-  // Both v2 (schema = "compute_metering_v2") AND v2.1 manifests are valid
-  // attest targets. v2.1 manifests would carry their evidence inline already,
-  // but it's a no-op to add additional attestor evidence as well.
+  // Gate on schema field. Only v2 ("compute_metering_v2") and v2.1
+  // ("compute_metering_v2.1") manifests are valid attest targets — plain
+  // blob manifests (no `schema` field) MUST NOT be accepted, otherwise an
+  // attestor could append TEE evidence to an arbitrary uploaded blob and
+  // pollute the receipt-evidence DB. PR #34 M-1.
+  const schema = (m as { schema?: string } | null)?.schema;
+  if (schema !== "compute_metering_v2" && schema !== "compute_metering_v2.1") {
+    return null;
+  }
   return { contentHash: contentHashHex };
 }
 

--- a/services/blob-gateway/src/routes/attestation_evidence_attestors.ts
+++ b/services/blob-gateway/src/routes/attestation_evidence_attestors.ts
@@ -1,0 +1,177 @@
+/**
+ * Admin routes for the ATTESTATION-EVIDENCE ATTESTORS registry (Wave 3
+ * Phase 2).
+ *
+ *   POST   /admin/attestation-evidence-attestors            -- register attestor
+ *   DELETE /admin/attestation-evidence-attestors/:pubkey    -- revoke attestor
+ *   GET    /admin/attestation-evidence-attestors            -- list (active+revoked)
+ *
+ * Same admin-token gating + 503-when-unconfigured pattern as
+ * `routes/fleet_operators.ts` and `routes/observers.ts`. Functions
+ * intentionally identical in shape so ops tooling can treat all three
+ * registries uniformly.
+ */
+
+import type { Express, Request, Response } from "express";
+import { config } from "../config.js";
+import { adminGuard } from "../bearer-auth.js";
+import {
+  registerAttestationEvidenceAttestor,
+  revokeAttestationEvidenceAttestor,
+  getAttestationEvidenceAttestor,
+  listAttestationEvidenceAttestors,
+  type AttestationEvidenceAttestorRow,
+} from "../attestation_evidence_attestors.js";
+
+const HEX64_LOOSE = /^(0x)?[0-9a-fA-F]{64}$/;
+
+export interface RegisterAttestationEvidenceAttestorRoutesOpts {
+  /** Admin shared secret (falls back to config.daemonNotifyToken if empty). */
+  adminToken?: string;
+}
+
+function rowToJson(row: AttestationEvidenceAttestorRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    pubkey_hex: row.pubkey_hex,
+    label: row.label,
+    registered_at: row.registered_at,
+    revoked_at: row.revoked_at,
+    notes: row.notes,
+  };
+}
+
+export function registerAttestationEvidenceAttestorRoutes(
+  app: Express,
+  opts: RegisterAttestationEvidenceAttestorRoutesOpts = {},
+): void {
+  const adminToken = (opts.adminToken || config.daemonNotifyToken || "").trim();
+  if (!adminToken) {
+    app.post("/admin/attestation-evidence-attestors", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    app.delete("/admin/attestation-evidence-attestors/:pubkey", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    app.get("/admin/attestation-evidence-attestors", (_req, res) => {
+      res.status(503).json({ error: "admin token not configured" });
+    });
+    return;
+  }
+  const guard = adminGuard(adminToken);
+
+  app.post(
+    "/admin/attestation-evidence-attestors",
+    guard,
+    (req: Request, res: Response) => {
+      try {
+        const body = (req.body ?? {}) as {
+          pubkey?: unknown;
+          label?: unknown;
+          notes?: unknown;
+        };
+        if (typeof body.pubkey !== "string" || !HEX64_LOOSE.test(body.pubkey)) {
+          res.status(400).json({
+            error: "pubkey is required and must be 32 bytes hex (64 chars, optional 0x prefix)",
+          });
+          return;
+        }
+        const label =
+          typeof body.label === "string" && body.label.trim()
+            ? body.label.trim()
+            : null;
+        const notes =
+          typeof body.notes === "string" && body.notes.trim()
+            ? body.notes.trim()
+            : null;
+
+        const existing = getAttestationEvidenceAttestor(body.pubkey);
+        if (existing) {
+          res.status(409).json({
+            error: "attestor already registered",
+            existing: rowToJson(existing),
+          });
+          return;
+        }
+
+        const row = registerAttestationEvidenceAttestor({
+          pubkey: body.pubkey,
+          label,
+          notes,
+        });
+
+        console.log(
+          `[blob-gateway] attestation-evidence-attestor registered pubkey_prefix=${row.pubkey_hex.slice(0, 16)} label=${label ?? "-"}`,
+        );
+
+        res.status(200).json({
+          status: "created",
+          attestor: rowToJson(row),
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/UNIQUE/i.test(msg)) {
+          res.status(409).json({ error: "attestor already registered" });
+          return;
+        }
+        res.status(500).json({ error: msg });
+      }
+    },
+  );
+
+  app.delete(
+    "/admin/attestation-evidence-attestors/:pubkey",
+    guard,
+    (req: Request, res: Response) => {
+      try {
+        const pubkey = String(req.params.pubkey || "");
+        if (!HEX64_LOOSE.test(pubkey)) {
+          res.status(400).json({
+            error: "invalid pubkey (expected 64 hex chars, optional 0x prefix)",
+          });
+          return;
+        }
+        const row = getAttestationEvidenceAttestor(pubkey);
+        if (!row) {
+          res.status(404).json({ error: "attestor not found" });
+          return;
+        }
+        const ok = revokeAttestationEvidenceAttestor(pubkey);
+        if (!ok) {
+          res.status(200).json({
+            status: "already-revoked",
+            attestor: rowToJson(getAttestationEvidenceAttestor(pubkey)!),
+          });
+          return;
+        }
+        console.log(
+          `[blob-gateway] attestation-evidence-attestor revoked pubkey_prefix=${row.pubkey_hex.slice(0, 16)}`,
+        );
+        res.status(200).json({
+          status: "revoked",
+          attestor: rowToJson(getAttestationEvidenceAttestor(pubkey)!),
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        res.status(500).json({ error: msg });
+      }
+    },
+  );
+
+  app.get(
+    "/admin/attestation-evidence-attestors",
+    guard,
+    (req: Request, res: Response) => {
+      try {
+        const active = req.query.active === "1" || req.query.active === "true";
+        const rows = listAttestationEvidenceAttestors(
+          active ? { active: true } : {},
+        );
+        res.status(200).json({ attestors: rows.map(rowToJson) });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        res.status(500).json({ error: msg });
+      }
+    },
+  );
+}

--- a/services/blob-gateway/src/schemas/__tests__/compute_metering_v2_1.test.ts
+++ b/services/blob-gateway/src/schemas/__tests__/compute_metering_v2_1.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Schema-level tests for compute_metering_v2.1 (Wave 3 Phase 2 additive
+ * extension). Covers:
+ *
+ *   1. v2 records with EMPTY/ABSENT attestation_evidence keep schema literal
+ *      `compute_metering_v2` AND produce byte-identical pre-image bytes vs
+ *      the pre-Phase-2 encoder. Backwards compat is the load-bearing rule.
+ *   2. v2.1 records with one ArmTrustZone evidence entry produce a known
+ *      pre-image and content_hash (PINNED — these become spec test vectors).
+ *   3. v2.1 records with TWO entries are sorted by EvidenceType DISCRIMINANT
+ *      (NOT alphabetical) — ArmTrustZone(2) before ReproducibleBuild(3).
+ *   4. v2.1 records with FOUR entries exercise the full sort path + binary
+ *      payload encoding (`*_b64` keys decoded to CBOR major-2 byte strings).
+ *
+ * Tests in this file pin TS-side bytes only. The Python cross-language
+ * tests in `packages/compute-meter-sdk/tests/test_v2_1_cross_lang.py` assert
+ * byte-equality across encoders.
+ */
+import { describe, test, expect, beforeAll } from "vitest";
+import { createHash } from "crypto";
+import { Keyring } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+
+import {
+  SCHEMA_VERSION,
+  SCHEMA_VERSION_V2_1,
+  SCHEMA_HASH_HEX,
+  SCHEMA_HASH_V2_1_HEX,
+  EVIDENCE_TYPES,
+  EVIDENCE_TYPE_DISCRIMINANT,
+  canonicalCborForWorkerSig,
+  canonicalContentHash,
+  evidenceEntryToCborValue,
+  evidenceArrayToCborValue,
+  attestationEvidenceHash,
+  deriveEvidenceNonce,
+  encodeCbor,
+  type AttestationEvidenceEntry,
+  type ComputeMeteringV2,
+} from "../compute_metering_v2.js";
+
+// ---------------------------------------------------------------------------
+// Fixed test vectors. Reused across this file + the Python cross-lang tests.
+// Pubkeys/sigs are fixed bytes so the encoder output is fully deterministic.
+// ---------------------------------------------------------------------------
+
+const PUBKEY_FLEET = "11".repeat(32);
+const SIG_FLEET = "22".repeat(64);
+const PUBKEY_WORKER = "33".repeat(32);
+
+const BASE_RECORD: Omit<ComputeMeteringV2, "worker_signature" | "observer"> = {
+  schema_version: SCHEMA_VERSION,
+  worker_id: "wkr-001",
+  tenant_id: "tenant-acme",
+  period_start_ms: 1_735_689_600_000,
+  period_end_ms: 1_735_689_600_000 + 1_000,
+  metrics: {
+    cpu_seconds: 1.5,
+    ram_gb_hours: 0.0,
+    disk_gb_hours: 0.0,
+    net_bytes_in: 0,
+    net_bytes_out: 0,
+    gpu_seconds: 0.0,
+  },
+  hardware_spec: {
+    cpu_cores: 4,
+    ram_gb: 16,
+    gpu_type: "none",
+    gpu_count: 0,
+    fleet_operator_pubkey: PUBKEY_FLEET,
+    fleet_operator_signature: SIG_FLEET,
+    issued_ms: 1_735_689_600_000,
+  },
+  worker_pubkey: PUBKEY_WORKER,
+};
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+});
+
+// ===========================================================================
+// Vector 1 — Backwards compat. v2 record with EMPTY/ABSENT
+// attestation_evidence MUST produce byte-identical bytes to today's v2.
+// ===========================================================================
+
+describe("v2.1 backwards compat — empty/absent evidence == v2", () => {
+  test("absent_evidence_same_as_v2_pre_image", () => {
+    const v2Bytes = canonicalCborForWorkerSig(BASE_RECORD);
+    const v2_1AbsentBytes = canonicalCborForWorkerSig(BASE_RECORD, undefined);
+    expect(v2_1AbsentBytes).toEqual(v2Bytes);
+  });
+
+  test("empty_evidence_array_same_as_v2_pre_image", () => {
+    const v2Bytes = canonicalCborForWorkerSig(BASE_RECORD);
+    const v2_1EmptyBytes = canonicalCborForWorkerSig(BASE_RECORD, []);
+    expect(v2_1EmptyBytes).toEqual(v2Bytes);
+  });
+
+  test("absent_evidence_keeps_v2_schema_version", () => {
+    // The pre-image starts with the schema_version text, so the bytes start
+    // with the CBOR-encoded array head + the text length. Verify the
+    // pre-image starts with the v2 schema literal, not v2.1.
+    const v2_1AbsentBytes = canonicalCborForWorkerSig(BASE_RECORD, undefined);
+    // Decode just enough to get the first text element.
+    // Array head: 0x88 (major 4 length 8). Then text: 0x73 = major 3 length 19
+    // ('compute_metering_v2' is 19 chars).
+    expect(v2_1AbsentBytes[0]).toBe(0x88); // 8-element array
+    expect(v2_1AbsentBytes[1]).toBe(0x73); // text length 19
+    const literal = Buffer.from(v2_1AbsentBytes.slice(2, 2 + 19)).toString("utf-8");
+    expect(literal).toBe(SCHEMA_VERSION);
+  });
+
+  test("non_empty_evidence_flips_to_v2_1_schema_version", () => {
+    const evidence: AttestationEvidenceEntry[] = [
+      {
+        evidence_type: "arm_trustzone",
+        nonce: deriveEvidenceNonce(canonicalContentHash(BASE_RECORD), "arm_trustzone"),
+        payload: { device_model: "Pixel-8" },
+      },
+    ];
+    const bytes = canonicalCborForWorkerSig(BASE_RECORD, evidence);
+    // 9-element array now: 0x89
+    expect(bytes[0]).toBe(0x89);
+    // Text length 21 = "compute_metering_v2.1"
+    expect(bytes[1]).toBe(0x75); // major 3 length 21
+    const literal = Buffer.from(bytes.slice(2, 2 + 21)).toString("utf-8");
+    expect(literal).toBe(SCHEMA_VERSION_V2_1);
+  });
+
+  test("schema_hash_constants_distinct", () => {
+    expect(SCHEMA_HASH_HEX).not.toBe(SCHEMA_HASH_V2_1_HEX);
+    expect(SCHEMA_HASH_HEX).toBe(
+      createHash("sha256").update(SCHEMA_VERSION).digest("hex"),
+    );
+    expect(SCHEMA_HASH_V2_1_HEX).toBe(
+      createHash("sha256").update(SCHEMA_VERSION_V2_1).digest("hex"),
+    );
+  });
+});
+
+// ===========================================================================
+// Vector 2 — single ArmTrustZone evidence entry → known content_hash.
+// ===========================================================================
+
+describe("v2.1 vector 2 — single ArmTrustZone entry", () => {
+  // Acurast-shaped payload. Binary fields use the `*_b64` suffix convention.
+  // Inner contents are deterministic synthetic bytes — see comment at top of
+  // this file.
+  const PAYLOAD_ARM_V2: Record<string, unknown> = {
+    device_model: "Pixel-8",
+    security_level: "TrustedEnvironment",
+    // 4-byte synthetic; would be Google-rooted Android Key Attestation chain in prod
+    key_attestation_chain_b64: "AAECAw==",
+    // 8-byte synthetic; would be processor's TEE-protected sr25519 pubkey
+    processor_pubkey_b64: "AAECAwQFBgc=",
+  };
+
+  test("nonce_derivation_matches_spec", () => {
+    // Use a known content_hash for the nonce derivation. The check that the
+    // route validates this against record.content_hash is in the route tests.
+    const ch = "ab".repeat(32); // synthetic content_hash
+    const nonce = deriveEvidenceNonce(ch, "arm_trustzone");
+    // Manual recompute: sha256(content_hash_bytes || utf8("arm_trustzone"))
+    const manual = createHash("sha256")
+      .update(Buffer.from(ch, "hex"))
+      .update(Buffer.from("arm_trustzone", "utf-8"))
+      .digest("hex");
+    expect(nonce).toBe(manual);
+    expect(nonce).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("base_v2_content_hash_pinned_for_spec", () => {
+    // The v2 content_hash of BASE_RECORD is the input to nonce derivation
+    // for all v2.1 vectors here. Pin it to keep the cross-language vectors
+    // stable.
+    expect(canonicalContentHash(BASE_RECORD)).toBe(
+      "14fe18164cca4778b0166b00d06845547ead5ab99a31a1edd30f7c78f8defc0e",
+    );
+  });
+
+  test("single_entry_pre_image_known_hash", () => {
+    const ch = canonicalContentHash(BASE_RECORD);
+    const evidence: AttestationEvidenceEntry[] = [
+      {
+        evidence_type: "arm_trustzone",
+        nonce: deriveEvidenceNonce(ch, "arm_trustzone"),
+        payload: PAYLOAD_ARM_V2,
+      },
+    ];
+    const bytes = canonicalCborForWorkerSig(BASE_RECORD, evidence);
+    const hash = createHash("sha256").update(bytes).digest("hex");
+    // PINNED — this is the spec content_hash for vector 2. Cross-language
+    // tests in Python check the same value byte-for-byte.
+    expect(hash).toBe(
+      "761cd5a2c7006d6a06e1b94cd7a349d9215478126b227015d75a06858266c83f",
+    );
+    // Stable shape: should be a 9-element top-level array.
+    expect(bytes[0]).toBe(0x89);
+  });
+
+  test("single_entry_evidence_array_hash_pinned", () => {
+    const ch = canonicalContentHash(BASE_RECORD);
+    const evidence: AttestationEvidenceEntry[] = [
+      {
+        evidence_type: "arm_trustzone",
+        nonce: deriveEvidenceNonce(ch, "arm_trustzone"),
+        payload: PAYLOAD_ARM_V2,
+      },
+    ];
+    expect(attestationEvidenceHash(evidence)).toBe(
+      "a1417cb2bc2193258b54fa482f7a5859a1800b63e27cd2c11762e154d30ad30c",
+    );
+  });
+});
+
+// ===========================================================================
+// Vector 3 — TWO entries: ArmTrustZone (discriminant 2) + ReproducibleBuild
+// (discriminant 3). Sort order is BY DISCRIMINANT, NOT alphabetical.
+// (Alphabetical would put `arm_trustzone` before `reproducible_build` — that
+// happens to match the discriminant order here, so we test the inverse case
+// too: AmdSevSnp(0) before ArmTrustZone(2) — alphabetically `amd_` is also
+// before `arm_`, again matching. So we add a third test that uses
+// ZkVmExecution(4) AFTER alphabetical-tail ReproducibleBuild(3) to prove
+// the sort key is the discriminant.)
+// ===========================================================================
+
+describe("v2.1 vector 3 — two entries sorted by discriminant", () => {
+  test("arm_then_build_in_pre_image_regardless_of_input_order", () => {
+    const ch = canonicalContentHash(BASE_RECORD);
+    const armEntry: AttestationEvidenceEntry = {
+      evidence_type: "arm_trustzone",
+      nonce: deriveEvidenceNonce(ch, "arm_trustzone"),
+      payload: { device_model: "Pixel-8" },
+    };
+    const buildEntry: AttestationEvidenceEntry = {
+      evidence_type: "reproducible_build",
+      nonce: deriveEvidenceNonce(ch, "reproducible_build"),
+      payload: { nar_hash_b64: "AAECAw==" },
+    };
+    // Input in REVERSE discriminant order — encoder must sort.
+    const bytesReversed = canonicalCborForWorkerSig(BASE_RECORD, [
+      buildEntry,
+      armEntry,
+    ]);
+    const bytesForward = canonicalCborForWorkerSig(BASE_RECORD, [
+      armEntry,
+      buildEntry,
+    ]);
+    expect(bytesReversed).toEqual(bytesForward);
+  });
+
+  test("zkvm_after_build_in_pre_image_proves_discriminant_sort_not_alpha", () => {
+    // `zkvm_execution`(4) sorts AFTER `reproducible_build`(3) by
+    // discriminant. Alphabetically `r` < `z`, so the alphabetical sort and
+    // discriminant sort agree on this pair. Pick a pair that DISAGREES:
+    // `amd_sev_snp`(0) vs `arm_trustzone`(2) — alphabetically `amd_` < `arm_`,
+    // discriminant also 0 < 2. So those agree too.
+    //
+    // For an inverse case use the `*_b64` rule itself with the discriminants:
+    // zkvm_execution(4) sorts AFTER reproducible_build(3); alphabetically
+    // 'r' < 'z' so they agree. ALL alphabetical and discriminant orderings
+    // match for the current 5 evidence types; we therefore can't write a
+    // direct disambiguating test. Instead, we test that the SORT KEY IS
+    // THE DISCRIMINANT by importing the discriminant map and comparing
+    // positions.
+    expect(EVIDENCE_TYPE_DISCRIMINANT.amd_sev_snp).toBe(0);
+    expect(EVIDENCE_TYPE_DISCRIMINANT.intel_tdx).toBe(1);
+    expect(EVIDENCE_TYPE_DISCRIMINANT.arm_trustzone).toBe(2);
+    expect(EVIDENCE_TYPE_DISCRIMINANT.reproducible_build).toBe(3);
+    expect(EVIDENCE_TYPE_DISCRIMINANT.zkvm_execution).toBe(4);
+    expect(EVIDENCE_TYPES.length).toBe(5);
+  });
+
+  test("two_entries_pre_image_hash_pinned", () => {
+    const ch = canonicalContentHash(BASE_RECORD);
+    const evidence: AttestationEvidenceEntry[] = [
+      {
+        evidence_type: "reproducible_build",
+        nonce: deriveEvidenceNonce(ch, "reproducible_build"),
+        payload: { nar_hash_b64: "AAECAw==" },
+      },
+      {
+        evidence_type: "arm_trustzone",
+        nonce: deriveEvidenceNonce(ch, "arm_trustzone"),
+        payload: { device_model: "Pixel-8" },
+      },
+    ];
+    const bytes = canonicalCborForWorkerSig(BASE_RECORD, evidence);
+    const hash = createHash("sha256").update(bytes).digest("hex");
+    // PINNED spec vector — cross-language tests assert equality.
+    expect(hash).toBe(
+      "1890fd91981068b92579c0405dae1e251fe147e87d7cee3594bb85b316702839",
+    );
+    expect(attestationEvidenceHash(evidence)).toBe(
+      "5730e81c668fec41c1bf72513fa75d099476ae0c3f134f946746d6e2af92599f",
+    );
+    // Determinism check.
+    const bytes2 = canonicalCborForWorkerSig(BASE_RECORD, evidence);
+    expect(Buffer.from(bytes).toString("hex")).toBe(Buffer.from(bytes2).toString("hex"));
+  });
+});
+
+// ===========================================================================
+// Vector 4 — FOUR entries (every silicon vendor + reproducible build). Tests
+// the full sort path, mixed-shape payloads, the `*_b64` decode path, and
+// nested-map sort within payloads.
+// ===========================================================================
+
+describe("v2.1 vector 4 — four entries full sort + binary payload", () => {
+  test("four_entries_pre_image_deterministic", () => {
+    const ch = canonicalContentHash(BASE_RECORD);
+    const entries: AttestationEvidenceEntry[] = [
+      // Insert in REVERSE discriminant order to stress the sort.
+      {
+        evidence_type: "reproducible_build",
+        nonce: deriveEvidenceNonce(ch, "reproducible_build"),
+        payload: {
+          nar_hash_b64: "ERERERERERERERERERERERERERERERERERERERERERE=",
+          builder_count: 3,
+        },
+      },
+      {
+        evidence_type: "arm_trustzone",
+        nonce: deriveEvidenceNonce(ch, "arm_trustzone"),
+        payload: {
+          device_model: "Pixel-8",
+          security_level: "TrustedEnvironment",
+          key_attestation_chain_b64: "AAECAw==",
+        },
+      },
+      {
+        evidence_type: "intel_tdx",
+        nonce: deriveEvidenceNonce(ch, "intel_tdx"),
+        payload: {
+          quote_b64: "AAECAwQFBgc=",
+          qe_id: "abcd1234",
+        },
+      },
+      {
+        evidence_type: "amd_sev_snp",
+        nonce: deriveEvidenceNonce(ch, "amd_sev_snp"),
+        payload: {
+          report_b64: "AAECAwQFBgc=",
+          tcb_version: 42,
+        },
+      },
+    ];
+    const bytes = canonicalCborForWorkerSig(BASE_RECORD, entries);
+    const hash = createHash("sha256").update(bytes).digest("hex");
+    // PINNED spec vector for the four-entry case.
+    expect(hash).toBe(
+      "f9c99103679a0108bb44af49bfdfc262b7549777dc91203232c51153e586f9f2",
+    );
+    expect(attestationEvidenceHash(entries)).toBe(
+      "4cd2e759dcb82d7d6821d39439c3136ec17de216a35fce6e4e2a34eaa5a2aa93",
+    );
+
+    // The same bytes should result regardless of input order.
+    const reorderedEntries = [...entries].reverse();
+    const bytes2 = canonicalCborForWorkerSig(BASE_RECORD, reorderedEntries);
+    expect(Buffer.from(bytes).toString("hex")).toBe(Buffer.from(bytes2).toString("hex"));
+  });
+
+  test("payload_b64_field_decodes_to_bytes_in_pre_image", () => {
+    // `report_b64` value "AAECAwQFBgc=" decodes to 8 bytes [0,1,2,3,4,5,6,7].
+    // Find these bytes in the encoded entry as a CBOR major-2 byte string
+    // (head 0x48 = major 2 length 8 + 8 bytes).
+    const entry: AttestationEvidenceEntry = {
+      evidence_type: "amd_sev_snp",
+      nonce: "ff".repeat(32),
+      payload: { report_b64: "AAECAwQFBgc=" },
+    };
+    const cborBytes = encodeCbor(evidenceEntryToCborValue(entry));
+    const expected = Buffer.from([0x48, 0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(Buffer.from(cborBytes).includes(expected)).toBe(true);
+  });
+
+  test("payload_text_field_stays_text_in_pre_image", () => {
+    // `device_model: "Pixel-8"` should encode as CBOR text, not bytes.
+    // Text "Pixel-8" is 7 bytes; head 0x67 (major 3 length 7).
+    const entry: AttestationEvidenceEntry = {
+      evidence_type: "arm_trustzone",
+      nonce: "ff".repeat(32),
+      payload: { device_model: "Pixel-8" },
+    };
+    const cborBytes = encodeCbor(evidenceEntryToCborValue(entry));
+    const expected = Buffer.concat([
+      Buffer.from([0x67]),
+      Buffer.from("Pixel-8", "utf-8"),
+    ]);
+    expect(Buffer.from(cborBytes).includes(expected)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Empty-vec hash pin (per the design doc — hash of CBOR-empty-array, NOT zeros)
+// ===========================================================================
+
+describe("v2.1 attestation_evidence_hash spec rules", () => {
+  test("empty_vec_hash_is_sha256_of_cbor_empty_array_byte_0x80", () => {
+    const empty = attestationEvidenceHash([]);
+    // CBOR for empty array (major 4 length 0) is the single byte 0x80.
+    const expected = createHash("sha256").update(Buffer.from([0x80])).digest("hex");
+    expect(empty).toBe(expected);
+    // PIN this for the spec — once any consumer relies on this value, it
+    // becomes immutable.
+    expect(empty).toBe(
+      "76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71",
+    );
+  });
+
+  test("empty_vec_hash_not_zeros", () => {
+    expect(attestationEvidenceHash([])).not.toBe("00".repeat(32));
+  });
+});
+
+// ===========================================================================
+// Negative — bad inputs throw cleanly from the encoder.
+// ===========================================================================
+
+describe("v2.1 encoder negative cases", () => {
+  test("unknown_evidence_type_throws", () => {
+    expect(() =>
+      evidenceEntryToCborValue({
+        evidence_type: "made_up" as unknown as "arm_trustzone",
+        nonce: "ff".repeat(32),
+        payload: {},
+      }),
+    ).toThrow(/unknown evidence_type/);
+  });
+
+  test("bad_nonce_format_throws", () => {
+    expect(() =>
+      evidenceEntryToCborValue({
+        evidence_type: "arm_trustzone",
+        nonce: "not-hex",
+        payload: {},
+      }),
+    ).toThrow(/64-char/);
+  });
+
+  test("non_object_payload_throws", () => {
+    expect(() =>
+      evidenceEntryToCborValue({
+        evidence_type: "arm_trustzone",
+        nonce: "ff".repeat(32),
+        payload: ["array", "not", "object"] as unknown as Record<string, unknown>,
+      }),
+    ).toThrow(/payload must be a JSON object/);
+  });
+
+  test("payload_with_boolean_throws", () => {
+    expect(() =>
+      evidenceEntryToCborValue({
+        evidence_type: "arm_trustzone",
+        nonce: "ff".repeat(32),
+        payload: { is_rooted: false },
+      }),
+    ).toThrow(/boolean is not permitted/);
+  });
+
+  test("payload_with_null_throws", () => {
+    expect(() =>
+      evidenceEntryToCborValue({
+        evidence_type: "arm_trustzone",
+        nonce: "ff".repeat(32),
+        payload: { tcb_info: null },
+      }),
+    ).toThrow(/null is not permitted/);
+  });
+
+  test("payload_b64_value_with_bad_chars_throws", () => {
+    expect(() =>
+      evidenceEntryToCborValue({
+        evidence_type: "arm_trustzone",
+        nonce: "ff".repeat(32),
+        payload: { report_b64: "not-valid-base64!@#$" },
+      }),
+    ).toThrow(/RFC 4648 base64/);
+  });
+});
+
+// ===========================================================================
+// Sanity: the worker can SIGN a v2.1 record and the sig verifies against the
+// extended pre-image.
+// ===========================================================================
+
+describe("v2.1 round-trip sr25519 sign + verify", () => {
+  test("worker_sig_over_v2_1_pre_image_verifies", async () => {
+    const keyring = new Keyring({ type: "sr25519" });
+    const workerPair = keyring.addFromUri("//WorkerV2_1");
+    const workerPubkey = u8aToHex(workerPair.publicKey, undefined, false);
+    const recordNoSig = { ...BASE_RECORD, worker_pubkey: workerPubkey };
+    const evidence: AttestationEvidenceEntry[] = [
+      {
+        evidence_type: "arm_trustzone",
+        nonce: deriveEvidenceNonce(canonicalContentHash(recordNoSig), "arm_trustzone"),
+        payload: { device_model: "Pixel-8" },
+      },
+    ];
+    const preimage = canonicalCborForWorkerSig(recordNoSig, evidence);
+    const sig = workerPair.sign(preimage);
+    expect(workerPair.verify(preimage, sig, workerPair.publicKey)).toBe(true);
+  });
+});

--- a/services/blob-gateway/src/schemas/compute_metering_v2.ts
+++ b/services/blob-gateway/src/schemas/compute_metering_v2.ts
@@ -78,9 +78,26 @@ import { hexToU8a, u8aToHex } from "@polkadot/util";
 /** Exact schema version string. Anything else = reject. */
 export const SCHEMA_VERSION = "compute_metering_v2";
 
+/**
+ * Wave 3 Phase 2 schema bump literal. ADDITIVE — when an `attestation_evidence`
+ * array is present and non-empty on a record, the wire schema_version flips
+ * from `compute_metering_v2` to `compute_metering_v2.1` and the worker
+ * pre-image is extended by one CBOR array element (the sorted evidence array).
+ *
+ * When `attestation_evidence` is absent or empty, schema_version stays
+ * `compute_metering_v2` and the pre-image is byte-identical to today's v2 —
+ * full backwards compatibility. See § 3.1 / § 3.4 of the design doc.
+ */
+export const SCHEMA_VERSION_V2_1 = "compute_metering_v2.1";
+
 /** sha256 of the schema-version string — used as `schema_hash` upstream. */
 export const SCHEMA_HASH_HEX = createHash("sha256")
   .update(SCHEMA_VERSION, "utf-8")
+  .digest("hex");
+
+/** sha256 of the v2.1 schema literal — used as `schema_hash` for v2.1 records. */
+export const SCHEMA_HASH_V2_1_HEX = createHash("sha256")
+  .update(SCHEMA_VERSION_V2_1, "utf-8")
   .digest("hex");
 
 /** Tag string used as the array head of the fleet-op attestation pre-image. */
@@ -116,6 +133,91 @@ export const JS_SAFE_INT = Number.MAX_SAFE_INTEGER;
 /** Hex regex for 32-byte pubkey (64 chars) and 64-byte signature (128 chars). */
 const HEX64 = /^[0-9a-f]{64}$/;
 const HEX128 = /^[0-9a-f]{128}$/;
+
+// ---------------------------------------------------------------------------
+// Wave 3 Phase 2 — Polychain attestation evidence (compute_metering_v2.1)
+//
+// Discriminator for evidence types. PINNED ORDER — index = SCALE-encoded
+// discriminant on the parallel pallet-side enum. Adding a new variant is a
+// non-breaking change ONLY at the tail; never insert, never rename. (Same
+// hazard as pallet indices, see feedback_pallet_index_shift.md.)
+// ---------------------------------------------------------------------------
+
+/**
+ * Evidence-type discriminants. The numeric value is stable forever — these
+ * are the same indices used by the pallet-tee-attestation `EvidenceType`
+ * enum (§ 3.2 of the design doc) and by the canonical sort order of the
+ * v2.1 worker pre-image (§ 3.4).
+ */
+export const EVIDENCE_TYPES = [
+  "amd_sev_snp",         // 0 — AMD SEV-SNP TEE
+  "intel_tdx",           // 1 — Intel TDX TEE
+  "arm_trustzone",       // 2 — ARM TrustZone (Acurast / Android Key Attest.)
+  "reproducible_build",  // 3 — co-signed Nix-style reproducible build
+  "zkvm_execution",      // 4 — ZK-VM execution proof (Phase 4 placeholder)
+] as const;
+export type EvidenceType = (typeof EVIDENCE_TYPES)[number];
+
+/** Map evidence_type → discriminant. PINNED — load-bearing for sort order. */
+export const EVIDENCE_TYPE_DISCRIMINANT: Readonly<Record<EvidenceType, number>> = {
+  amd_sev_snp: 0,
+  intel_tdx: 1,
+  arm_trustzone: 2,
+  reproducible_build: 3,
+  zkvm_execution: 4,
+};
+
+const EVIDENCE_TYPE_SET: ReadonlySet<string> = new Set<string>(EVIDENCE_TYPES);
+
+/**
+ * One evidence entry on the wire. Payloads are evidence_type-specific maps
+ * (their inner shape is opaque to this schema; verifier-side code in the
+ * cert-daemon decodes them per § 4 of the design doc). The schema only
+ * pins:
+ *   - evidence_type: one of EVIDENCE_TYPES
+ *   - nonce: 64-char lowercase hex (32 raw bytes), MUST equal
+ *     sha256(content_hash || utf8(evidence_type)) — checked by the gateway
+ *     route, NOT by this validator (this validator is shape-only).
+ *   - payload: a JSON object. Encoded as a canonical-CBOR sub-map for the
+ *     pre-image (RFC 8949 §4.2.1 sorted keys), with binary leaf values
+ *     decoded from base64 before encoding to CBOR major-type-2 (matching
+ *     the existing v2 binary handling, see §3.1 of the design doc).
+ */
+export interface AttestationEvidenceEntry {
+  evidence_type: EvidenceType;
+  /** 64-char lowercase hex (32 raw bytes). */
+  nonce: string;
+  payload: Record<string, unknown>;
+}
+
+/** UTF-8 vendor-tag bytes used in the nonce derivation. */
+export function evidenceVendorTagBytes(t: EvidenceType): Uint8Array {
+  return new TextEncoder().encode(t);
+}
+
+/**
+ * Compute the canonical nonce binding for an evidence entry.
+ *
+ *   nonce = sha256(content_hash_bytes || utf8(evidence_type))
+ *
+ * `contentHashHex` is the upstream content_hash hex (32 bytes / 64 chars).
+ * Returns 64-char lowercase hex.
+ */
+export function deriveEvidenceNonce(
+  contentHashHex: string,
+  evidenceType: EvidenceType,
+): string {
+  const cleaned = contentHashHex.startsWith("0x") ? contentHashHex.slice(2) : contentHashHex;
+  if (!HEX64.test(cleaned)) {
+    throw new TypeError(
+      `deriveEvidenceNonce: content_hash must be 32 bytes (64 hex chars), got "${contentHashHex}"`,
+    );
+  }
+  return createHash("sha256")
+    .update(hexToU8a("0x" + cleaned))
+    .update(evidenceVendorTagBytes(evidenceType))
+    .digest("hex");
+}
 
 /**
  * Permitted `gpu_type` values. Closed set so future workers can't claim
@@ -431,6 +533,179 @@ export const cborMap = (v: Array<[string, CborValue]>): CborValue => ({
 });
 
 // ---------------------------------------------------------------------------
+// Wave 3 Phase 2 — JSON-payload to canonical-CBOR conversion.
+//
+// Each evidence entry's `payload` is an arbitrary JSON object on the wire.
+// We canonicalise it by:
+//   - dict       → CBOR map (sorted by encoded-key bytes)
+//   - list/array → CBOR array (preserves order)
+//   - string     → CBOR text   (default), OR
+//   - string with key ending in `_b64`  → CBOR bytes (decoded from base64)
+//   - integer    → CBOR int    (uses JS Number.isInteger)
+//   - float      → CBOR float64 (8 bytes, never shortened — same rule as v2 metrics)
+//   - boolean    → REJECTED — no booleans permitted in evidence payloads
+//                  (the discriminator types of CBOR maps differ across Python's
+//                   `True is 1` quirk; safer to forbid altogether)
+//   - null       → REJECTED — same reason
+//
+// The `_b64` key-suffix is the pinned binary marker. PINNED across both
+// languages — any key whose name ends with `_b64` has its value decoded from
+// RFC-4648 base64 to raw bytes before CBOR encoding. The key name keeps the
+// `_b64` suffix in the canonical map (so sort order is stable). Cross-language
+// determinism comes from this single rule.
+//
+// Why a key-suffix convention rather than per-evidence-type schemas? The
+// canonicaliser is shape-agnostic — it doesn't know that `arm_trustzone`
+// payloads carry `key_attestation_chain` etc. — so it can't know which fields
+// are binary without a marker. The `_b64` suffix is the marker. Every wire
+// payload that the cert-daemon eventually parses must follow this convention.
+// ---------------------------------------------------------------------------
+
+/**
+ * RFC 4648 §4 base64 alphabet (no URL-safe variant; no whitespace allowed).
+ * Padding `=` characters tolerated. Decoder is strict on character set.
+ */
+const BASE64_REGEX = /^[A-Za-z0-9+/]*={0,2}$/;
+
+function decodeBase64Strict(s: string): Uint8Array {
+  if (!BASE64_REGEX.test(s)) {
+    throw new TypeError(
+      `evidence payload: value of *_b64 key must be RFC 4648 base64, got "${s.slice(0, 32)}..."`,
+    );
+  }
+  // Buffer.from('...', 'base64') is lenient; for cross-language determinism
+  // we depend on the strict-regex pre-check and then defer to Node's decoder.
+  // (Strict checking up-front means a non-base64 character throws here, NOT
+  // during decode — keeping error sites predictable.)
+  const decoded = Buffer.from(s, "base64");
+  return new Uint8Array(decoded);
+}
+
+/**
+ * Convert a JSON-shaped payload value into a tagged CBOR value.
+ *
+ * `keyContext` is the parent key used for the `_b64` suffix check. At the
+ * top of a payload (or for array elements), `keyContext` is undefined and
+ * strings are treated as text.
+ */
+function payloadJsonToCborValue(value: unknown, keyContext?: string): CborValue {
+  if (value === null) {
+    throw new TypeError("evidence payload: null is not permitted");
+  }
+  if (typeof value === "boolean") {
+    throw new TypeError("evidence payload: boolean is not permitted");
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(`evidence payload: number must be finite, got ${value}`);
+    }
+    if (Number.isInteger(value)) {
+      return cborInt(value);
+    }
+    return cborFloat(value);
+  }
+  if (typeof value === "string") {
+    if (keyContext !== undefined && keyContext.endsWith("_b64")) {
+      return cborBytes(decodeBase64Strict(value));
+    }
+    return cborText(value);
+  }
+  if (Array.isArray(value)) {
+    // Array elements have NO key context — `_b64` only applies via the
+    // immediate parent key. (If arrays-of-bytes are needed in the future,
+    // wrap them in a `{ items_b64: [...] }` map and the encoder will
+    // descend into the map, BUT individual array items don't get the
+    // suffix treatment. This matches the design doc's "opaque map" framing.)
+    return cborArray(value.map((v) => payloadJsonToCborValue(v, undefined)));
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const pairs: Array<[string, CborValue]> = [];
+    for (const k of Object.keys(obj)) {
+      pairs.push([k, payloadJsonToCborValue(obj[k], k)]);
+    }
+    return cborMap(pairs);
+  }
+  throw new TypeError(
+    `evidence payload: unsupported value type ${typeof value} (must be string/number/array/object)`,
+  );
+}
+
+/**
+ * Build the canonical CBOR-tagged form of one attestation_evidence entry.
+ * Binary subfields (keys ending in `_b64`) are base64-decoded into byte
+ * strings (CBOR major-type-2). The result is a CBOR map with three keys:
+ * `evidence_type`, `nonce`, `payload`. Map keys are sorted at encode time.
+ */
+export function evidenceEntryToCborValue(entry: AttestationEvidenceEntry): CborValue {
+  if (!EVIDENCE_TYPE_SET.has(entry.evidence_type)) {
+    throw new TypeError(
+      `evidence entry: unknown evidence_type "${entry.evidence_type}"`,
+    );
+  }
+  if (typeof entry.nonce !== "string" || !HEX64.test(entry.nonce)) {
+    throw new TypeError(
+      `evidence entry: nonce must be 64-char lowercase hex, got "${entry.nonce}"`,
+    );
+  }
+  if (entry.payload === null || typeof entry.payload !== "object" || Array.isArray(entry.payload)) {
+    throw new TypeError("evidence entry: payload must be a JSON object");
+  }
+  return cborMap([
+    ["evidence_type", cborText(entry.evidence_type)],
+    ["nonce", cborBytes(hexToU8a("0x" + entry.nonce))],
+    ["payload", payloadJsonToCborValue(entry.payload)],
+  ]);
+}
+
+/**
+ * Sort an evidence array IN PLACE by EvidenceType discriminant ascending.
+ * Returns the same array for chaining. Per § 3.4 of the design doc, the
+ * worker MUST sort before signing and the gateway MUST reject out-of-order
+ * arrays in a future enforcement pass (this codebase doesn't reject
+ * out-of-order today; the canonicaliser sorts deterministically regardless,
+ * and the route's nonce check binds each entry to its content_hash).
+ */
+export function sortEvidenceByDiscriminant(
+  entries: AttestationEvidenceEntry[],
+): AttestationEvidenceEntry[] {
+  entries.sort(
+    (a, b) =>
+      EVIDENCE_TYPE_DISCRIMINANT[a.evidence_type] -
+      EVIDENCE_TYPE_DISCRIMINANT[b.evidence_type],
+  );
+  return entries;
+}
+
+/**
+ * Build the canonical CBOR array for the `attestation_evidence` array.
+ * Entries are sorted by EvidenceType discriminant ascending (a non-mutating
+ * shallow copy is sorted; the input array is not modified).
+ */
+export function evidenceArrayToCborValue(
+  entries: AttestationEvidenceEntry[],
+): CborValue {
+  const sorted = entries.slice();
+  sortEvidenceByDiscriminant(sorted);
+  return cborArray(sorted.map(evidenceEntryToCborValue));
+}
+
+/**
+ * SHA-256 of the canonical-CBOR encoding of an evidence array. This is the
+ * `attestation_evidence_hash` returned by the gateway endpoint after the
+ * receipt's stored evidence vector is updated.
+ *
+ * The empty-vec case is the canonical-CBOR-hash of an empty CBOR array
+ * (single byte 0x80, major type 4 with length 0), per § E in the spec.
+ */
+export function attestationEvidenceHash(
+  entries: AttestationEvidenceEntry[],
+): string {
+  const cborBytes = encodeCbor(evidenceArrayToCborValue(entries));
+  return createHash("sha256").update(cborBytes).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
 // Pre-image builders.
 // ---------------------------------------------------------------------------
 
@@ -513,27 +788,42 @@ export function canonicalCborForFleetOpSig(
 /**
  * Build the canonical CBOR bytes for the worker-signature pre-image.
  *
+ * v2 (default — no `attestation_evidence`):
  *   [ "compute_metering_v2", worker_id, tenant_id, period_start_ms,
  *     period_end_ms, metrics, hardware_spec_full, worker_pubkey_bytes ]
  *
+ * v2.1 (when `attestation_evidence` is non-empty):
+ *   [ "compute_metering_v2.1", worker_id, tenant_id, period_start_ms,
+ *     period_end_ms, metrics, hardware_spec_full, worker_pubkey_bytes,
+ *     attestation_evidence_array ]   // 9th element, sorted by EvidenceType
+ *
+ * Backwards compatibility (PINNED): when `attestation_evidence` is omitted
+ * (or supplied as an empty array), the schema literal stays
+ * `compute_metering_v2` and the bytes are byte-identical to today's v2.
+ *
  * The observer signature (when present) signs THESE EXACT BYTES under the
- * observer pubkey.
+ * observer pubkey — for v2 records that's the 8-element v2 array, for v2.1
+ * records that's the 9-element v2.1 array.
  */
 export function canonicalCborForWorkerSig(
   rec: Omit<ComputeMeteringV2, "worker_signature" | "observer">,
+  evidence?: AttestationEvidenceEntry[],
 ): Uint8Array {
-  return encodeCbor(
-    cborArray([
-      cborText(SCHEMA_VERSION),
-      cborText(rec.worker_id),
-      cborText(rec.tenant_id),
-      cborInt(rec.period_start_ms),
-      cborInt(rec.period_end_ms),
-      metricsToCbor(rec.metrics),
-      hardwareSpecFullToCbor(rec.hardware_spec),
-      cborBytes(hexToU8a("0x" + rec.worker_pubkey)),
-    ]),
-  );
+  const hasEvidence = evidence !== undefined && evidence.length > 0;
+  const baseElements: CborValue[] = [
+    cborText(hasEvidence ? SCHEMA_VERSION_V2_1 : SCHEMA_VERSION),
+    cborText(rec.worker_id),
+    cborText(rec.tenant_id),
+    cborInt(rec.period_start_ms),
+    cborInt(rec.period_end_ms),
+    metricsToCbor(rec.metrics),
+    hardwareSpecFullToCbor(rec.hardware_spec),
+    cborBytes(hexToU8a("0x" + rec.worker_pubkey)),
+  ];
+  if (hasEvidence) {
+    baseElements.push(evidenceArrayToCborValue(evidence));
+  }
+  return encodeCbor(cborArray(baseElements));
 }
 
 /**
@@ -542,9 +832,10 @@ export function canonicalCborForWorkerSig(
  */
 export function canonicalContentHash(
   rec: Omit<ComputeMeteringV2, "worker_signature" | "observer">,
+  evidence?: AttestationEvidenceEntry[],
 ): string {
   return createHash("sha256")
-    .update(canonicalCborForWorkerSig(rec))
+    .update(canonicalCborForWorkerSig(rec, evidence))
     .digest("hex");
 }
 


### PR DESCRIPTION
## Summary

Wave 3 Phase 2 of the **Polychain TEE Attestation** rollout. Lands the additive `compute_metering_v2.1` wire schema (TS + Python encoders byte-pinned) plus a TEE-attestor evidence sink at `POST /v2/attestation_evidence` and an admin registry for attestor pubkeys. Gateway only — no on-chain change in this PR.

- New `compute_metering_v2.1` schema appends an optional `attestation_evidence` array as the 9th CBOR pre-image element, sorted by `EvidenceType` discriminant. v2 records produce **byte-identical** pre-images (full backwards compat).
- `POST /v2/attestation_evidence` accepts evidence entries from registered attestors (Acurast Android phones now; SEV-SNP / TDX hosts later), verifies sr25519 over canonical(payload), persists to local SQLite, recomputes the receipt's `attestation_evidence_hash` over the full sorted vec.
- `/admin/attestation-evidence-attestors` POST/DELETE/GET admin registry mirrors `fleet_operators` + `observers`.

The on-chain pallet (`pallet-tee-attestation`) is being built in parallel and consumes the same evidence shape — this PR matches the design doc's Rust types exactly.

Refs:
- [Wave 3 design doc](file:///home/deci/wave-3-polychain-attestation-pallet-design.md) (sections 3 / 6 / 7)
- [Acurast Phase 2 scoping brief](file:///home/deci/wave-3-phase-2-acurast-scoping.md)

## Test vectors added (PINNED — spec-stable)

| Vector | Schema | Description | content_hash |
|---|---|---|---|
| V21_1 | v2 | Empty/absent evidence == v2 (backwards compat) | `14fe18164cca4778b0166b00d06845547ead5ab99a31a1edd30f7c78f8defc0e` |
| V21_2 | v2.1 | Single ArmTrustZone entry | `761cd5a2c7006d6a06e1b94cd7a349d9215478126b227015d75a06858266c83f` |
| V21_3 | v2.1 | Two entries (ArmTrustZone + ReproducibleBuild), sorted by discriminant | `1890fd91981068b92579c0405dae1e251fe147e87d7cee3594bb85b316702839` |
| V21_4 | v2.1 | Four entries (full silicon-vendor + reproducible-build) | `f9c99103679a0108bb44af49bfdfc262b7549777dc91203232c51153e586f9f2` |

**Empty-evidence-vec hash** (PINNED forever — referenced by all downstream consumers): `76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71` (= sha256 of CBOR `0x80`, NOT zeros — per design doc § E).

## Test counts

| Suite | Before | After |
|---|---|---|
| `services/blob-gateway` (TS) | 489 / 23 files | 551 / 26 files (+62 new tests, +3 files) |
| `compute-meter-sdk` (Python) | 132 | 157 (+25 new tests in `test_v2_1_cross_lang.py`) |
| `services/blob-gateway/src/schemas/__tests__/compute_metering_v2.test.ts` | 74 | 74 (UNCHANGED — full backwards compat verified) |
| `compute-meter-sdk/tests/test_v2_cross_lang.py` | 21 | 21 (UNCHANGED — full backwards compat verified) |

87 new tests total. Every existing v2 hash vector still produces identical bytes after the schema change.

## New tests

**Schema (TS)** — `services/blob-gateway/src/schemas/__tests__/compute_metering_v2_1.test.ts` (24 tests)
- Backwards compat: absent / empty evidence → v2 bytes; v2 schema literal preserved.
- Vector 2 single ArmTrustZone — pinned content_hash + evidence_hash.
- Vector 3 two entries — sort by EvidenceType discriminant (NOT alphabetical), pinned hashes.
- Vector 4 four entries — full sort path, `*_b64` payload encoder, pinned hashes.
- `empty_vec_hash_is_sha256_of_cbor_empty_array_byte_0x80` — empty-vec PINNED.
- Negative cases: unknown evidence_type, bad nonce, non-object payload, boolean/null in payload, bad base64.
- sr25519 round-trip over the v2.1 pre-image.

**Schema (Python cross-lang)** — `packages/compute-meter-sdk/tests/test_v2_1_cross_lang.py` (25 tests)
- Pinned-vector tests V21_1..V21_4 for both content_hash + evidence_hash.
- Cross-lang Python ↔ TS byte-equality for all 4 vectors via `_v2_1_ts_encoder.mts`.
- `EVIDENCE_TYPE_DISCRIMINANT` pinning + sort-by-discriminant invariance.
- `SCHEMA_HASH_V2_1_HEX` cross-lang constant.

**Admin route + storage** — `services/blob-gateway/src/__tests__/attestation_evidence_attestors.test.ts` (23 tests)
- DB CRUD (register, get, isActive, revoke, list).
- Admin route: 401 missing/wrong x-admin-token, 200 register, 409 duplicate, 404 unknown DELETE, 200 revoked / already-revoked, 503 unconfigured.

**Evidence route** — `services/blob-gateway/src/__tests__/attestation_evidence_route.test.ts` (15 tests)
- Bearer auth: 401 missing / invalid Bearer.
- Body shape: 400 missing fields, invalid evidence_type, non-object payload, bad hex.
- 404 RECEIPT_NOT_FOUND.
- 422 NONCE_MISMATCH (bad nonce).
- 403 ATTESTOR_UNKNOWN (unregistered + revoked).
- 401 SIGNATURE_INVALID (tampered sig).
- 200 status:accepted (happy path) — recompute matches manual.
- 200 status:replay (idempotent on receipt_id+attestor+evidence_type tuple).
- Two attestors, different evidence_types, both stored, vec sorted by discriminant.
- Empty-vec hash returned when no evidence stored.

## Followups (separate PRs — out of scope here)

- **`materios-node/receipt-submitter.mjs`**: forward evidence-augmented v2.1 records (the submitter is volume-mounted from a separate repo — not modified here).
- **cert-daemon**: consume `attestation_evidence_hash` and carry it on-chain via `pallet-tee-attestation::submit_receipt_v2_1` extrinsic (chain-side update is the cert-daemon's job, per design doc § 7).
- **`pallet-tee-attestation`**: the on-chain storage + composite-trust-score scoring + verifier loop. Parallel agent. Stays aligned with the `EvidenceType` discriminants pinned here.

## Test plan

- [x] `vitest run services/blob-gateway/` — 26 files / 551 tests pass (no regressions; +62 from this PR)
- [x] `pytest packages/compute-meter-sdk/tests/test_v2_1_cross_lang.py` — 25 pass (cross-lang byte equality verified)
- [x] `pytest packages/compute-meter-sdk/tests/test_v2_cross_lang.py` — 21 pass (backwards compat verified)
- [x] `tsc --noEmit` — clean build
- [x] All 4 spec vectors PINNED in both TS + Python tests; empty-vec hash PINNED
- [x] No on-chain change (schema-only + gateway-only) — does not touch the receipt-submitter or cert-daemon