### PR TITLE
test(compute-meter-sdk): Phase 2 Path C smoke harness — Pixel/Samsung test-vector demo

### DIFF
--- a/packages/compute-meter-sdk/pyproject.toml
+++ b/packages/compute-meter-sdk/pyproject.toml
@@ -31,6 +31,18 @@ markers = [
     "integration: live preprod gateway test (requires network + API key)",
     "e2e: end-to-end pipeline test against live preprod (task #113, ≤15 min)",
     "slow: long-running E2E test (≤30 min, includes Cardano anchor wait)",
+    # Wave 3 Phase 2 — test-vector-driven polychain attestation smoke. The
+    # five tests in `tests/test_phase2_path_c_smoke.py` post a real
+    # Google-rooted Pixel StrongBox cert chain (vendored from
+    # pallets/tee-attestation/src/test_vectors.rs) to the gateway's
+    # /v2/attestation_evidence endpoint, watch the chain attest +
+    # Cardano-anchor it, and round-trip the attestation_evidence_hash
+    # back through Blockfrost. Gated behind this marker so it only runs
+    # when explicitly invoked: `pytest -m phase_2_smoke -v`. All five
+    # SKIP cleanly with a named-prereq message until the runtime
+    # upgrade for pallet-tee-attestation lands and the kill-switch is
+    # flipped via sudo set_disabled(false).
+    "phase_2_smoke: Wave 3 Phase 2 demo harness (Pixel test-vector chain)",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/packages/compute-meter-sdk/tests/E2E.md
+++ b/packages/compute-meter-sdk/tests/E2E.md
@@ -195,3 +195,84 @@ The suite gracefully skips with a CLEAR diagnostic at module level when:
 
 A skipped E2E run is NOT a failure — it tells the operator exactly which
 upstream piece is missing so they can fix THAT, not chase the SDK.
+
+---
+
+## Wave 3 Phase 2 Path C smoke — `tests/test_phase2_path_c_smoke.py`
+
+Test-vector-driven Phase 2 demo: submits a `compute_metering_v2.1` record
+that carries a real Google-rooted Pixel StrongBox attestation chain
+(vendored from `pallets/tee-attestation/src/test_vectors.rs`), watches the
+chain attest + Cardano-anchor it, and round-trips the
+`attestation_evidence_hash` back through Blockfrost. When this harness
+goes green end-to-end, Wave 3 Phase 2 is shipped.
+
+The harness uses two independent trust layers — see the long explanation
+in `tests/_phase2_helpers.py`. Short version: the cert chain in the
+payload is REAL (Google-rooted Android Key Attestation); the sr25519
+signature on `/v2/attestation_evidence` is from a fresh synthetic key
+(we don't have the Pixel TEE's private key). The on-chain pallet's
+`ArmTrustZoneVerifier` is what proves the chain-of-trust property; the
+endpoint signature only authenticates "this attestor agrees this evidence
+belongs to this receipt."
+
+### Quick run
+
+```bash
+cd /home/deci/work/orynq-sdk/packages/compute-meter-sdk
+
+# Required:
+export MATERIOS_E2E_BEARER="matra_<your_token>"
+export MATERIOS_E2E_HARDWARE_SPEC="/path/to/fleet-signed-hardware.json"
+export PHASE2_ADMIN_TOKEN="<gateway-admin-shared-secret>"
+
+# Strongly recommended (otherwise the synthetic worker_id won't verify
+# against a baked-in spec):
+export MATERIOS_E2E_FLEET_OPERATOR_KEY="/path/to/fleet-operator-key.json"
+
+# Required for test #5 (Cardano metadata round-trip):
+export PHASE2_BLOCKFROST_PROJECT_ID="preprod<your_project_id>"
+
+# Optional:
+export MATERIOS_E2E_GATEWAY="https://materios.fluxpointstudios.com/preprod-blobs"
+export MATERIOS_RPC_URL="ws://127.0.0.1:9945"
+export PHASE2_ATTESTOR_KEY="/path/to/attestor-key.json"   # otherwise generated fresh per session
+export PHASE2_BLOCKFROST_URL="https://cardano-preprod.blockfrost.io/api/v0"
+
+.venv/bin/pytest tests/test_phase2_path_c_smoke.py -m phase_2_smoke -v
+```
+
+### Tests in the Phase 2 suite
+
+| name | what it proves | budget |
+|---|---|---|
+| `test_path_c_v2_record_lands_on_chain` | Gateway accepts a v2.1 envelope under the tenant Bearer; receipt visible in `/billing/usage` within 60 s. | <60s |
+| `test_path_c_evidence_submission_returns_correct_hash` | The gateway's `attestation_evidence_hash` matches the SDK's pinned canonical-CBOR-sha256 byte-for-byte. Cross-language encoder property test, end-to-end. | <60s |
+| `test_path_c_invalid_pixel_chain_rejected` | Tampered Pixel chain (`PIXEL_KEY_CERT_INVALID`) — the gateway accepts the evidence at the endpoint level, but `composite_trust_score` MUST stay at 0 past `PHASE2_DEADLINE_NEGATIVE_S` (default 180 s). The cert-daemon refuses to attest. | <3 min |
+| `test_path_c_valid_pixel_chain_attested` | Headline demo. Valid Pixel chain → `composite_trust_score >= 1` AND `cardano_anchor_tx != null`. Logs the cexplorer.io URL on success. | <20 min |
+| `test_path_c_anchor_evidence_hash_round_trips` | Reads back the Cardano anchor tx via Blockfrost, parses label-8746 metadata, finds the leaf for our receipt, asserts the leaf's `attestation_evidence_hash` matches the SDK's value. Real Google-rooted hardware → Cardano L1 audit trail. | <30s after #4 |
+
+### Phase 2 skip behaviour
+
+Each test reports the FIRST unmet prerequisite:
+
+* `MATERIOS_E2E_BEARER` not set
+* `MATERIOS_E2E_HARDWARE_SPEC` not set or file missing
+* `PHASE2_ADMIN_TOKEN` not set (needed for attestor registration)
+* Gateway unreachable
+* Gateway returns 404 on `POST /v2/attestation_evidence` — old image, deploy the v2.1 build (PR #34)
+* Gateway returns 404 on `/admin/attestation-evidence-attestors` — same fix
+* Materios RPC unreachable
+* `pallet-tee-attestation` not in runtime metadata — runtime upgrade for PR #17 hasn't landed yet
+* `pallet-tee-attestation::Disabled` is `true` — sudo-flip via `set_disabled(false)` needed to take the kill-switch off
+
+The skip messages are deliberately verbose — running `pytest -m phase_2_smoke -v -rs` should tell you in one shot exactly which step of the upgrade ceremony is incomplete. There is no "look at the wiki" — the test output IS the runbook.
+
+### Polling budgets — env overrides
+
+| var | default | meaning |
+|---|---|---|
+| `PHASE2_DEADLINE_RECEIPT_S` | 60 | Max time to wait for the v2.1 record to surface in `/billing/usage`. |
+| `PHASE2_DEADLINE_CERT_S` | 600 | (reserved) — the chain attestation half budget. |
+| `PHASE2_DEADLINE_NEGATIVE_S` | 180 | Negative-test deadline: how long to wait before concluding the cert-daemon WON'T attest a tampered chain. |
+| `PHASE2_DEADLINE_ANCHOR_S` | 1200 | Max wait for the headline demo's anchor + trust-score to land (Cardano preprod p50 ≈ 5-15 min). |

--- a/packages/compute-meter-sdk/tests/_phase2_helpers.py
+++ b/packages/compute-meter-sdk/tests/_phase2_helpers.py
@@ -1,0 +1,630 @@
+"""Helpers for the Phase 2 (Wave 3) Path C smoke harness.
+
+Path C ships the Wave 3 Phase 2 demo without a live phone: it submits a
+`compute_metering_v2.1` record carrying ONE `arm_trustzone` evidence entry
+whose payload contains a REAL Google-rooted Pixel StrongBox attestation
+chain, vendored verbatim from `pallets/tee-attestation/src/test_vectors.rs`
+(itself imported from Acurast/acurast-substrate). The pallet's
+`ArmTrustZoneVerifier` validates the chain end-to-end (Google root →
+intermediates → leaf), proving the same hardware-attestation primitive
+that protects production Acurast workloads is live on Materios preprod.
+
+Two trust layers, kept independent in the demo's design:
+
+  1. **Cert-chain layer (the chain-of-trust check on chain).**
+     The cert chain in the evidence payload is REAL — pulled from the
+     Acurast test vectors which themselves came from production Pixel
+     StrongBox / Samsung TEE devices. The pallet's verifier walks
+     Google Root → intermediates → leaf, verifying every signature.
+     This is what the demo proves: Materios accepts real Google-rooted
+     Android Key Attestation chains.
+
+  2. **Attestor-signature layer (the gateway's `/v2/attestation_evidence`
+     endpoint).**
+     The endpoint requires a `signature` over canonical CBOR of the
+     payload. The signing key is the attestor's sr25519 keypair, NOT
+     the cert chain's leaf private key (we don't have that — it's in
+     the real device's TEE). For the demo we generate a fresh sr25519
+     keypair, register its pubkey via `/admin/attestation-evidence-attestors`,
+     and sign the payload with it. The cert chain inside the payload is
+     untouched — the on-chain pallet verifies it independently.
+
+These layers are deliberately separate concerns:
+
+   * Layer 1 = "this evidence was produced inside Google-rooted hardware"
+   * Layer 2 = "this attestor agrees this evidence belongs to this receipt"
+
+A real-phone deployment (queued behind Acurast onboarding) collapses
+the two layers into one signing key inside the phone's TEE — but the
+demo proves Layer 1 today on the data plane that Layer 2 will use
+unchanged.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import httpx
+
+# v2.1 canonical helpers — re-used so the harness shares one source of truth
+# with the SDK's encoder, the cross-language test, and the gateway's TS code.
+from materios_compute_meter.canonical import (
+    canonical_cbor_for_evidence_payload,
+    derive_evidence_nonce,
+)
+from materios_compute_meter.keypair import WorkerKeypair
+
+
+# ---------------------------------------------------------------------------
+# Real-device test vectors. Source-of-truth lives in
+# `materios-task180/partnerchain/pallets/tee-attestation/src/test_vectors.rs`
+# (which itself vendors them from Acurast/acurast-substrate@d205a7d3).
+#
+# We mirror them here as Python constants so the smoke harness has no
+# build-time coupling to the pallet crate. If the pallet's vectors change,
+# regenerate this module's constants from the .rs file and re-pin.
+# ---------------------------------------------------------------------------
+
+# --- Pixel chain (Google Pixel StrongBox / Titan-M chip). Index 0 is root,
+# ascending toward leaf. The pallet's verifier accepts the chain in
+# root → leaf order.
+
+PIXEL_ROOT_CERT_B64 = (
+    "MIIFYDCCA0igAwIBAgIJAOj6GWMU0voYMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNVBAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTYwNTI2MTYyODUyWhcNMjYwNTI0MTYyODUyWjAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdSSxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggjnar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGqC4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQoVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+OJtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/EgsTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRiigHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+MRPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9EaDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5UmAGMCAwEAAaOBpjCBozAdBgNVHQ4EFgQUNmHhAHyIBQlRi0RsR/8aTMnqTxIwHwYDVR0jBBgwFoAUNmHhAHyIBQlRi0RsR/8aTMnqTxIwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwQAYDVR0fBDkwNzA1oDOgMYYvaHR0cHM6Ly9hbmRyb2lkLmdvb2dsZWFwaXMuY29tL2F0dGVzdGF0aW9uL2NybC8wDQYJKoZIhvcNAQELBQADggIBACDIw41L3KlXG0aMiS//cqrG+EShHUGo8HNsw30W1kJtjn6UBwRM6jnmiwfBPb8VA91chb2vssAtX2zbTvqBJ9+LBPGCdw/E53Rbf86qhxKaiAHOjpvAy5Y3m00mqC0w/Zwvju1twb4vhLaJ5NkUJYsUS7rmJKHHBnETLi8GFqiEsqTWpG/6ibYCv7rYDBJDcR9W62BW9jfIoBQcxUCUJouMPH25lLNcDc1ssqvC2v7iUgI9LeoM1sNovqPmQUiG9rHli1vXxzCyaMTjwftkJLkf6724DFhuKug2jITV0QkXvaJWF4nUaHOTNA4uJU9WDvZLI1j83A+/xnAJUucIv/zGJ1AMH2boHqF8CY16LpsYgBt6tKxxWH00XcyDCdW2KlBCeqbQPcsFmWyWugxdcekhYsAWyoSf818NUsZdBWBaR/OukXrNLfkQ79IyZohZbvabO/X+MVT3rriAoKc8oE2Uws6DF+60PV7/WIPjNvXySdqspImSN78mflxDqwLqRBYkA3I75qppLGG9rp7UCdRjxMl8ZDBld+7yvHVgt1cVzJx9xnyGCC23UaicMDSXYrB4I4WHXPGjxhZuCuPBLTdOLU8YRvMYdEvYebWHMpvwGCF6bAx3JBpIeOQ1wDB5y0USicV3YgYGmi+NZfhA4URSh77Yd6uuJOJENRaNVTzk"
+)
+
+PIXEL_INTERMEDIATE_2_CERT_B64 = (
+    "MIID1zCCAb+gAwIBAgIKA4gmZ2BliZaF9TANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MB4XDTE5MDgwOTIzMDMyM1oXDTI5MDgwNjIzMDMyM1owLzEZMBcGA1UEBRMQNTRmNTkzNzA1NDJmNWE5NTESMBAGA1UEDAwJU3Ryb25nQm94MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE41Inb5v86kMBpfBCf6ZHjlcyCa5E/XYs+8V8u9RxNjFQnoAuoOlAU25U+iVwyihGFUaYB1UJKTsxALOVW0MXdosoa/b+JlHFmvbGsNszYAkKRkfHhg527MO4p9tc5XrMo4G2MIGzMB0GA1UdDgQWBBRpkLEMOwiK7ir4jDOHtCwS2t/DpjAfBgNVHSMEGDAWgBQ2YeEAfIgFCVGLRGxH/xpMyepPEjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwICBDBQBgNVHR8ESTBHMEWgQ6BBhj9odHRwczovL2FuZHJvaWQuZ29vZ2xlYXBpcy5jb20vYXR0ZXN0YXRpb24vY3JsLzhGNjczNEM5RkE1MDQ3ODkwDQYJKoZIhvcNAQELBQADggIBAFxZEyegsCSeytyUkYTJZR7R8qYXoXUWQ5h1Qp6b0h+H/SNl0NzedHAiwZQQ8jqzgP4c7w9HrrxEPCpFMd8+ykEBv5bWvDDf2HjtZzRlMRG154KgM1DMJgXhKLSKV+f/H+S/QQTeP3yprOavsBvdkgX6ELkYN6M3JXr7gpCvpFb6Ypz65Ud7FysAm/KNQ9zU0x7cvz3Btvz8ylw4p5dz04tanTzNgVLVHyX5kAcB2ftPvxMH4X/PXdx1lAmGPS8PsubCRGjJxdhRVOEEMYyxCuYLonuyUggOByZFaBw55WDoWGpkVQhnFi9L3p23VkWILLnq/07+GwoxL1vUAiQpjJHxNQYbjgTo+kxhjDP3uULAKPANGBE7+25VqVLMtdce4Eb5v9yFqgg+JtlL41RUWVS3DIEqxOMm/fB3A7t55TbUKf8dCZyBci2BcUWTx8K7VnQMy8gBMyu1SGleKPLIrBRSomDP5X8xGtwTLo3aAdY4+aSjEoimI6kX9bbIfhyDFpJxKaDRHzhCUdLfJrlCp2hEq5GWj0lT50hPLs0tbhh/l3LTtFhKyYbiB5vHXyB3P4gUui0WxyZnYdajUF+Tn8MW79qHhwhaXU9HnflE+dBh0smazOc+0xdwZZKXET+UFAUAMGiHvhuICCuWsY4SPKv8/715toeCoECHSMv08C9C"
+)
+
+PIXEL_INTERMEDIATE_1_CERT_B64 = (
+    "MIICMDCCAbegAwIBAgIKFZBYV0ZxdmNYNDAKBggqhkjOPQQDAjAvMRkwFwYDVQQFExA1NGY1OTM3MDU0MmY1YTk1MRIwEAYDVQQMDAlTdHJvbmdCb3gwHhcNMTkwNzI3MDE1MjE5WhcNMjkwNzI0MDE1MjE5WjAvMRkwFwYDVQQFExA5NzM1Mzc3OTM2ZDBkZDc0MRIwEAYDVQQMDAlTdHJvbmdCb3gwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAR2OZY6u30za18jjYs1Xv2zlaIrLM3me9okMo5Lv4Av76l/IE3YvbRQMyy15Wb3Wb3G/6+587x443R9/Ognjl8Co4G6MIG3MB0GA1UdDgQWBBRBPjyps0vHpRy7ASXAQhvmUa162DAfBgNVHSMEGDAWgBRpkLEMOwiK7ir4jDOHtCwS2t/DpjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwICBDBUBgNVHR8ETTBLMEmgR6BFhkNodHRwczovL2FuZHJvaWQuZ29vZ2xlYXBpcy5jb20vYXR0ZXN0YXRpb24vY3JsLzE1OTA1ODU3NDY3MTc2NjM1ODM0MAoGCCqGSM49BAMCA2cAMGQCMBeg3ziAoi6h1LPfvbbASk5WVdC6cL3IpaxIOycMHm1SDNqYALOtd1uujfzMeobs+AIwKJj5XySGe7MRL0QNtdrSd2nkK+fbjcUc8LKvVapDwRAC40CiTzllAy+aOnyDxrvb"
+)
+
+PIXEL_KEY_CERT_B64 = (
+    "MIICnDCCAkGgAwIBAgIBATAMBggqhkjOPQQDAgUAMC8xGTAXBgNVBAUTEDk3MzUzNzc5MzZkMGRkNzQxEjAQBgNVBAwMCVN0cm9uZ0JveDAiGA8yMDIyMDcwOTEwNTE1NVoYDzIwMjgwNTIzMjM1OTU5WjAfMR0wGwYDVQQDDBRBbmRyb2lkIEtleXN0b3JlIEtleTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLIMHRVHdmJiPs9DAQSJgAbg+BwNsbrofLlqh8d3dARlnlhdPZBXuKL/iuYfQBoHj8dc9SyMQmjoEPk3mMcp6GKjggFWMIIBUjAOBgNVHQ8BAf8EBAMCB4AwggE+BgorBgEEAdZ5AgERBIIBLjCCASoCAQQKAQICASkKAQIECHRlc3Rhc2RmBAAwbL+FPQgCBgGB4pZhH7+FRVwEWjBYMTIwMAQrY29tLnViaW5ldGljLmF0dGVzdGVkLmV4ZWN1dG9yLnRlc3QudGVzdG5ldAIBDjEiBCC9y0Vg9rPEHa2SBmgWnCi+HvnqSfI9mM2OsvN65EiP+TCBoaEFMQMCAQKiAwIBA6MEAgIBAKUFMQMCAQCqAwIBAb+DdwIFAL+FPgMCAQC/hUBMMEoEIIec0/GOp24kTU1Kw7y5wzfBO0ZnGQsZA1r+JTZVAFDxAQH/CgEABCA/QTbuNYHmq6jqM3prQ9cD3h7KJB+bfyd+zfr/96jc8b+FQQUCAwHUwL+FQgUCAwMV3r+FTgYCBAE0ir2/hU8GAgQBNIq9MAwGCCqGSM49BAMCBQADRwAwRAIgM6YTzOmm7SUCakkrZR8Kxnw8AonU5HQxaMaQPi+qC9oCIDJM01xL8mldca0Sooho5pIyESki6vDjaZ9q3YEz1SjZ"
+)
+
+# Tampered leaf (last byte of signature flipped Z->Y). Used by the negative
+# test: the cert-daemon must REFUSE to attest. The chain still parses and
+# the gateway will still STORE the evidence — the rejection is a chain-side
+# property of the pallet's verifier.
+PIXEL_KEY_CERT_INVALID_B64 = (
+    "MIICnDCCAkGgAwIBAgIBATAMBggqhkjOPQQDAgUAMC8xGTAXBgNVBAUTEDk3MzUzNzc5MzZkMGRkNzQxEjAQBgNVBAwMCVN0cm9uZ0JveDAiGA8yMDIyMDcwOTEwNTE1NVoYDzIwMjgwNTIzMjM1OTU5WjAfMR0wGwYDVQQDDBRBbmRyb2lkIEtleXN0b3JlIEtleTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLIMHRVHdmJiPs9DAQSJgAbg+BwNsbrofLlqh8d3dARlnlhdPZBXuKL/iuYfQBoHj8dc9SyMQmjoEPk3mMcp6GKjggFWMIIBUjAOBgNVHQ8BAf8EBAMCB4AwggE+BgorBgEEAdZ5AgERBIIBLjCCASoCAQQKAQICASkKAQIECHRlc3Rhc2RmBAAwbL+FPQgCBgGB4pZhH7+FRVwEWjBYMTIwMAQrY29tLnViaW5ldGljLmF0dGVzdGVkLmV4ZWN1dG9yLnRlc3QudGVzdG5ldAIBDjEiBCC9y0Vg9rPEHa2SBmgWnCi+HvnqSfI9mM2OsvN65EiP+TCBoaEFMQMCAQKiAwIBA6MEAgIBAKUFMQMCAQCqAwIBAb+DdwIFAL+FPgMCAQC/hUBMMEoEIIec0/GOp24kTU1Kw7y5wzfBO0ZnGQsZA1r+JTZVAFDxAQH/CgEABCA/QTbuNYHmq6jqM3prQ9cD3h7KJB+bfyd+zfr/96jc8b+FQQUCAwHUwL+FQgUCAwMV3r+FTgYCBAE0ir2/hU8GAgQBNIq9MAwGCCqGSM49BAMCBQADRwAwRAIgM6YTzOmm7SUCakkrZR8Kxnw8AonU5HQxaMaQPi+qC9oCIDJM01xL8mldca0Sooho5pIyESki6vDjaZ9q3YAz1SjZ"
+)
+
+
+def pixel_chain_b64(*, valid: bool = True) -> List[str]:
+    """Return the Pixel StrongBox cert chain as a list of base64 strings.
+
+    Order matches what the pallet's verifier accepts: index 0 = Google root,
+    last entry = leaf. When ``valid=False`` the leaf is the tampered cert
+    `PIXEL_KEY_CERT_INVALID` — used by the negative attestation test.
+    """
+    return [
+        PIXEL_ROOT_CERT_B64,
+        PIXEL_INTERMEDIATE_2_CERT_B64,
+        PIXEL_INTERMEDIATE_1_CERT_B64,
+        (PIXEL_KEY_CERT_B64 if valid else PIXEL_KEY_CERT_INVALID_B64),
+    ]
+
+
+# Samsung TEE chain — kept here as a comment-pointer for the multi-vendor
+# follow-up. The harness uses Pixel as the canonical demo; flipping to
+# Samsung means swapping `pixel_chain_b64()` for `samsung_chain_b64()` and
+# regenerating the SPKI sha256 for the registered attestor key. The Samsung
+# vectors are present in
+# `pallets/tee-attestation/src/test_vectors.rs` (constants `SAMSUNG_*`)
+# and can be lifted in a follow-up commit when we want a Pixel-vs-Samsung
+# parity smoke.
+
+
+# ---------------------------------------------------------------------------
+# Minimal ASN.1 DER walker — extracts a leaf cert's SubjectPublicKeyInfo
+# bytes so we can compute the pallet's `attest_key_hash`.
+#
+# The pallet's ARM verifier sets `attest_key_hash = sha256(SPKI_DER)` for
+# every successfully-validated leaf. We mirror that derivation in Python so
+# the smoke harness can emit the same hash value as the on-chain pallet —
+# critical for the round-trip assertions in the Cardano-anchor test.
+#
+# The standard `cryptography` library would give us this in two lines, but
+# it's not in compute-meter-sdk's existing pyproject.toml deps. The walk
+# below is ~30 lines and uses only the stdlib — see the per-byte annotations
+# inline. If we ever pick up `cryptography` for a different reason, this
+# walker can be deleted and replaced with `x509.load_der_x509_certificate`.
+# ---------------------------------------------------------------------------
+
+
+def _parse_der_tlv(buf: bytes, off: int) -> Tuple[int, int, int, int]:
+    """Parse one ASN.1 DER TLV at ``buf[off:]``.
+
+    Returns ``(tag, length, content_offset, total_consumed)``. The total
+    consumed is the number of bytes the TLV occupies as a whole — i.e.
+    ``buf[off:off+total_consumed]`` is the raw TLV.
+    """
+    tag = buf[off]
+    pos = off + 1
+    first = buf[pos]
+    if first & 0x80:
+        # Long-form length: low 7 bits = number of length bytes that follow.
+        nlen = first & 0x7F
+        length = int.from_bytes(buf[pos + 1 : pos + 1 + nlen], "big")
+        content_off = pos + 1 + nlen
+    else:
+        length = first
+        content_off = pos + 1
+    total = (content_off + length) - off
+    return tag, length, content_off, total
+
+
+def extract_leaf_spki_der(leaf_cert_der: bytes) -> bytes:
+    """Return the SubjectPublicKeyInfo SEQUENCE bytes (with its outer
+    `0x30 <len> ...` wrapper) from a DER-encoded X.509 certificate.
+
+    The pallet computes ``attest_key_hash = sha256(SPKI_DER)`` over exactly
+    these bytes; mirror the derivation here. Implementation walks:
+
+        Certificate ::= SEQUENCE {
+            tbsCertificate    TBSCertificate,
+            signatureAlgorithm AlgorithmIdentifier,
+            signatureValue    BIT STRING
+        }
+        TBSCertificate ::= SEQUENCE {
+            version              [0] EXPLICIT INTEGER DEFAULT v1,
+            serialNumber         INTEGER,
+            signature            AlgorithmIdentifier,
+            issuer               Name,
+            validity             Validity,
+            subject              Name,
+            subjectPublicKeyInfo SubjectPublicKeyInfo,    -- target
+            ...
+        }
+    """
+    # Outer Certificate SEQUENCE
+    tag, _, content_off, _ = _parse_der_tlv(leaf_cert_der, 0)
+    if tag != 0x30:
+        raise ValueError("leaf cert: outer tag is not SEQUENCE")
+    # TBSCertificate SEQUENCE
+    tbs_off = content_off
+    tag2, l2, content_off2, _ = _parse_der_tlv(leaf_cert_der, tbs_off)
+    if tag2 != 0x30:
+        raise ValueError("leaf cert: TBS tag is not SEQUENCE")
+    end_tbs = content_off2 + l2
+    ptr = content_off2
+
+    # Optional [0] EXPLICIT version tag — context-specific, constructed.
+    if leaf_cert_der[ptr] == 0xA0:
+        _, _, _, c = _parse_der_tlv(leaf_cert_der, ptr)
+        ptr += c
+    # serialNumber (INTEGER)
+    _, _, _, c = _parse_der_tlv(leaf_cert_der, ptr)
+    ptr += c
+    # signature AlgorithmIdentifier
+    _, _, _, c = _parse_der_tlv(leaf_cert_der, ptr)
+    ptr += c
+    # issuer
+    _, _, _, c = _parse_der_tlv(leaf_cert_der, ptr)
+    ptr += c
+    # validity
+    _, _, _, c = _parse_der_tlv(leaf_cert_der, ptr)
+    ptr += c
+    # subject
+    _, _, _, c = _parse_der_tlv(leaf_cert_der, ptr)
+    ptr += c
+    # subjectPublicKeyInfo — the prize.
+    if ptr >= end_tbs:
+        raise ValueError("leaf cert: walked past TBS without finding SPKI")
+    spki_start = ptr
+    tag_spki, _, _, c_spki = _parse_der_tlv(leaf_cert_der, ptr)
+    if tag_spki != 0x30:
+        raise ValueError("leaf cert: SPKI tag is not SEQUENCE")
+    return leaf_cert_der[spki_start : spki_start + c_spki]
+
+
+def pixel_leaf_spki_sha256() -> str:
+    """SHA-256 hex of the Pixel leaf cert's SPKI bytes.
+
+    This is the value the pallet stores as `attest_key_hash` once it has
+    successfully verified the chain. Useful to log in the smoke output so a
+    human reviewing the demo can grep for it on chain.
+    """
+    leaf_der = base64.b64decode(PIXEL_KEY_CERT_B64)
+    spki = extract_leaf_spki_der(leaf_der)
+    return hashlib.sha256(spki).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic sr25519 attestor — the Layer 2 key (see module docstring).
+#
+# Generated fresh per session OR loaded from a stable file (set the env var
+# below to point at a JSON file that `WorkerKeypair` understands). Keeping
+# the key stable across sessions lets the operator register the pubkey ONCE
+# via `/admin/attestation-evidence-attestors` and then re-run the harness
+# repeatedly without re-registering.
+# ---------------------------------------------------------------------------
+
+
+def load_or_generate_synthetic_attestor() -> WorkerKeypair:
+    """Return the synthetic sr25519 keypair used for evidence-endpoint sigs.
+
+    If `PHASE2_ATTESTOR_KEY` is set and points at an existing file, load it.
+    Otherwise generate a fresh keypair (its pubkey will need re-registering
+    each session — fine for one-shot smokes; set the env var for long runs).
+    """
+    path = os.environ.get("PHASE2_ATTESTOR_KEY", "").strip()
+    if path and os.path.isfile(path):
+        return WorkerKeypair.load(path)
+    return WorkerKeypair.generate()
+
+
+# ---------------------------------------------------------------------------
+# Evidence-payload builder. Mirrors the canonical wire shape the gateway's
+# CBOR encoder + the pallet's verifier both expect:
+#
+#   { "cert_chain_b64": [<root>, <int>, ..., <leaf>] }
+#
+# Binary keys end in `_b64` per the gateway's pinned convention (see
+# `services/blob-gateway/src/schemas/compute_metering_v2.ts §
+# attestation_evidence — payload encoding`). The base64 strings are
+# canonical-CBOR-decoded into raw bytes by the encoder before signing.
+#
+# Note: the pallet's `ArmTrustZoneVerifier` SCALE-decodes the payload's
+# bytes-list as `Vec<Vec<u8>>` (chain entries). The gateway encodes the
+# same chain as a CBOR array of byte-strings. The cert-daemon is the layer
+# that translates the CBOR-array shape into the SCALE-array shape it
+# submits on chain — so the wire shapes don't have to match byte-for-byte.
+# What we need to keep stable is the LIST of cert DER bytes; that's what
+# this helper hands the gateway.
+# ---------------------------------------------------------------------------
+
+
+def build_arm_trustzone_payload(*, valid: bool = True) -> Dict[str, object]:
+    """Return the canonical evidence payload for an `arm_trustzone` entry.
+
+    Shape:
+        {
+            "cert_chain_b64": [<root>, <int1>, <int2>, <leaf>],
+            "device_model": "Pixel-strongbox-test-vector",
+            "security_level": "StrongBox",
+        }
+
+    The non-binary keys are metadata only — the pallet's verifier reads the
+    leaf cert's parsed `KeyDescription` for the actual security level. The
+    `device_model` / `security_level` strings are echoed in audit logs.
+    """
+    return {
+        "cert_chain_b64": pixel_chain_b64(valid=valid),
+        "device_model": "Pixel-strongbox-test-vector",
+        "security_level": "StrongBox",
+    }
+
+
+@dataclass(frozen=True)
+class SignedEvidence:
+    """Bundle ready to POST to `/v2/attestation_evidence`.
+
+    Attributes:
+        receipt_id: 64-hex receipt_id derived from content_hash.
+        evidence_type: "arm_trustzone".
+        nonce: sha256(content_hash || utf8(evidence_type)) — 64 hex.
+        payload: JSON-shaped payload dict (CBOR-canonicalised by the gateway).
+        attestor_pubkey: 64 hex of the synthetic sr25519 attestor.
+        signature: 128 hex sr25519 sig over canonical-CBOR(payload).
+    """
+
+    receipt_id: str
+    evidence_type: str
+    nonce: str
+    payload: Dict[str, object]
+    attestor_pubkey: str
+    signature: str
+
+    def to_wire(self) -> Dict[str, object]:
+        """Wire-format dict to JSON-encode for the POST body."""
+        return {
+            "receipt_id": self.receipt_id,
+            "evidence_type": self.evidence_type,
+            "nonce": self.nonce,
+            "payload": self.payload,
+            "attestor_pubkey": self.attestor_pubkey,
+            "signature": self.signature,
+        }
+
+
+def derive_receipt_id(content_hash_hex: str) -> str:
+    """Mirror of `services/blob-gateway/src/storage.ts::computeReceiptId`.
+
+    `receipt_id = sha256(content_hash_bytes)`. Returns 64 lowercase hex,
+    no `0x` prefix (the wire schema accepts both forms; we emit the
+    no-prefix form for byte-stable comparison with /admin endpoints).
+    """
+    cleaned = content_hash_hex[2:] if content_hash_hex.startswith("0x") else content_hash_hex
+    return hashlib.sha256(bytes.fromhex(cleaned)).hexdigest()
+
+
+def sign_evidence(
+    *,
+    content_hash_hex: str,
+    payload: Dict[str, object],
+    attestor: WorkerKeypair,
+    evidence_type: str = "arm_trustzone",
+) -> SignedEvidence:
+    """Build + sign an evidence bundle ready for `/v2/attestation_evidence`.
+
+    The gateway expects the signature over the canonical CBOR of the
+    PAYLOAD only (NOT the full evidence map). We re-use the SDK's pinned
+    encoder (`canonical_cbor_for_evidence_payload`) so byte equality with
+    the gateway's verifier is a byte-for-byte property test.
+    """
+    nonce = derive_evidence_nonce(content_hash_hex, evidence_type)
+    payload_bytes = canonical_cbor_for_evidence_payload(payload)
+    sig = attestor.sign_bytes(payload_bytes)
+    return SignedEvidence(
+        receipt_id=derive_receipt_id(content_hash_hex),
+        evidence_type=evidence_type,
+        nonce=nonce,
+        payload=payload,
+        attestor_pubkey=attestor.public_hex,
+        signature=sig.hex(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gateway client — register attestor + post evidence.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GatewayConfig:
+    base_url: str
+    bearer: str  # tenant-bound matra_* token (used by /metering/submit)
+    admin_token: Optional[str]  # admin shared secret (used by /admin/*)
+
+
+def gateway_evidence_endpoint_present(
+    base_url: str, *, timeout_s: float = 5.0
+) -> Optional[bool]:
+    """Probe whether the gateway exposes the v2.1 evidence endpoint.
+
+    Returns True if the route exists (any 4xx response other than 404),
+    False if the gateway returns 404, None on transport error.
+    Used by the prereq check; if the gateway image is the OLD one, all
+    Phase 2 tests skip with a clear message.
+    """
+    url = f"{base_url.rstrip('/')}/v2/attestation_evidence"
+    try:
+        with httpx.Client(timeout=timeout_s) as c:
+            r = c.post(url, json={"probe": True})
+        if r.status_code == 404:
+            return False
+        return True
+    except httpx.HTTPError:
+        return None
+
+
+def gateway_admin_attestor_endpoint_present(
+    base_url: str, *, admin_token: str, timeout_s: float = 5.0
+) -> Optional[bool]:
+    """Probe whether the admin-attestor registry route is deployed.
+
+    Sends a HEAD to GET /admin/attestation-evidence-attestors. 404 = not
+    deployed. 401/403/200/503 = deployed (gateway answered).
+    """
+    url = f"{base_url.rstrip('/')}/admin/attestation-evidence-attestors"
+    try:
+        with httpx.Client(timeout=timeout_s) as c:
+            r = c.get(url, headers={"x-admin-token": admin_token})
+        if r.status_code == 404:
+            return False
+        return True
+    except httpx.HTTPError:
+        return None
+
+
+def register_attestor(
+    cfg: GatewayConfig,
+    *,
+    pubkey_hex: str,
+    label: str,
+    notes: str,
+    timeout_s: float = 10.0,
+) -> Dict[str, object]:
+    """POST `/admin/attestation-evidence-attestors`. Idempotent: a 409
+    response (already-registered) is treated as success and the existing
+    row is returned. Any other non-2xx status raises.
+    """
+    if not cfg.admin_token:
+        raise RuntimeError("admin_token missing from GatewayConfig")
+    url = f"{cfg.base_url.rstrip('/')}/admin/attestation-evidence-attestors"
+    body = {"pubkey": pubkey_hex, "label": label, "notes": notes}
+    headers = {"x-admin-token": cfg.admin_token, "content-type": "application/json"}
+    with httpx.Client(timeout=timeout_s) as c:
+        r = c.post(url, json=body, headers=headers)
+    if r.status_code in (200, 201):
+        return r.json()
+    if r.status_code == 409:
+        # Already registered — return the existing row's JSON.
+        return r.json()
+    raise RuntimeError(
+        f"register_attestor: gateway returned {r.status_code} {r.text[:200]!r}"
+    )
+
+
+def post_evidence(
+    cfg: GatewayConfig,
+    bundle: SignedEvidence,
+    *,
+    timeout_s: float = 15.0,
+) -> Tuple[int, Dict[str, object]]:
+    """POST a signed evidence bundle to `/v2/attestation_evidence`.
+
+    Returns ``(status_code, decoded_json_body)``. Tests assert on both.
+    """
+    url = f"{cfg.base_url.rstrip('/')}/v2/attestation_evidence"
+    headers = {
+        "authorization": f"Bearer {cfg.bearer}",
+        "content-type": "application/json",
+        "user-agent": "materios-compute-meter-phase2-smoke/0.1",
+    }
+    with httpx.Client(timeout=timeout_s) as c:
+        r = c.post(url, json=bundle.to_wire(), headers=headers)
+    try:
+        body = r.json()
+    except Exception:
+        body = {"_raw": r.text}
+    return r.status_code, body
+
+
+# ---------------------------------------------------------------------------
+# Substrate prereq probe — confirms the pallet-tee-attestation runtime
+# upgrade has landed AND the kill-switch is flipped.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PalletReadiness:
+    metadata_present: bool   # True if `TeeAttestation` pallet is in metadata
+    disabled: Optional[bool]  # None if storage missing; bool when readable
+
+    @property
+    def fully_ready(self) -> bool:
+        return self.metadata_present and self.disabled is False
+
+
+def probe_pallet_tee_attestation(
+    rpc_url: str, *, pallet_name: str = "TeeAttestation", timeout_s: float = 10.0
+) -> Optional[PalletReadiness]:
+    """Connect to the Materios substrate RPC and inspect the runtime metadata.
+
+    Returns a `PalletReadiness` with two booleans, OR None if the RPC is
+    unreachable. The kill-switch storage is `Disabled: bool` per PR #17.
+    """
+    try:
+        # Local import — substrate-interface drags scalecodec at module-load,
+        # and we want the import error to show up in this helper rather than
+        # at test-collection time on hosts without the dep.
+        from substrateinterface import SubstrateInterface  # noqa: WPS433
+    except Exception:
+        return None
+    try:
+        si = SubstrateInterface(url=rpc_url, ws_options={"timeout": timeout_s})
+    except Exception:
+        return None
+    try:
+        metadata = si.metadata
+        names = [
+            getattr(p, "name", None) or p.value.get("name")
+            for p in metadata.pallets
+        ]
+        present = pallet_name in names
+        disabled: Optional[bool] = None
+        if present:
+            try:
+                v = si.query(pallet_name, "Disabled")
+                # `v` is a ScaleType wrapping a bool. `v.value` is the python bool.
+                disabled = bool(getattr(v, "value", v))
+            except Exception:
+                disabled = None
+        return PalletReadiness(metadata_present=present, disabled=disabled)
+    finally:
+        try:
+            si.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Cardano metadata probe — reads label-8746 leaves from a Cardano explorer
+# (cexplorer.io / Blockfrost / kupo) and asserts our receipt's
+# `attestation_evidence_hash` round-trips. The test calls into whatever
+# explorer is configured by env var; if no explorer is configured the
+# round-trip test skips.
+# ---------------------------------------------------------------------------
+
+
+def cardano_explorer_url(tx_hex: str) -> str:
+    """Return the cexplorer.io URL for a Cardano preprod tx.
+
+    Per the standing rule (`feedback_cardano_explorer.md`): use cexplorer.io
+    for ALL human-facing Cardano links. cardanoscan.io is NOT used.
+    """
+    cleaned = tx_hex[2:] if tx_hex.startswith("0x") else tx_hex
+    return f"https://preprod.cexplorer.io/tx/{cleaned}"
+
+
+def fetch_cardano_metadata_8746(
+    tx_hex: str,
+    *,
+    blockfrost_url: Optional[str] = None,
+    blockfrost_project_id: Optional[str] = None,
+    timeout_s: float = 15.0,
+) -> Optional[List[Dict[str, object]]]:
+    """Best-effort Cardano metadata fetch.
+
+    If ``blockfrost_url`` + ``blockfrost_project_id`` are provided, query
+    Blockfrost's tx-metadata endpoint and return the label-8746 entries.
+    Returns None when either argument is absent — callers should skip the
+    round-trip test in that case.
+
+    This deliberately does NOT depend on a long-living Cardano client; the
+    smoke harness is one-shot and a Blockfrost call is plenty.
+    """
+    if not blockfrost_url or not blockfrost_project_id:
+        return None
+    cleaned = tx_hex[2:] if tx_hex.startswith("0x") else tx_hex
+    url = f"{blockfrost_url.rstrip('/')}/txs/{cleaned}/metadata"
+    headers = {"project_id": blockfrost_project_id}
+    try:
+        with httpx.Client(timeout=timeout_s) as c:
+            r = c.get(url, headers=headers)
+    except httpx.HTTPError:
+        return None
+    if r.status_code != 200:
+        return None
+    try:
+        items = r.json()
+    except Exception:
+        return None
+    if not isinstance(items, list):
+        return None
+    out: List[Dict[str, object]] = []
+    for it in items:
+        if isinstance(it, dict) and str(it.get("label")) == "8746":
+            v = it.get("json_metadata")
+            if isinstance(v, dict):
+                out.append(v)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic helpers — used by the `pytest.skip(...)` reason strings so the
+# operator running the harness knows EXACTLY which prereq is missing.
+# ---------------------------------------------------------------------------
+
+
+def explain_skip(prereq: str, detail: Optional[str] = None) -> str:
+    """Format a uniform skip-reason string."""
+    base = f"Phase 2 Path C: prerequisite missing — {prereq}"
+    if detail:
+        return f"{base} ({detail})"
+    return base
+
+
+# Convenience: small list of the ENV vars this harness consults, surfaced
+# in a single skip message so an operator can see them all in one place.
+HARNESS_ENV_VARS: Tuple[str, ...] = (
+    "MATERIOS_E2E_GATEWAY",          # https://materios.fluxpointstudios.com/preprod-blobs
+    "MATERIOS_E2E_BEARER",           # tenant-bound matra_* Bearer
+    "MATERIOS_E2E_HARDWARE_SPEC",    # path to fleet-signed hardware.json
+    "MATERIOS_E2E_FLEET_OPERATOR_KEY",  # optional fleet-op key for re-issue
+    "MATERIOS_RPC_URL",              # ws://127.0.0.1:9945 or preprod public RPC
+    "PHASE2_ADMIN_TOKEN",            # gateway admin shared secret
+    "PHASE2_ATTESTOR_KEY",           # optional path to a saved attestor key
+    "PHASE2_BLOCKFROST_URL",         # https://cardano-preprod.blockfrost.io/api/v0
+    "PHASE2_BLOCKFROST_PROJECT_ID",  # preprodXXXXXXXX
+)

--- a/packages/compute-meter-sdk/tests/_phase2_helpers.py
+++ b/packages/compute-meter-sdk/tests/_phase2_helpers.py
@@ -517,6 +517,12 @@ def probe_pallet_tee_attestation(
         return None
     try:
         metadata = si.metadata
+        # `SubstrateInterface(url=...)` returns a constructor success even
+        # when the RPC URL doesn't speak Substrate (the websocket connects
+        # but no metadata is fetched). In that case `metadata` is None and
+        # the caller should treat the chain as unreachable.
+        if metadata is None or not hasattr(metadata, "pallets"):
+            return None
         names = [
             getattr(p, "name", None) or p.value.get("name")
             for p in metadata.pallets
@@ -531,6 +537,10 @@ def probe_pallet_tee_attestation(
             except Exception:
                 disabled = None
         return PalletReadiness(metadata_present=present, disabled=disabled)
+    except Exception:
+        # Any exception walking metadata or querying storage means the
+        # chain isn't actually reachable in the way we need it to be.
+        return None
     finally:
         try:
             si.close()

--- a/packages/compute-meter-sdk/tests/test_phase2_path_c_smoke.py
+++ b/packages/compute-meter-sdk/tests/test_phase2_path_c_smoke.py
@@ -1,0 +1,887 @@
+"""Phase 2 Path C smoke harness — Wave 3 polychain attestation, demo-mode.
+
+Path C is the test-vector-driven Phase 2 demo: when this harness goes green
+end-to-end, Materios Wave 3 Phase 2 is shipped. It submits a
+``compute_metering_v2.1`` record carrying a real Pixel StrongBox attestation
+chain (vendored from `pallets/tee-attestation/src/test_vectors.rs`), watches
+the gateway accept it, the cert-daemon attest it, the anchor-worker batch
+it onto Cardano L1, and the billing API surface ``composite_trust_score=1``
++ a Cardano anchor tx hash. cexplorer.io URL printed on success.
+
+The five acceptance criteria (one test each) come from the brief:
+
+    1. test_path_c_v2_record_lands_on_chain
+       — submit a v2.1 record with EMPTY evidence vec; assert receipt
+       reaches the chain within 60 s (proves the v2.1 schema is accepted).
+
+    2. test_path_c_evidence_submission_returns_correct_hash
+       — register the synthetic attestor, post one Pixel-chain evidence
+       entry, assert the gateway-returned attestation_evidence_hash equals
+       the off-chain canonical-CBOR-sha256 over the same vec.
+
+    3. test_path_c_invalid_pixel_chain_rejected
+       — post a TAMPERED Pixel cert chain (PIXEL_KEY_CERT_INVALID).
+       The gateway accepts the evidence at the endpoint level (it doesn't
+       run the Rust verifier locally), but the cert-daemon must REFUSE to
+       attest, so on-chain ``availability_cert_hash`` stays zero past a
+       reasonable wait window.
+
+    4. test_path_c_valid_pixel_chain_attested
+       — the headline demo. Post a GOOD Pixel chain; poll until
+       ``availability_cert_hash != 0`` AND ``composite_trust_score == 1``
+       AND ``cardano_anchor_tx != null``. When this passes, Phase 2
+       end-to-end is shipped.
+
+    5. test_path_c_anchor_evidence_hash_round_trips
+       — fetch the Cardano anchor tx via Blockfrost, parse label-8746,
+       find the leaf for our receipt, assert the leaf's
+       ``attestation_evidence_hash`` matches the SDK-computed value.
+
+All five are gated behind ``@pytest.mark.phase_2_smoke`` so they only run
+when explicitly invoked: ``pytest -m phase_2_smoke -v``.
+
+Pre-flight skip conditions (each test prints exactly which one fired):
+
+    * Gateway unreachable — DNS/TLS error.
+    * ``/v2/attestation_evidence`` 404s — gateway image is the OLD one.
+    * ``/admin/attestation-evidence-attestors`` 404s — same.
+    * RPC unreachable — Materios chain RPC down.
+    * Pallet metadata missing — runtime upgrade hasn't landed yet.
+    * Pallet ``Disabled`` is true — kill-switch flipped on, sudo-flip
+      via ``set_disabled(false)`` needed.
+    * Bearer / Hardware-spec env vars missing — same as the v2 e2e suite.
+    * Gateway admin token missing — needed to register the attestor.
+
+The harness ships in this state on purpose: every prereq has a clear,
+named skip message. Future-deci runs ``pytest -m phase_2_smoke -v`` and
+the skips tell them what's left to do.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import httpx
+import pytest
+
+from materios_compute_meter import (
+    HardwareSpec,
+    SubmissionResult,
+    WorkerKeypair,
+    build_record_v2,
+    canonical_content_hash_v2,
+    sign_record_v2,
+    submit_v2,
+    verify_record_v2,
+)
+from materios_compute_meter.canonical import attestation_evidence_hash
+
+from tests._e2e_helpers import (
+    GatewayConfig as E2EGatewayConfig,
+    PollResult,
+    _exp_backoff,
+    _find_record_by_hash,
+    fetch_billing_usage,
+)
+from tests._phase2_helpers import (
+    GatewayConfig as Phase2GatewayConfig,
+    HARNESS_ENV_VARS,
+    PalletReadiness,
+    build_arm_trustzone_payload,
+    cardano_explorer_url,
+    derive_receipt_id,
+    explain_skip,
+    fetch_cardano_metadata_8746,
+    gateway_admin_attestor_endpoint_present,
+    gateway_evidence_endpoint_present,
+    load_or_generate_synthetic_attestor,
+    post_evidence,
+    probe_pallet_tee_attestation,
+    register_attestor,
+    sign_evidence,
+)
+
+pytestmark = pytest.mark.phase_2_smoke
+
+_LOG = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Resolved configuration. All env vars listed in `HARNESS_ENV_VARS`.
+# ---------------------------------------------------------------------------
+
+GATEWAY_URL = os.environ.get(
+    "MATERIOS_E2E_GATEWAY",
+    "https://materios.fluxpointstudios.com/preprod-blobs",
+)
+BEARER = os.environ.get("MATERIOS_E2E_BEARER", "")
+HARDWARE_SPEC_PATH = os.environ.get("MATERIOS_E2E_HARDWARE_SPEC", "")
+FLEET_OPERATOR_KEY_PATH = os.environ.get("MATERIOS_E2E_FLEET_OPERATOR_KEY", "")
+RPC_URL = os.environ.get("MATERIOS_RPC_URL", "ws://127.0.0.1:9945")
+ADMIN_TOKEN = os.environ.get("PHASE2_ADMIN_TOKEN", "")
+TENANT_ID_PREFIX = os.environ.get("MATERIOS_E2E_TENANT_ID", "tenant-phase2")
+WORKER_ID_PREFIX = os.environ.get("MATERIOS_E2E_WORKER_ID", "worker-phase2")
+BLOCKFROST_URL = os.environ.get(
+    "PHASE2_BLOCKFROST_URL", "https://cardano-preprod.blockfrost.io/api/v0"
+)
+BLOCKFROST_PROJECT_ID = os.environ.get("PHASE2_BLOCKFROST_PROJECT_ID", "")
+
+# Polling budgets. Set conservatively; the demo's slow leg is the Cardano
+# anchor (~5-15 min p50 on preprod). Override via env for fast/slow fleets.
+DEADLINE_RECEIPT_S = float(os.environ.get("PHASE2_DEADLINE_RECEIPT_S", "60"))
+DEADLINE_CERT_S = float(os.environ.get("PHASE2_DEADLINE_CERT_S", "600"))
+DEADLINE_NEGATIVE_S = float(os.environ.get("PHASE2_DEADLINE_NEGATIVE_S", "180"))
+DEADLINE_ANCHOR_S = float(os.environ.get("PHASE2_DEADLINE_ANCHOR_S", "1200"))
+
+
+# ---------------------------------------------------------------------------
+# Module-scope prerequisite probe — used by every test's skip path.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Prereqs:
+    """Resolved state of the harness's external prerequisites.
+
+    Used by per-test fixtures: each test calls into this once and skips on
+    the first unmet condition. The dataclass is frozen so a half-cached
+    `Prereqs` can't be mutated mid-run by a flaky test.
+    """
+
+    bearer_set: bool
+    hardware_spec_set: bool
+    admin_token_set: bool
+    gateway_evidence_route_present: Optional[bool]  # None = transport error
+    gateway_admin_attestor_route_present: Optional[bool]
+    pallet: Optional[PalletReadiness]  # None = RPC unreachable
+
+    def first_unmet_reason(self, *, requires_admin: bool = True) -> Optional[str]:
+        """Return the human-readable reason for the FIRST failing prereq, or
+        None when all required conditions are satisfied.
+
+        The order matches the sequence of operations in the actual harness
+        — env vars first (cheapest to fail), then network probes, then
+        chain probes (most expensive). Order of messages is the order the
+        operator should fix things.
+        """
+        if not self.bearer_set:
+            return explain_skip(
+                "MATERIOS_E2E_BEARER not set",
+                f"see {', '.join(HARNESS_ENV_VARS)} for the full env list",
+            )
+        if not self.hardware_spec_set:
+            return explain_skip(
+                "MATERIOS_E2E_HARDWARE_SPEC not set",
+                "pass the path to a fleet-operator-signed hardware spec JSON",
+            )
+        if requires_admin and not self.admin_token_set:
+            return explain_skip(
+                "PHASE2_ADMIN_TOKEN not set",
+                "needed to register the synthetic attestor pubkey via "
+                "POST /admin/attestation-evidence-attestors",
+            )
+        if self.gateway_evidence_route_present is None:
+            return explain_skip(
+                f"gateway {GATEWAY_URL} is unreachable",
+                "transport error probing /v2/attestation_evidence",
+            )
+        if self.gateway_evidence_route_present is False:
+            return explain_skip(
+                "gateway image is too old — POST /v2/attestation_evidence is 404",
+                "deploy the v2.1 gateway image (PR #34 already merged to "
+                "orynq-sdk main)",
+            )
+        if requires_admin and self.gateway_admin_attestor_route_present is False:
+            return explain_skip(
+                "gateway image is too old — /admin/attestation-evidence-attestors is 404",
+                "deploy the v2.1 gateway image (PR #34)",
+            )
+        if self.pallet is None:
+            return explain_skip(
+                f"Materios RPC at {RPC_URL} is unreachable",
+                "set MATERIOS_RPC_URL to a reachable endpoint",
+            )
+        if not self.pallet.metadata_present:
+            return explain_skip(
+                "pallet-tee-attestation is not in runtime metadata",
+                "the runtime upgrade ceremony for PR #17 hasn't landed yet",
+            )
+        if self.pallet.disabled is None:
+            return explain_skip(
+                "pallet-tee-attestation::Disabled storage unreadable",
+                "metadata exposes the pallet but the storage query failed",
+            )
+        if self.pallet.disabled is True:
+            return explain_skip(
+                "pallet-tee-attestation::Disabled is true (kill-switch on)",
+                "sudo-flip via set_disabled(false) needed before the smoke can run",
+            )
+        return None
+
+
+@pytest.fixture(scope="module")
+def prereqs() -> Prereqs:
+    """Resolve once per module. Tests skip on whatever the FIRST unmet
+    condition is — the order in `Prereqs.first_unmet_reason` is the
+    operator-friendly fix sequence.
+    """
+    base_url = GATEWAY_URL.rstrip("/")
+    ev_route = gateway_evidence_endpoint_present(base_url)
+    if ADMIN_TOKEN:
+        admin_route = gateway_admin_attestor_endpoint_present(
+            base_url, admin_token=ADMIN_TOKEN
+        )
+    else:
+        admin_route = None
+    pallet = probe_pallet_tee_attestation(RPC_URL)
+    return Prereqs(
+        bearer_set=bool(BEARER),
+        hardware_spec_set=bool(HARDWARE_SPEC_PATH and os.path.isfile(HARDWARE_SPEC_PATH)),
+        admin_token_set=bool(ADMIN_TOKEN),
+        gateway_evidence_route_present=ev_route,
+        gateway_admin_attestor_route_present=admin_route,
+        pallet=pallet,
+    )
+
+
+def _skip_unless_ready(prereqs: Prereqs, *, requires_admin: bool = True) -> None:
+    """Helper: skip with a clear reason on the first unmet prereq."""
+    reason = prereqs.first_unmet_reason(requires_admin=requires_admin)
+    if reason is not None:
+        pytest.skip(reason)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: hardware spec, worker key, attestor key. Module-scoped where
+# possible to keep the smoke single-trip on the chain.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def hardware_spec(prereqs: Prereqs) -> HardwareSpec:
+    if not prereqs.hardware_spec_set:
+        pytest.skip(prereqs.first_unmet_reason() or "hardware spec missing")
+    return HardwareSpec.load(HARDWARE_SPEC_PATH)
+
+
+@pytest.fixture(scope="module")
+def fleet_operator_kp() -> Optional[WorkerKeypair]:
+    if FLEET_OPERATOR_KEY_PATH and os.path.isfile(FLEET_OPERATOR_KEY_PATH):
+        return WorkerKeypair.load(FLEET_OPERATOR_KEY_PATH)
+    return None
+
+
+@pytest.fixture(scope="module")
+def worker_kp() -> WorkerKeypair:
+    return WorkerKeypair.generate()
+
+
+@pytest.fixture(scope="module")
+def attestor_kp() -> WorkerKeypair:
+    """Synthetic sr25519 attestor — the Layer-2 key (see
+    ``_phase2_helpers.py`` module docstring). Pubkey is registered with
+    the gateway once per session.
+    """
+    return load_or_generate_synthetic_attestor()
+
+
+@pytest.fixture(scope="module")
+def gateway_cfg() -> Phase2GatewayConfig:
+    return Phase2GatewayConfig(
+        base_url=GATEWAY_URL.rstrip("/"),
+        bearer=BEARER,
+        admin_token=ADMIN_TOKEN or None,
+    )
+
+
+@pytest.fixture(scope="module")
+def e2e_gateway_cfg() -> E2EGatewayConfig:
+    """Re-use the v1/v2 e2e helpers' config shape for billing/usage polls."""
+    return E2EGatewayConfig(base_url=GATEWAY_URL.rstrip("/"), bearer=BEARER)
+
+
+@pytest.fixture(scope="module")
+def attestor_registered(
+    prereqs: Prereqs, attestor_kp: WorkerKeypair, gateway_cfg: Phase2GatewayConfig
+) -> str:
+    """Register the synthetic attestor's pubkey (idempotent). Returns the
+    pubkey hex on success. Skips on the first unmet prereq.
+    """
+    _skip_unless_ready(prereqs, requires_admin=True)
+    register_attestor(
+        gateway_cfg,
+        pubkey_hex=attestor_kp.public_hex,
+        label="phase-2-path-c-pixel-strongbox-test-vector",
+        notes=(
+            "Phase 2 Path C demo. Synthetic sr25519 keypair signing real "
+            "Google-rooted Pixel StrongBox cert chain from "
+            "pallets/tee-attestation/src/test_vectors.rs. Layer-1 chain trust "
+            "is what the on-chain pallet verifies; this Layer-2 sig only "
+            "authenticates the evidence-submission endpoint. Replaceable by "
+            "live-phone evidence once Acurast onboarding unblocks."
+        ),
+    )
+    return attestor_kp.public_hex
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build a per-test sealed v2.1 envelope.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_spec_for_worker(
+    base_spec: HardwareSpec, fleet_kp: Optional[WorkerKeypair], worker_id: str
+) -> HardwareSpec:
+    """If ``base_spec`` verifies for ``worker_id``, use it as-is. Otherwise
+    re-issue with ``fleet_kp`` (the v2 e2e suite's pattern). Skips when
+    neither path is available.
+    """
+    if base_spec.verify(worker_id):
+        return base_spec
+    if fleet_kp is not None:
+        from materios_compute_meter.hardware_spec import sign_hardware_spec
+
+        return sign_hardware_spec(
+            worker_id=worker_id,
+            cpu_cores=base_spec.cpu_cores,
+            ram_gb=base_spec.ram_gb,
+            gpu_type=base_spec.gpu_type,
+            gpu_count=base_spec.gpu_count,
+            issued_ms=int(time.time() * 1000),
+            fleet_operator_keypair=fleet_kp,
+        )
+    pytest.skip(
+        "hardware_spec does not verify for the synthetic worker_id and no "
+        "MATERIOS_E2E_FLEET_OPERATOR_KEY is set; cannot re-issue per run"
+    )
+
+
+def _build_v2_1_envelope(
+    *,
+    spec: HardwareSpec,
+    worker_kp: WorkerKeypair,
+    worker_id: str,
+    tenant_id: str,
+    period_start_ms: int,
+    period_end_ms: int,
+) -> Dict[str, Any]:
+    """Build + sign a v2 record body (no attestation_evidence inline — the
+    evidence is posted to /v2/attestation_evidence in a SECOND call).
+
+    The schema_version on the wire stays ``compute_metering_v2`` because
+    the evidence is attached out-of-band; per the v2.1 spec
+    (services/blob-gateway/src/schemas/compute_metering_v2.ts), the
+    schema literal flips to ``compute_metering_v2.1`` ONLY when
+    ``attestation_evidence`` is non-empty INSIDE the metering record. The
+    Path C harness uses the out-of-band path because that's the path the
+    real cert-daemon uses (see PR #34 design doc).
+    """
+    body = build_record_v2(
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+        metrics={
+            "cpu_seconds": 30,
+            "ram_gb_hours": 0.05,
+            "disk_gb_hours": 0.0,
+            "net_bytes_in": 4096,
+            "net_bytes_out": 2048,
+            "gpu_seconds": 0,
+        },
+        hardware_spec=spec,
+    )
+    return sign_record_v2(body, worker_kp)
+
+
+def _wait_for_anchor(
+    cfg: E2EGatewayConfig,
+    *,
+    tenant_id: str,
+    content_hash: str,
+    period_start_ms: int,
+    period_end_ms: int,
+    deadline_s: float,
+    require_trust_score: bool,
+) -> PollResult:
+    """Poll ``/billing/usage`` until the record reports ``cardano_anchor_tx``
+    AND (optionally) ``composite_trust_score >= 1`` — the Phase-2 demo's
+    headline state.
+
+    Mirrors the existing ``wait_for_cardano_anchor`` pattern from
+    ``_e2e_helpers.py`` but adds the trust-score gate (which the existing
+    helper doesn't know about — it pre-dates v2.1).
+    """
+    start = time.monotonic()
+    attempt = 0
+    last_body: Optional[Dict[str, Any]] = None
+    last_status: Optional[str] = None
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= deadline_s:
+            return PollResult(
+                success=False,
+                elapsed_s=elapsed,
+                polls=attempt,
+                final=last_body,
+                final_status=last_status,
+            )
+        attempt += 1
+        try:
+            r = fetch_billing_usage(
+                cfg,
+                tenant_id=tenant_id,
+                start_ms=max(0, period_start_ms - 1),
+                end_ms=period_end_ms + 1,
+                include_records=True,
+                timeout_s=15.0,
+            )
+        except httpx.HTTPError:
+            time.sleep(_exp_backoff(attempt))
+            continue
+        if r.status_code == 200:
+            try:
+                body = r.json()
+            except Exception:
+                body = None
+            if isinstance(body, dict):
+                last_body = body
+                rec = _find_record_by_hash(body, content_hash)
+                if rec is not None:
+                    last_status = rec.get("attestation_status")
+                    anchor_tx = rec.get("cardano_anchor_tx")
+                    trust_score = rec.get("composite_trust_score")
+                    score_ok = (
+                        trust_score is not None and int(trust_score) >= 1
+                        if require_trust_score
+                        else True
+                    )
+                    if anchor_tx and score_ok:
+                        return PollResult(
+                            success=True,
+                            elapsed_s=time.monotonic() - start,
+                            polls=attempt,
+                            final=body,
+                            final_status="anchored",
+                        )
+        remaining = deadline_s - (time.monotonic() - start)
+        if remaining <= 0:
+            continue
+        time.sleep(min(_exp_backoff(attempt), max(0.5, remaining)))
+
+
+# ===========================================================================
+# Test 1 — v2.1 record lands on chain (with empty evidence vec)
+# ===========================================================================
+
+
+def test_path_c_v2_record_lands_on_chain(
+    prereqs: Prereqs,
+    hardware_spec: HardwareSpec,
+    fleet_operator_kp: Optional[WorkerKeypair],
+    worker_kp: WorkerKeypair,
+    e2e_gateway_cfg: E2EGatewayConfig,
+) -> None:
+    """Submit a v2.1 record (with empty evidence vec — i.e. plain v2 wire
+    bytes) and confirm the gateway records it under our tenant within a
+    minute. This is the smoke's first leg — it proves the gateway accepts
+    the v2.1 SDK payload shape under the tenant-bound bearer."""
+    _skip_unless_ready(prereqs, requires_admin=False)
+
+    period_start_ms = int(time.time() * 1000)
+    period_end_ms = period_start_ms + 60_000
+    worker_id = f"{WORKER_ID_PREFIX}-t1-{period_start_ms}"
+    tenant_id = f"{TENANT_ID_PREFIX}-t1-{period_start_ms}"
+
+    spec = _resolve_spec_for_worker(hardware_spec, fleet_operator_kp, worker_id)
+    sealed = _build_v2_1_envelope(
+        spec=spec,
+        worker_kp=worker_kp,
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+    )
+
+    assert verify_record_v2(sealed) is True
+    expected_hash = canonical_content_hash_v2(sealed)
+    res = submit_v2(sealed, gateway_url=GATEWAY_URL, bearer=BEARER)
+    assert isinstance(res, SubmissionResult)
+    assert 200 <= res.status_code < 300, f"submit_v2 status={res.status_code}"
+    assert res.content_hash == expected_hash, (
+        "gateway-returned content_hash diverged from SDK-computed"
+    )
+
+    # Poll the gateway's /billing/usage until our record is visible. The
+    # window is narrow so a single page contains the row.
+    deadline = time.monotonic() + DEADLINE_RECEIPT_S
+    seen = False
+    while time.monotonic() < deadline and not seen:
+        r = fetch_billing_usage(
+            e2e_gateway_cfg,
+            tenant_id=tenant_id,
+            start_ms=period_start_ms - 1,
+            end_ms=period_end_ms + 1,
+            include_records=True,
+            timeout_s=10.0,
+        )
+        if r.status_code == 200:
+            body = r.json() if r.text else {}
+            if _find_record_by_hash(body, expected_hash) is not None:
+                seen = True
+                break
+        time.sleep(2.0)
+    assert seen, (
+        f"v2.1 record content_hash={expected_hash} did not appear in "
+        f"/billing/usage within {DEADLINE_RECEIPT_S}s"
+    )
+
+
+# ===========================================================================
+# Test 2 — evidence submission returns the expected hash
+# ===========================================================================
+
+
+def test_path_c_evidence_submission_returns_correct_hash(
+    prereqs: Prereqs,
+    hardware_spec: HardwareSpec,
+    fleet_operator_kp: Optional[WorkerKeypair],
+    worker_kp: WorkerKeypair,
+    attestor_kp: WorkerKeypair,
+    attestor_registered: str,
+    gateway_cfg: Phase2GatewayConfig,
+    e2e_gateway_cfg: E2EGatewayConfig,
+) -> None:
+    """Round-trip an evidence submission and assert the returned
+    ``attestation_evidence_hash`` equals what we compute off-chain via the
+    SDK's pinned canonical-CBOR encoder.
+
+    This is the gateway-side property test: the encoder on both sides
+    (Python in our SDK, TypeScript in the gateway) MUST agree byte-for-byte
+    on the evidence hash. The cross-language test (test_v2_1_cross_lang.py)
+    already proves this with synthetic vectors; this test verifies the same
+    property end-to-end with a real gateway round-trip.
+    """
+    _skip_unless_ready(prereqs, requires_admin=True)
+    assert attestor_registered == attestor_kp.public_hex
+
+    # Build + submit the metering record first — the evidence post requires
+    # the receipt's content_hash to derive the nonce.
+    period_start_ms = int(time.time() * 1000)
+    period_end_ms = period_start_ms + 60_000
+    worker_id = f"{WORKER_ID_PREFIX}-t2-{period_start_ms}"
+    tenant_id = f"{TENANT_ID_PREFIX}-t2-{period_start_ms}"
+
+    spec = _resolve_spec_for_worker(hardware_spec, fleet_operator_kp, worker_id)
+    sealed = _build_v2_1_envelope(
+        spec=spec,
+        worker_kp=worker_kp,
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+    )
+    expected_content_hash = canonical_content_hash_v2(sealed)
+    submit_v2(sealed, gateway_url=GATEWAY_URL, bearer=BEARER)
+
+    # Build + post evidence. The Pixel chain in the payload is the REAL one;
+    # the sig is from our synthetic sr25519 attestor (Layer 1 vs Layer 2,
+    # see _phase2_helpers.py).
+    payload = build_arm_trustzone_payload(valid=True)
+    bundle = sign_evidence(
+        content_hash_hex=expected_content_hash,
+        payload=payload,
+        attestor=attestor_kp,
+        evidence_type="arm_trustzone",
+    )
+    status, body = post_evidence(gateway_cfg, bundle)
+    assert status == 200, f"evidence post failed: {status} {body!r}"
+    assert body.get("ok") is True, body
+    assert body.get("status") in ("accepted", "replay"), body
+    returned_hash = body.get("attestation_evidence_hash")
+    assert isinstance(returned_hash, str) and len(returned_hash) == 64
+
+    # Off-chain recomputation: build the canonical-CBOR-sha256 over the
+    # ONE-entry evidence vec we just stored and confirm equality.
+    expected_evidence_hash = attestation_evidence_hash(
+        [
+            {
+                "evidence_type": bundle.evidence_type,
+                "nonce": bundle.nonce,
+                "payload": bundle.payload,
+                "attestor_pubkey": bundle.attestor_pubkey,
+            }
+        ]
+    )
+    assert returned_hash == expected_evidence_hash, (
+        f"gateway-returned attestation_evidence_hash {returned_hash!r} != "
+        f"SDK-computed {expected_evidence_hash!r} — encoder drift"
+    )
+
+
+# ===========================================================================
+# Test 3 — invalid Pixel chain is rejected (cert-daemon refuses to attest)
+# ===========================================================================
+
+
+def test_path_c_invalid_pixel_chain_rejected(
+    prereqs: Prereqs,
+    hardware_spec: HardwareSpec,
+    fleet_operator_kp: Optional[WorkerKeypair],
+    worker_kp: WorkerKeypair,
+    attestor_kp: WorkerKeypair,
+    attestor_registered: str,
+    gateway_cfg: Phase2GatewayConfig,
+    e2e_gateway_cfg: E2EGatewayConfig,
+) -> None:
+    """Submit a TAMPERED Pixel chain (PIXEL_KEY_CERT_INVALID — last byte of
+    the leaf signature flipped). The gateway accepts the evidence at the
+    endpoint level (it doesn't run the Rust verifier locally), but the
+    cert-daemon must REFUSE to attest. We assert the on-chain
+    ``availability_cert_hash`` stays at zero past a reasonable deadline.
+
+    The deadline is shorter than the positive test's anchor wait — we're
+    checking ABSENCE of attestation, so we want to fail fast if the
+    cert-daemon decided to attest anyway.
+    """
+    _skip_unless_ready(prereqs, requires_admin=True)
+    assert attestor_registered == attestor_kp.public_hex
+
+    period_start_ms = int(time.time() * 1000)
+    period_end_ms = period_start_ms + 60_000
+    worker_id = f"{WORKER_ID_PREFIX}-t3-{period_start_ms}"
+    tenant_id = f"{TENANT_ID_PREFIX}-t3-{period_start_ms}"
+
+    spec = _resolve_spec_for_worker(hardware_spec, fleet_operator_kp, worker_id)
+    sealed = _build_v2_1_envelope(
+        spec=spec,
+        worker_kp=worker_kp,
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+    )
+    expected_content_hash = canonical_content_hash_v2(sealed)
+    submit_v2(sealed, gateway_url=GATEWAY_URL, bearer=BEARER)
+
+    # Tampered chain — pallet's chain-of-trust check will fail at the leaf.
+    payload = build_arm_trustzone_payload(valid=False)
+    bundle = sign_evidence(
+        content_hash_hex=expected_content_hash,
+        payload=payload,
+        attestor=attestor_kp,
+    )
+    status, body = post_evidence(gateway_cfg, bundle)
+    # Endpoint accepts the evidence — it doesn't run the Rust verifier.
+    assert status == 200, f"evidence post unexpectedly failed: {status} {body!r}"
+
+    # Now the absence assertion: poll for `composite_trust_score`. After
+    # `DEADLINE_NEGATIVE_S`, the score MUST still be 0 (or the field absent
+    # / null). If the cert-daemon attested a tampered chain, this fails
+    # loudly.
+    deadline = time.monotonic() + DEADLINE_NEGATIVE_S
+    last_seen_score: Any = None
+    last_seen_anchor: Any = None
+    while time.monotonic() < deadline:
+        r = fetch_billing_usage(
+            e2e_gateway_cfg,
+            tenant_id=tenant_id,
+            start_ms=period_start_ms - 1,
+            end_ms=period_end_ms + 1,
+            include_records=True,
+            timeout_s=10.0,
+        )
+        if r.status_code == 200:
+            body = r.json() if r.text else {}
+            rec = _find_record_by_hash(body, expected_content_hash)
+            if rec is not None:
+                last_seen_score = rec.get("composite_trust_score")
+                last_seen_anchor = rec.get("cardano_anchor_tx")
+                # Hard fail if the cert-daemon attested.
+                if last_seen_score is not None and int(last_seen_score) > 0:
+                    pytest.fail(
+                        f"tampered Pixel chain unexpectedly attested: "
+                        f"composite_trust_score={last_seen_score}, "
+                        f"cardano_anchor_tx={last_seen_anchor!r}. The pallet's "
+                        f"ArmTrustZoneVerifier should have failed "
+                        f"ChainOfTrustBroken on PIXEL_KEY_CERT_INVALID."
+                    )
+        time.sleep(5.0)
+    # Reached the deadline with no attestation — exactly what we want.
+    assert (last_seen_score in (None, 0)), (
+        f"unexpected end-state composite_trust_score={last_seen_score}"
+    )
+
+
+# ===========================================================================
+# Test 4 — the headline demo: valid Pixel chain attests + anchors to L1
+# ===========================================================================
+
+
+def test_path_c_valid_pixel_chain_attested(
+    prereqs: Prereqs,
+    hardware_spec: HardwareSpec,
+    fleet_operator_kp: Optional[WorkerKeypair],
+    worker_kp: WorkerKeypair,
+    attestor_kp: WorkerKeypair,
+    attestor_registered: str,
+    gateway_cfg: Phase2GatewayConfig,
+    e2e_gateway_cfg: E2EGatewayConfig,
+    request: pytest.FixtureRequest,
+) -> None:
+    """The Path C headline demo. When this passes, Phase 2 end-to-end is
+    SHIPPED.
+
+    Submits a valid Pixel chain. Polls until the receipt has BOTH:
+        * ``composite_trust_score >= 1`` (cert-daemon attested), AND
+        * ``cardano_anchor_tx`` non-null (anchor-worker batched it).
+    Prints the cexplorer.io URL on success — the demo's evidence link.
+    """
+    _skip_unless_ready(prereqs, requires_admin=True)
+    assert attestor_registered == attestor_kp.public_hex
+
+    period_start_ms = int(time.time() * 1000)
+    period_end_ms = period_start_ms + 60_000
+    worker_id = f"{WORKER_ID_PREFIX}-t4-{period_start_ms}"
+    tenant_id = f"{TENANT_ID_PREFIX}-t4-{period_start_ms}"
+
+    spec = _resolve_spec_for_worker(hardware_spec, fleet_operator_kp, worker_id)
+    sealed = _build_v2_1_envelope(
+        spec=spec,
+        worker_kp=worker_kp,
+        worker_id=worker_id,
+        tenant_id=tenant_id,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+    )
+    content_hash = canonical_content_hash_v2(sealed)
+    submit_v2(sealed, gateway_url=GATEWAY_URL, bearer=BEARER)
+
+    payload = build_arm_trustzone_payload(valid=True)
+    bundle = sign_evidence(
+        content_hash_hex=content_hash, payload=payload, attestor=attestor_kp
+    )
+    status, body = post_evidence(gateway_cfg, bundle)
+    assert status == 200, f"evidence post failed: {status} {body!r}"
+    expected_evidence_hash = body.get("attestation_evidence_hash")
+    assert isinstance(expected_evidence_hash, str) and len(expected_evidence_hash) == 64
+
+    # Watch the chain.
+    result = _wait_for_anchor(
+        e2e_gateway_cfg,
+        tenant_id=tenant_id,
+        content_hash=content_hash,
+        period_start_ms=period_start_ms,
+        period_end_ms=period_end_ms,
+        deadline_s=DEADLINE_ANCHOR_S,
+        require_trust_score=True,
+    )
+    assert result.success, (
+        f"Phase 2 headline assertion FAILED: receipt did not anchor + attest "
+        f"within {DEADLINE_ANCHOR_S}s. final_status={result.final_status!r}, "
+        f"polls={result.polls}, final body excerpt={str(result.final)[:400]!r}"
+    )
+    rec = _find_record_by_hash(result.final or {}, content_hash) or {}
+    anchor_tx = rec.get("cardano_anchor_tx")
+    trust_score = rec.get("composite_trust_score")
+    explorer = cardano_explorer_url(str(anchor_tx))
+    _LOG.info(
+        "Phase 2 Path C demo complete: composite_trust_score=%s anchor_tx=%s "
+        "explorer=%s",
+        trust_score,
+        anchor_tx,
+        explorer,
+    )
+    # Stash for the round-trip test in case it's run in the same session.
+    request.config.cache.set("phase2/last_anchor_tx", str(anchor_tx))
+    request.config.cache.set("phase2/last_content_hash", content_hash)
+    request.config.cache.set("phase2/last_evidence_hash", expected_evidence_hash)
+    request.config.cache.set("phase2/last_receipt_id", derive_receipt_id(content_hash))
+
+    assert isinstance(anchor_tx, str) and len(anchor_tx) >= 64
+    assert int(trust_score) >= 1
+
+
+# ===========================================================================
+# Test 5 — Cardano-anchor round-trip: label-8746 leaf carries our evidence_hash
+# ===========================================================================
+
+
+def test_path_c_anchor_evidence_hash_round_trips(
+    prereqs: Prereqs,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Read back the Cardano anchor tx for the headline demo, parse the
+    label-8746 metadata, find the leaf for our receipt, and assert the
+    leaf's ``attestation_evidence_hash`` equals what we computed off-chain.
+
+    This is what closes the Phase 2 loop end-to-end:
+    real Google-rooted hardware attestation → Cardano L1 audit trail.
+    """
+    _skip_unless_ready(prereqs, requires_admin=True)
+
+    if not BLOCKFROST_PROJECT_ID:
+        pytest.skip(
+            explain_skip(
+                "PHASE2_BLOCKFROST_PROJECT_ID not set",
+                "needed to fetch tx metadata for the round-trip assertion",
+            )
+        )
+
+    cache = request.config.cache
+    anchor_tx = cache.get("phase2/last_anchor_tx", None)
+    receipt_id = cache.get("phase2/last_receipt_id", None)
+    evidence_hash = cache.get("phase2/last_evidence_hash", None)
+    if not (anchor_tx and receipt_id and evidence_hash):
+        pytest.skip(
+            "round-trip test requires test_path_c_valid_pixel_chain_attested "
+            "to have run successfully in the same session"
+        )
+
+    metas = fetch_cardano_metadata_8746(
+        str(anchor_tx),
+        blockfrost_url=BLOCKFROST_URL,
+        blockfrost_project_id=BLOCKFROST_PROJECT_ID,
+    )
+    if metas is None:
+        pytest.skip(
+            "Blockfrost did not return metadata for the anchor tx (transient "
+            "explorer lag or wrong network); rerun"
+        )
+    assert metas, f"no label-8746 entries in tx {anchor_tx}"
+
+    # Walk every label-8746 entry's `leaves` list (or top-level dict shape —
+    # the on-chain payload format is documented in
+    # project_cardano_l1_metadata_labels.md). Find a leaf with our
+    # receipt_id and assert its `attestation_evidence_hash`.
+    found = False
+    cleaned_receipt = (
+        receipt_id[2:] if str(receipt_id).startswith("0x") else str(receipt_id)
+    )
+    for meta in metas:
+        leaves = meta.get("leaves") if isinstance(meta, dict) else None
+        if not isinstance(leaves, list):
+            continue
+        for leaf in leaves:
+            if not isinstance(leaf, dict):
+                continue
+            leaf_rid = str(leaf.get("receipt_id", "")).lower()
+            leaf_rid = leaf_rid[2:] if leaf_rid.startswith("0x") else leaf_rid
+            if leaf_rid == cleaned_receipt.lower():
+                leaf_eh = str(leaf.get("attestation_evidence_hash", "")).lower()
+                leaf_eh = leaf_eh[2:] if leaf_eh.startswith("0x") else leaf_eh
+                assert leaf_eh == str(evidence_hash).lower(), (
+                    f"leaf attestation_evidence_hash on chain {leaf_eh} != "
+                    f"SDK-computed {evidence_hash}"
+                )
+                found = True
+                break
+        if found:
+            break
+    assert found, (
+        f"no leaf in label-8746 metadata of {anchor_tx} matched our "
+        f"receipt_id={cleaned_receipt}"
+    )


### PR DESCRIPTION
## Summary

Ships the **Wave 3 Phase 2 Path C smoke harness** — a test-vector-driven
end-to-end demo that closes the polychain-attestation loop without a live
phone. When the runtime upgrade for [PR #17 (pallet-tee-attestation)](https://github.com/Flux-Point-Studios/materios-task180/pull/17)
lands and the kill-switch is sudo-flipped to `Disabled = false`, this
harness runs in one command and proves Wave 3 Phase 2 is shipped.

* `packages/compute-meter-sdk/tests/test_phase2_path_c_smoke.py` — 5 acceptance tests
* `packages/compute-meter-sdk/tests/_phase2_helpers.py` — vendored Pixel cert chain + synthetic sr25519 attestor + DER walker + gateway / chain probes
* `packages/compute-meter-sdk/pyproject.toml` — registers the `phase_2_smoke` marker
* `packages/compute-meter-sdk/tests/E2E.md` — Phase 2 runbook section

### Acceptance tests

Each is gated behind `@pytest.mark.phase_2_smoke`; run with `pytest -m phase_2_smoke -v`.

| test | proves |
|---|---|
| `test_path_c_v2_record_lands_on_chain` | gateway accepts a v2.1 envelope, receipt visible in `/billing/usage` within 60 s |
| `test_path_c_evidence_submission_returns_correct_hash` | gateway-returned `attestation_evidence_hash` byte-equals SDK-computed canonical-CBOR-sha256 |
| `test_path_c_invalid_pixel_chain_rejected` | tampered Pixel chain (`PIXEL_KEY_CERT_INVALID`) — `composite_trust_score` stays at 0 past the negative deadline (cert-daemon refuses to attest) |
| `test_path_c_valid_pixel_chain_attested` | **headline demo**: real Pixel chain → `composite_trust_score >= 1` AND `cardano_anchor_tx != null`. Logs the cexplorer.io URL on success. |
| `test_path_c_anchor_evidence_hash_round_trips` | reads the Cardano anchor tx via Blockfrost, parses label-8746 metadata, asserts the leaf's `attestation_evidence_hash` matches off-chain |

### Trust-layer design (the load-bearing comment)

Two independent layers in the harness, kept deliberately separate and
documented in `_phase2_helpers.py`:

1. **Cert-chain layer** (the chain-of-trust check on chain).
   The cert chain in the evidence payload is REAL — Pixel StrongBox
   from production Acurast test vectors, vendored into the pallet at
   `pallets/tee-attestation/src/test_vectors.rs`. The pallet's
   `ArmTrustZoneVerifier` walks Google root → intermediates → leaf,
   verifying every signature. **This is what the demo proves.**

2. **Attestor-signature layer** (the gateway endpoint).
   `/v2/attestation_evidence` requires an sr25519 sig over canonical
   CBOR of the payload. We don't have the Pixel TEE's private key
   (real device), so we generate a fresh sr25519 attestor key per
   session, register its pubkey via
   `/admin/attestation-evidence-attestors`, and sign with it. The
   chain inside the payload is untouched; the on-chain pallet
   verifies it independently.

A real-phone deployment (queued behind Acurast onboarding) collapses
the two layers into one TEE-protected key. The demo proves Layer 1
today on the data plane that Layer 2 will use unchanged.

### State today

All 5 tests SKIP cleanly with a NAMED prerequisite message — the message
IS the runbook. Locally:

```
$ pytest -m phase_2_smoke -v -rs
SKIPPED [5] Phase 2 Path C: prerequisite missing — MATERIOS_E2E_BEARER not set (see MATERIOS_E2E_GATEWAY, MATERIOS_E2E_BEARER, MATERIOS_E2E_HARDWARE_SPEC, ...)
====================== 5 skipped, 231 deselected in 0.47s ======================
```

Test count 231 → 236 (5 new). No regressions in the existing suite
(220 passed, 16 deselected on a full unmarked run).

### Pixel leaf SPKI sha256

For the runtime-upgrade-and-flip step: the value the pallet will store
as `attest_key_hash` after a successful verification is

```
58fd384003f5701a74500becbfc715be854dfecc959986fcf6021ded38b5d436
```

(sha256 of the `PIXEL_KEY_CERT` leaf's SubjectPublicKeyInfo bytes, per
the pallet's verifier). This is NOT the synthetic attestor's pubkey —
the synthetic attestor is generated at session start; its hex is
printed in the test logs when it registers.

### References

* [PR #17 — pallet-tee-attestation (vendored Acurast verifier + Pixel/Samsung test vectors)](https://github.com/Flux-Point-Studios/materios-task180/pull/17)
* [PR #34 — compute_metering_v2.1 schema + /v2/attestation_evidence (#34)](https://github.com/Flux-Point-Studios/orynq-sdk/pull/34) — already merged to `orynq-sdk` main
* Design spec: `/home/deci/wave-3-polychain-attestation-pallet-design.md`
* Runbook: `/home/deci/work/acurast-bootstrap/PHASE_2_DEMO_PATH_C.md`

## Test plan

- [x] `pytest --collect-only -q` reports 236 tests (231 + 5)
- [x] `pytest -m phase_2_smoke -v -rs` reports 5/5 SKIP with named-prereq messages, 231 deselected
- [x] Full unmarked run (`pytest -m "not phase_2_smoke and not e2e and not integration and not slow"`) reports 220 passed, 0 failed
- [x] `_phase2_helpers.pixel_leaf_spki_sha256()` returns the expected hex value
- [x] Module-level Python imports succeed; no unused imports
- [ ] (deferred to runtime-upgrade ceremony) all 5 tests turn GREEN end-to-end on preprod after `set_disabled(false)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)