### PR TITLE
feat(blob-gateway): surface composite_trust_score from TeeAttestation pallet on /billing/usage

### DIFF
--- a/services/blob-gateway/src/__tests__/billing_aggregate.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_aggregate.test.ts
@@ -29,6 +29,9 @@ function rec(over: Partial<AggregatableRecord> = {}): AggregatableRecord {
     gpu_seconds: 0,
     attestation_status: "pending",
     cardano_anchor_tx: null,
+    // Default to null — "we didn't ask the chain" is the safest no-op
+    // value for fixtures. Tests that pin the trust-score path override.
+    composite_trust_score: null,
     ...over,
   };
 }
@@ -40,6 +43,7 @@ describe("aggregateRecords", () => {
       record_count: 0,
       certified_count: 0,
       anchored_count: 0,
+      tee_attested_count: 0,
       cpu_seconds_total: 0,
       ram_gb_hours_total: 0,
       disk_gb_hours_total: 0,
@@ -81,6 +85,47 @@ describe("aggregateRecords", () => {
     expect(out.record_count).toBe(4);
     expect(out.certified_count).toBe(2);
     expect(out.anchored_count).toBe(1);
+  });
+
+  test("tee_attested_count counts only records with composite_trust_score >= 1 (task #142)", () => {
+    // Pin the rule:
+    //   - >= 1: counted (single-vendor, multi-vendor, +build, +ZK)
+    //   - 0:    NOT counted (committee-attested baseline)
+    //   - null: NOT counted (chain query failed; we couldn't ask)
+    // The Path C harness `_wait_for_anchor` reads `composite_trust_score`
+    // and waits for it to become >= 1 — this aggregate counter mirrors
+    // that contract at the bulk level so customers can see "how many of
+    // my records have hardware-backed attestation" at a glance.
+    const records: AggregatableRecord[] = [
+      rec({ composite_trust_score: 0 }), // baseline — NOT counted
+      rec({ composite_trust_score: 1 }), // single-vendor — counted
+      rec({ composite_trust_score: 2 }), // multi-vendor — counted
+      rec({ composite_trust_score: 3 }), // multi+build — counted
+      rec({ composite_trust_score: 4 }), // full quorum — counted
+      rec({ composite_trust_score: null }), // chain failed — NOT counted
+      rec({ composite_trust_score: null }), // ditto
+    ];
+    const out = aggregateRecords(records);
+    expect(out.record_count).toBe(7);
+    expect(out.tee_attested_count).toBe(4);
+  });
+
+  test("tee_attested_count is zero when every record has score 0 or null", () => {
+    // The "production until task #143 ships" case: chain reachable but no
+    // submit_evidence calls yet → every score is 0. Aggregate must not
+    // claim any records are TEE-attested.
+    const allZero: AggregatableRecord[] = [
+      rec({ composite_trust_score: 0 }),
+      rec({ composite_trust_score: 0 }),
+      rec({ composite_trust_score: 0 }),
+    ];
+    expect(aggregateRecords(allZero).tee_attested_count).toBe(0);
+
+    const allNull: AggregatableRecord[] = [
+      rec({ composite_trust_score: null }),
+      rec({ composite_trust_score: null }),
+    ];
+    expect(aggregateRecords(allNull).tee_attested_count).toBe(0);
   });
 
   test("sums float fields with reasonable precision", () => {

--- a/services/blob-gateway/src/__tests__/billing_chain_query.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_chain_query.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for `billing/chain_query.ts::queryCompositeTrustScores` (task #142).
+ *
+ * Pins the contract that `chain_query.ts` exposes to the route handler:
+ *
+ *   - When chain returns a u8 (0..=4), surface that integer.
+ *   - When the storage adapter returns `{ value: N }` or a Codec with
+ *     `.toNumber()`, decode correctly. The substrate metadata can render
+ *     `pub struct CompositeTrustScore(pub u8);` either way depending on
+ *     the @polkadot/api version.
+ *   - When the storage adapter returns out-of-band values (>4 / negative /
+ *     non-numeric), return null. We never fabricate a score.
+ *   - When the api connection isn't available, return null per record.
+ *   - When the pallet isn't present (pre-spec-213 runtime), return null.
+ *   - When `result.isEmpty === true` (forward-compat for OptionQuery),
+ *     return 0.
+ *
+ * Tests inject a stub via the `apiOverride` parameter so we don't need a
+ * live WS — the same shape as `queryReceiptStatuses` exposes for tests.
+ */
+
+import { describe, test, expect } from "vitest";
+import {
+  queryCompositeTrustScores,
+  receiptIdFromContentHash,
+} from "../billing/chain_query.js";
+
+/** Build a fake api stub that returns `value` for any compositeTrustScores call. */
+function fakeApi(value: unknown): unknown {
+  return {
+    query: {
+      teeAttestation: {
+        compositeTrustScores: async () => value,
+      },
+    },
+  };
+}
+
+describe("queryCompositeTrustScores — decoding paths", () => {
+  test("returns empty array on empty input", async () => {
+    const out = await queryCompositeTrustScores([], fakeApi(0));
+    expect(out).toEqual([]);
+  });
+
+  test("decodes a bare number as the score (0..4 range)", async () => {
+    const ch = "ab".repeat(32);
+    // toJSON on a `pub struct(pub u8)` pallet type often renders as a bare number.
+    const stub = {
+      query: {
+        teeAttestation: {
+          compositeTrustScores: async () => ({ toJSON: () => 2 }),
+        },
+      },
+    };
+    const out = await queryCompositeTrustScores([ch], stub);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      content_hash: ch,
+      receipt_id: receiptIdFromContentHash(ch),
+      composite_trust_score: 2,
+    });
+  });
+
+  test("decodes a { value: N } shape", async () => {
+    const ch = "cd".repeat(32);
+    const stub = {
+      query: {
+        teeAttestation: {
+          compositeTrustScores: async () => ({ toJSON: () => ({ value: 3 }) }),
+        },
+      },
+    };
+    const out = await queryCompositeTrustScores([ch], stub);
+    expect(out[0].composite_trust_score).toBe(3);
+  });
+
+  test("decodes via .toNumber() when toJSON yields a Codec", async () => {
+    const ch = "01".repeat(32);
+    // Some @polkadot/api versions return a Codec at toJSON; .toNumber() lives on the value.
+    const stub = {
+      query: {
+        teeAttestation: {
+          compositeTrustScores: async () => ({
+            toJSON: () => ({ toNumber: () => 4 }),
+          }),
+        },
+      },
+    };
+    const out = await queryCompositeTrustScores([ch], stub);
+    expect(out[0].composite_trust_score).toBe(4);
+  });
+
+  test("returns 0 for the chain default (committee-attested baseline)", async () => {
+    // ValueQuery means missing keys return 0. Pallet default. This is the
+    // path EVERY production record will hit until task #143 ships.
+    const ch = "ee".repeat(32);
+    const stub = {
+      query: {
+        teeAttestation: {
+          compositeTrustScores: async () => ({ toJSON: () => 0 }),
+        },
+      },
+    };
+    const out = await queryCompositeTrustScores([ch], stub);
+    expect(out[0].composite_trust_score).toBe(0);
+  });
+
+  test("returns 0 when result.isEmpty === true (OptionQuery forward-compat)", async () => {
+    const ch = "12".repeat(32);
+    const stub = {
+      query: {
+        teeAttestation: {
+          compositeTrustScores: async () => ({ isEmpty: true }),
+        },
+      },
+    };
+    const out = await queryCompositeTrustScores([ch], stub);
+    expect(out[0].composite_trust_score).toBe(0);
+  });
+
+  test("returns null for out-of-band score (>4 or <0)", async () => {
+    const ch1 = "22".repeat(32);
+    const ch2 = "33".repeat(32);
+    const stub = {
+      query: {
+        teeAttestation: {
+          compositeTrustScores: async (rid: string) => {
+            // Different bogus values per receipt id — proves we don't
+            // collapse / fabricate a score.
+            const isFirst = rid === receiptIdFromContentHash(ch1);
+            return { toJSON: () => (isFirst ? 99 : -3) };
+          },
+        },
+      },
+    };
+    const out = await queryCompositeTrustScores([ch1, ch2], stub);
+    const byHash = new Map(out.map((r) => [r.content_hash, r]));
+    expect(byHash.get(ch1)?.composite_trust_score).toBeNull();
+    expect(byHash.get(ch2)?.composite_trust_score).toBeNull();
+  });
+
+  test("returns null when the pallet is missing on pre-upgrade chain", async () => {
+    const ch = "44".repeat(32);
+    // Old runtime: api.query.teeAttestation doesn't exist at all.
+    const stub = { query: {} };
+    const out = await queryCompositeTrustScores([ch], stub);
+    expect(out[0].composite_trust_score).toBeNull();
+  });
+
+  test("returns null when the storage query throws", async () => {
+    const ch = "55".repeat(32);
+    const stub = {
+      query: {
+        teeAttestation: {
+          compositeTrustScores: async () => {
+            throw new Error("metadata mismatch");
+          },
+        },
+      },
+    };
+    const out = await queryCompositeTrustScores([ch], stub);
+    expect(out[0].composite_trust_score).toBeNull();
+  });
+
+  test("dedupes input content_hashes (one query per unique value)", async () => {
+    // Same content_hash twice in input should produce one entry.
+    const ch = "66".repeat(32);
+    let calls = 0;
+    const stub = {
+      query: {
+        teeAttestation: {
+          compositeTrustScores: async () => {
+            calls += 1;
+            return { toJSON: () => 1 };
+          },
+        },
+      },
+    };
+    const out = await queryCompositeTrustScores([ch, ch, ch], stub);
+    expect(out).toHaveLength(1);
+    expect(out[0].composite_trust_score).toBe(1);
+    expect(calls).toBe(1);
+  });
+});

--- a/services/blob-gateway/src/__tests__/billing_route.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_route.test.ts
@@ -77,6 +77,11 @@ vi.mock("../billing/chain_query.js", async (importOriginal) => {
   return {
     ...actual,
     queryReceiptStatuses: vi.fn(),
+    // Trust-score query is also mocked here. The dedicated wiring test
+    // (`billing_route_trust_score.test.ts`) pins the per-record / aggregate
+    // surface; in this file we just need the route to not crash when the
+    // function is called.
+    queryCompositeTrustScores: vi.fn(),
   };
 });
 
@@ -93,11 +98,13 @@ vi.mock("../billing/anchor_resolver.js", async (importOriginal) => {
 import { billingRouter } from "../routes/billing.js";
 import {
   queryReceiptStatuses,
+  queryCompositeTrustScores,
   type ChainStatus,
 } from "../billing/chain_query.js";
 import { resolveAnchorTxs } from "../billing/anchor_resolver.js";
 
 const queryReceiptStatusesMock = vi.mocked(queryReceiptStatuses);
+const queryCompositeTrustScoresMock = vi.mocked(queryCompositeTrustScores);
 const resolveAnchorTxsMock = vi.mocked(resolveAnchorTxs);
 
 let keyring: Keyring;
@@ -304,6 +311,16 @@ beforeEach(() => {
       status: "unknown",
       cert_hash: null,
     } satisfies ChainStatus)),
+  );
+  // Trust-score default: null (chain RPC degraded). Same shape as
+  // queryReceiptStatusesMock — the dedicated trust-score test file
+  // overrides per-test.
+  queryCompositeTrustScoresMock.mockImplementation(async (hashes) =>
+    hashes.map((h) => ({
+      content_hash: h,
+      receipt_id: "0x" + createHash("sha256").update(Buffer.from(h, "hex")).digest("hex"),
+      composite_trust_score: null,
+    })),
   );
   resolveAnchorTxsMock.mockImplementation(async (certs) =>
     certs.map(() => null),

--- a/services/blob-gateway/src/__tests__/billing_route_trust_score.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_route_trust_score.test.ts
@@ -1,0 +1,520 @@
+/**
+ * Integration tests for task #142 — composite_trust_score on /billing/usage.
+ *
+ * The chain pallet `pallet-tee-attestation` exposes a per-receipt
+ * `CompositeTrustScores` storage map (u8, ValueQuery, default = 0). The
+ * gateway billing route must surface that score for every record and a
+ * `tee_attested_count` aggregate so customers can tell at a glance how
+ * many of their workloads have hardware-backed attestation.
+ *
+ * The Path C smoke harness (Phase 2) polls this very field — the harness
+ * function `_wait_for_anchor` looks for
+ *
+ *     composite_trust_score >= 1 AND cardano_anchor_tx != null
+ *
+ * to confirm a Pixel/Samsung TEE-attested run made it onto chain.
+ *
+ * What this file pins:
+ *   - score = 0 from chain → surfaced as 0 (NOT null).
+ *   - score = 3 from chain → surfaced verbatim (no clamping or
+ *     re-bucketing into {certified, anchored, ...} aggregate buckets).
+ *   - chain RPC fails → surfaced as null per record (NOT 0). The
+ *     distinction is load-bearing for downstream consumers that wait on
+ *     the field becoming non-zero.
+ *   - aggregate.tee_attested_count counts records with score >= 1.
+ *   - include_records=true plumbs the score per-record via the http handler.
+ *
+ * What this file does NOT cover (covered elsewhere):
+ *   - Live preprod chain query → tested manually + by the Path C harness.
+ *   - Pure aggregate math → `billing_aggregate.test.ts`.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  vi,
+} from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Keyring } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+import { createHash } from "crypto";
+
+import { config } from "../config.js";
+import { meteringRouter } from "../routes/metering.js";
+import {
+  initWorkerBoundsDb,
+  setWorkerBoundsDbForTests,
+} from "../worker_bounds.js";
+import {
+  canonicalBody,
+  SCHEMA_VERSION,
+  type ComputeMeteringV1,
+} from "../schemas/compute_metering_v1.js";
+import {
+  initApiTokensDb,
+  setApiTokensDb,
+  issueToken,
+} from "../api-tokens.js";
+import {
+  setQuotaDbForTests,
+  migrateBindingColumn,
+} from "../quota.js";
+
+// Mock the chain RPC layer. The two query helpers are independent at the
+// module boundary — we mock both so route tests don't need a live node.
+vi.mock("../billing/chain_query.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../billing/chain_query.js")>();
+  return {
+    ...actual,
+    queryReceiptStatuses: vi.fn(),
+    queryCompositeTrustScores: vi.fn(),
+  };
+});
+
+// Mock anchor resolver too (same reasoning as billing_route.test.ts).
+vi.mock("../billing/anchor_resolver.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../billing/anchor_resolver.js")>();
+  return {
+    ...actual,
+    resolveAnchorTxs: vi.fn(),
+  };
+});
+
+import { billingRouter } from "../routes/billing.js";
+import {
+  queryReceiptStatuses,
+  queryCompositeTrustScores,
+  type ChainStatus,
+  type ChainTrustScore,
+} from "../billing/chain_query.js";
+import { resolveAnchorTxs } from "../billing/anchor_resolver.js";
+
+const queryReceiptStatusesMock = vi.mocked(queryReceiptStatuses);
+const queryCompositeTrustScoresMock = vi.mocked(queryCompositeTrustScores);
+const resolveAnchorTxsMock = vi.mocked(resolveAnchorTxs);
+
+let keyring: Keyring;
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+  keyring = new Keyring({ type: "sr25519" });
+});
+
+interface BuildOpts {
+  worker_id?: string;
+  tenant_id?: string;
+  period_start?: number;
+  period_end?: number;
+  uri?: string;
+}
+
+function buildSigned(opts: BuildOpts = {}): ComputeMeteringV1 {
+  const pair = keyring.addFromUri(opts.uri ?? "//ComputeWorkerTrust");
+  const now = Date.now();
+  const period_end = opts.period_end ?? now - 5000;
+  const period_start = opts.period_start ?? period_end - 3_600_000;
+  const body = {
+    schema_version: SCHEMA_VERSION,
+    worker_id: opts.worker_id ?? "worker-trust-001",
+    tenant_id: opts.tenant_id ?? "tenant-trust-1",
+    period_start,
+    period_end,
+    cpu_seconds: 30,
+    ram_gb_hours: 0.5,
+    disk_gb_hours: 1,
+    net_bytes_in: 1024,
+    net_bytes_out: 512,
+    gpu_seconds: 0,
+    worker_pubkey: u8aToHex(pair.publicKey, undefined, false),
+  } as const;
+  const cb = canonicalBody(body);
+  const sig = u8aToHex(pair.sign(cb), undefined, false);
+  return { ...body, worker_signature: sig };
+}
+
+interface Ctx {
+  app: express.Express;
+  storage: string;
+  prevStorage: string;
+  prevSubmitterUrl: string;
+  workerBoundsDb: Database.Database;
+  quotaDb: Database.Database;
+  tokensDb: Database.Database;
+  bearerToken: string;
+}
+
+async function setupApp(): Promise<Ctx> {
+  const storage = mkdtempSync(join(tmpdir(), "billing-trust-test-"));
+  const prevStorage = config.storagePath;
+  config.storagePath = storage;
+
+  const prevSubmitterUrl = config.sponsoredReceiptSubmitterUrl;
+  config.sponsoredReceiptSubmitterUrl = "";
+
+  const workerBoundsDb = new Database(":memory:");
+  initWorkerBoundsDb(workerBoundsDb);
+  setWorkerBoundsDbForTests(workerBoundsDb);
+
+  const quotaDb = new Database(":memory:");
+  quotaDb.pragma("journal_mode = WAL");
+  quotaDb.exec(`
+    CREATE TABLE api_keys (
+      key_hash TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      max_receipts_per_day INTEGER NOT NULL DEFAULT 100,
+      max_bytes_per_day INTEGER NOT NULL DEFAULT 1073741824,
+      max_concurrent_uploads INTEGER NOT NULL DEFAULT 5,
+      validator_id TEXT DEFAULT NULL
+    );
+  `);
+  migrateBindingColumn(quotaDb);
+  setQuotaDbForTests(quotaDb);
+
+  const tokensDb = new Database(":memory:");
+  tokensDb.pragma("journal_mode = WAL");
+  initApiTokensDb(tokensDb);
+  setApiTokensDb(tokensDb);
+
+  const ss58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"; // //Alice
+  const tok = issueToken(tokensDb, {
+    accountSs58: ss58,
+    label: "billing-trust-test",
+  });
+
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.use(meteringRouter);
+  app.use(billingRouter);
+
+  return {
+    app,
+    storage,
+    prevStorage,
+    prevSubmitterUrl,
+    workerBoundsDb,
+    quotaDb,
+    tokensDb,
+    bearerToken: tok.token,
+  };
+}
+
+async function teardown(ctx: Ctx): Promise<void> {
+  config.storagePath = ctx.prevStorage;
+  config.sponsoredReceiptSubmitterUrl = ctx.prevSubmitterUrl;
+  rmSync(ctx.storage, { recursive: true, force: true });
+  ctx.workerBoundsDb.close();
+  ctx.quotaDb.close();
+  ctx.tokensDb.close();
+}
+
+interface FetchInit {
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+async function call(
+  app: express.Express,
+  method: string,
+  path: string,
+  init: FetchInit = {},
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const headers: Record<string, string> = { ...(init.headers ?? {}) };
+      const opts: RequestInit = { method, headers };
+      if (init.body !== undefined) {
+        headers["content-type"] = "content-type" in headers ? headers["content-type"] : "application/json";
+        opts.body = JSON.stringify(init.body);
+      }
+      fetch(url, opts)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+async function submitOne(
+  ctx: Ctx,
+  opts: BuildOpts = {},
+): Promise<{ content_hash: string }> {
+  const r = buildSigned(opts);
+  const res = await call(ctx.app, "POST", "/metering/submit", { body: r });
+  if (res.status !== 200) {
+    throw new Error(
+      `submit failed ${res.status}: ${JSON.stringify(res.body)}`,
+    );
+  }
+  return { content_hash: (res.body as { content_hash: string }).content_hash };
+}
+
+/** Helper: synthesise a `ChainStatus` row that matches the receipt-id. */
+function statusRow(content_hash: string, status: ChainStatus["status"], cert_hash: string | null): ChainStatus {
+  return {
+    content_hash,
+    receipt_id: "0x" + createHash("sha256").update(Buffer.from(content_hash, "hex")).digest("hex"),
+    status,
+    cert_hash,
+  };
+}
+
+/** Helper: synthesise a `ChainTrustScore` row. */
+function trustRow(content_hash: string, score: number | null): ChainTrustScore {
+  return {
+    content_hash,
+    receipt_id: "0x" + createHash("sha256").update(Buffer.from(content_hash, "hex")).digest("hex"),
+    composite_trust_score: score,
+  };
+}
+
+beforeEach(() => {
+  // Base mocks: status all "unknown", trust all null. Specific tests
+  // override per-call. Keeps the harness aligned with billing_route.test.ts.
+  queryReceiptStatusesMock.mockImplementation(async (hashes) =>
+    hashes.map((h) => statusRow(h, "unknown", null)),
+  );
+  queryCompositeTrustScoresMock.mockImplementation(async (hashes) =>
+    hashes.map((h) => trustRow(h, null)),
+  );
+  resolveAnchorTxsMock.mockImplementation(async (certs) => certs.map(() => null));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /billing/usage — composite_trust_score wiring (task #142)", () => {
+  let ctx: Ctx;
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  test("composite_trust_score is surfaced as 0 when chain returns 0 (committee-attested baseline)", async () => {
+    // Chain says: receipt exists, no TEE evidence yet → 0. The route MUST
+    // surface 0, NOT null. Distinguishing 0 from null is the whole point
+    // of the field.
+    const tenant = "tenant-trust-zero";
+    const baseEnd = Date.now() - 60_000;
+    const sub = await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-zero",
+      uri: "//WkrTrustZero",
+      period_start: baseEnd - 3_600_000,
+      period_end: baseEnd,
+    });
+    queryCompositeTrustScoresMock.mockImplementation(async (hashes) =>
+      hashes.map((h) => trustRow(h, 0)),
+    );
+
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${baseEnd - 2 * 3_600_000}&end_ms=${baseEnd + 1000}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      records: Array<{ content_hash: string; composite_trust_score: number | null }>;
+      aggregate: { tee_attested_count: number };
+    };
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0].content_hash).toBe(sub.content_hash);
+    expect(body.records[0].composite_trust_score).toBe(0);
+    // 0 does NOT count as TEE-attested.
+    expect(body.aggregate.tee_attested_count).toBe(0);
+  });
+
+  test("composite_trust_score = 3 (multi-vendor + build) flows through verbatim", async () => {
+    // Non-default value path. The route must NOT clamp / re-bucket / drop
+    // the score; downstream consumers compare against literal 1..4.
+    const tenant = "tenant-trust-three";
+    const baseEnd = Date.now() - 60_000;
+    const sub = await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-three",
+      uri: "//WkrTrustThree",
+      period_start: baseEnd - 3_600_000,
+      period_end: baseEnd,
+    });
+    queryCompositeTrustScoresMock.mockImplementation(async (hashes) =>
+      hashes.map((h) => trustRow(h, 3)),
+    );
+
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${baseEnd - 2 * 3_600_000}&end_ms=${baseEnd + 1000}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      records: Array<{ content_hash: string; composite_trust_score: number | null }>;
+      aggregate: { tee_attested_count: number };
+    };
+    expect(body.records[0].content_hash).toBe(sub.content_hash);
+    expect(body.records[0].composite_trust_score).toBe(3);
+    expect(body.aggregate.tee_attested_count).toBe(1);
+  });
+
+  test("composite_trust_score is null when chain query failed", async () => {
+    // RPC unreachable → trust query returns null per record. The route
+    // MUST preserve null (not collapse to 0). The Path C harness reads
+    // this field and treats null as "keep waiting", whereas 0 would lie
+    // that the chain confirmed no evidence.
+    const tenant = "tenant-trust-null";
+    const baseEnd = Date.now() - 60_000;
+    await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-null",
+      uri: "//WkrTrustNull",
+      period_start: baseEnd - 3_600_000,
+      period_end: baseEnd,
+    });
+    // Trust mock: explicit null. (This is also the default, but
+    // we set it explicitly so the test's intent is obvious.)
+    queryCompositeTrustScoresMock.mockImplementation(async (hashes) =>
+      hashes.map((h) => trustRow(h, null)),
+    );
+
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${baseEnd - 2 * 3_600_000}&end_ms=${baseEnd + 1000}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      records: Array<{ composite_trust_score: number | null }>;
+      aggregate: { tee_attested_count: number };
+    };
+    expect(body.records[0].composite_trust_score).toBeNull();
+    expect(body.aggregate.tee_attested_count).toBe(0);
+  });
+
+  test("aggregate tee_attested_count counts only records with score >= 1 (mixed batch)", async () => {
+    // Five records, all in one tenant, with mixed trust scores. Aggregate
+    // is the only block returned (include_records is false), so this
+    // pins the aggregate path explicitly.
+    const tenant = "tenant-trust-mixed";
+    const baseEnd = Date.now() - 60_000;
+    const subs: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const s = await submitOne(ctx, {
+        tenant_id: tenant,
+        worker_id: `wkr-mixed-${i}`,
+        uri: `//WkrTrustMixed${i}`,
+        period_start: baseEnd - (i + 1) * 3_600_000,
+        period_end: baseEnd - i * 3_600_000,
+      });
+      subs.push(s.content_hash);
+    }
+    // Scores: [null, 0, 1, 2, 4] — only three (scores >= 1) count.
+    const scoreByHash = new Map<string, number | null>();
+    scoreByHash.set(subs[0], null);
+    scoreByHash.set(subs[1], 0);
+    scoreByHash.set(subs[2], 1);
+    scoreByHash.set(subs[3], 2);
+    scoreByHash.set(subs[4], 4);
+    queryCompositeTrustScoresMock.mockImplementation(async (hashes) =>
+      hashes.map((h) => trustRow(h, scoreByHash.has(h) ? scoreByHash.get(h)! : null)),
+    );
+
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${baseEnd - 10 * 3_600_000}&end_ms=${baseEnd + 1000}`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      aggregate: { record_count: number; tee_attested_count: number };
+    };
+    expect(body.aggregate.record_count).toBe(5);
+    expect(body.aggregate.tee_attested_count).toBe(3);
+  });
+
+  test("include_records=true plumbs trust score per record alongside cardano_anchor_tx", async () => {
+    // The Path C harness's headline assertion combines both fields. Pin
+    // the wiring so they appear on the same record together: a record
+    // can be both TEE-attested AND Cardano-anchored at the same time.
+    const tenant = "tenant-trust-anchor";
+    const baseEnd = Date.now() - 60_000;
+    const sub = await submitOne(ctx, {
+      tenant_id: tenant,
+      worker_id: "wkr-trust-anchor",
+      uri: "//WkrTrustAnchor",
+      period_start: baseEnd - 3_600_000,
+      period_end: baseEnd,
+    });
+    const certHash = "0x" + "ee".repeat(32);
+    const anchorTx = "11".repeat(32);
+    queryReceiptStatusesMock.mockImplementation(async (hashes) =>
+      hashes.map((h) => statusRow(h, "certified", certHash)),
+    );
+    queryCompositeTrustScoresMock.mockImplementation(async (hashes) =>
+      hashes.map((h) => trustRow(h, 2)),
+    );
+    resolveAnchorTxsMock.mockImplementation(async (certs) =>
+      certs.map((c) => (c === certHash ? anchorTx : null)),
+    );
+
+    const res = await call(
+      ctx.app,
+      "GET",
+      `/billing/usage?tenant_id=${tenant}&start_ms=${baseEnd - 2 * 3_600_000}&end_ms=${baseEnd + 1000}&include_records=true`,
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      records: Array<{
+        content_hash: string;
+        composite_trust_score: number | null;
+        cardano_anchor_tx: string | null;
+      }>;
+      aggregate: {
+        certified_count: number;
+        anchored_count: number;
+        tee_attested_count: number;
+      };
+    };
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0].content_hash).toBe(sub.content_hash);
+    expect(body.records[0].composite_trust_score).toBe(2);
+    expect(body.records[0].cardano_anchor_tx).toBe("0x" + anchorTx);
+    expect(body.aggregate.certified_count).toBe(1);
+    expect(body.aggregate.anchored_count).toBe(1);
+    expect(body.aggregate.tee_attested_count).toBe(1);
+  });
+});

--- a/services/blob-gateway/src/__tests__/billing_tenant_binding.test.ts
+++ b/services/blob-gateway/src/__tests__/billing_tenant_binding.test.ts
@@ -65,6 +65,7 @@ vi.mock("../billing/chain_query.js", async () => {
   return {
     ...actual,
     queryReceiptStatuses: vi.fn(async () => []),
+    queryCompositeTrustScores: vi.fn(async () => []),
   };
 });
 vi.mock("../billing/anchor_resolver.js", async () => {

--- a/services/blob-gateway/src/billing/aggregate.ts
+++ b/services/blob-gateway/src/billing/aggregate.ts
@@ -47,6 +47,21 @@ export interface AggregatableRecord {
   attestation_status: AttestationStatus;
   /** Non-null cardano tx hash when anchor_resolver matched a checkpoint. */
   cardano_anchor_tx: string | null;
+  /**
+   * Composite trust score from `pallet-tee-attestation::CompositeTrustScores`
+   * (task #142). Range 0..=4:
+   *   0 = COMMITTEE_ATTESTED_BASELINE — no TEE evidence on chain yet.
+   *   1 = SINGLE_VENDOR
+   *   2 = MULTI_VENDOR
+   *   3 = MULTI_VENDOR_PLUS_BUILD
+   *   4 = FULL_QUORUM
+   *
+   * `null` means the chain query failed (RPC unreachable / pallet not
+   * present on a pre-spec-213 runtime) — semantically distinct from `0`,
+   * which means "chain reachable, no evidence yet". Downstream consumers
+   * (e.g. the Path C harness `_wait_for_anchor`) MUST NOT collapse the two.
+   */
+  composite_trust_score: number | null;
 }
 
 export type AttestationStatus = "certified" | "pending" | "unknown";
@@ -56,6 +71,15 @@ export interface BillingAggregate {
   record_count: number;
   certified_count: number;
   anchored_count: number;
+  /**
+   * Count of records with `composite_trust_score >= 1` — i.e. at least
+   * one TEE evidence record accepted on chain. Records with
+   * `composite_trust_score === 0` (committee-attested baseline) and
+   * `composite_trust_score === null` (chain query failed) do NOT count
+   * here. See `AggregatableRecord.composite_trust_score` for the level
+   * semantics.
+   */
+  tee_attested_count: number;
   cpu_seconds_total: number;
   ram_gb_hours_total: number;
   disk_gb_hours_total: number;
@@ -82,6 +106,7 @@ export function aggregateRecords(
     record_count: 0,
     certified_count: 0,
     anchored_count: 0,
+    tee_attested_count: 0,
     cpu_seconds_total: 0,
     ram_gb_hours_total: 0,
     disk_gb_hours_total: 0,
@@ -98,6 +123,16 @@ export function aggregateRecords(
     result.record_count += 1;
     if (r.attestation_status === "certified") result.certified_count += 1;
     if (r.cardano_anchor_tx !== null) result.anchored_count += 1;
+    // `composite_trust_score` is null when the chain query failed; only
+    // count records that POSITIVELY have at least one accepted TEE
+    // evidence record (>= 1). Baseline (=0) and unknown (null) are
+    // explicitly NOT counted.
+    if (
+      typeof r.composite_trust_score === "number" &&
+      r.composite_trust_score >= 1
+    ) {
+      result.tee_attested_count += 1;
+    }
     result.cpu_seconds_total += r.cpu_seconds;
     result.ram_gb_hours_total += r.ram_gb_hours;
     result.disk_gb_hours_total += r.disk_gb_hours;

--- a/services/blob-gateway/src/billing/chain_query.ts
+++ b/services/blob-gateway/src/billing/chain_query.ts
@@ -184,6 +184,155 @@ export async function queryReceiptStatuses(
   return out;
 }
 
+/**
+ * Per-content-hash composite-trust-score lookup result. The chain stores a
+ * `CompositeTrustScore(u8)` (0..=4) per receipt_id under the
+ * `pallet-tee-attestation::CompositeTrustScores` storage map (ValueQuery,
+ * default = 0).
+ *
+ * Score levels:
+ *   0 = COMMITTEE_ATTESTED_BASELINE — default for any submitted receipt;
+ *       no TEE evidence on chain yet.
+ *   1 = SINGLE_VENDOR — one accepted TEE evidence record.
+ *   2 = MULTI_VENDOR — evidence from 2+ distinct vendors.
+ *   3 = MULTI_VENDOR_PLUS_BUILD — multi-vendor + reproducible-build
+ *       attestation.
+ *   4 = FULL_QUORUM — multi-vendor + build + ZK-proof attestation.
+ *
+ * IMPORTANT: `composite_trust_score === null` means "couldn't query the
+ * chain" (RPC down / decode failure). `composite_trust_score === 0` means
+ * "chain reachable, receipt has no TEE evidence yet". The two are
+ * semantically distinct — a downstream consumer waiting for the field to
+ * become non-zero (see Path C harness `_wait_for_anchor`) MUST NOT treat
+ * `null` as `0`.
+ */
+export interface ChainTrustScore {
+  content_hash: string;
+  receipt_id: string;
+  /** 0..=4 from chain; null only when RPC unreachable / query failed. */
+  composite_trust_score: number | null;
+}
+
+/**
+ * Bulk composite-trust-score lookup. Mirrors `queryReceiptStatuses` shape
+ * (one storage query per content_hash, run concurrently); the only delta
+ * is the storage map — `teeAttestation.compositeTrustScores(receipt_id)`
+ * vs `orinqReceipts.receipts(receipt_id)`.
+ *
+ * The two queries are independent so the route handler can issue both via
+ * `Promise.all` and only pay the latency of the slower one.
+ *
+ * If the API connection is down, every record gets
+ * `composite_trust_score: null` — the route surfaces that as null in the
+ * response so callers can distinguish "no TEE evidence yet" (= 0) from
+ * "couldn't ask the chain" (= null).
+ *
+ * `ValueQuery` semantics on the chain mean the storage map ALWAYS returns
+ * a value (0 default for missing keys). So `result.isEmpty` shouldn't fire
+ * here, but we handle it defensively for forward-compat with future
+ * pallet revisions that might switch to OptionQuery.
+ *
+ * Test hook: `apiOverride` lets unit tests inject a stub. Identical
+ * shape to `queryReceiptStatuses`.
+ */
+export async function queryCompositeTrustScores(
+  contentHashes: readonly string[],
+  apiOverride?: unknown,
+): Promise<ChainTrustScore[]> {
+  if (contentHashes.length === 0) return [];
+
+  const uniq = Array.from(new Set(contentHashes));
+  const ids: { content_hash: string; receipt_id: string }[] = uniq.map(
+    (contentHashHex) => ({
+      content_hash: contentHashHex,
+      receipt_id: receiptIdFromContentHash(contentHashHex),
+    }),
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let api: any = apiOverride;
+  if (api === undefined) {
+    const pending = getOrConnectApi();
+    if (!pending) {
+      // Connection unavailable — surface null per record (NOT 0). We must
+      // preserve the distinction between "chain says no evidence" and
+      // "couldn't ask chain".
+      return ids.map((x) => ({
+        content_hash: x.content_hash,
+        receipt_id: x.receipt_id,
+        composite_trust_score: null,
+      }));
+    }
+    try {
+      api = await pending;
+    } catch {
+      return ids.map((x) => ({
+        content_hash: x.content_hash,
+        receipt_id: x.receipt_id,
+        composite_trust_score: null,
+      }));
+    }
+  }
+
+  // Issue queries concurrently. A single failure (e.g. metadata mismatch
+  // from a forkless upgrade not yet picked up) degrades only that record,
+  // not the whole batch.
+  const out = await Promise.all(
+    ids.map(async ({ content_hash, receipt_id }): Promise<ChainTrustScore> => {
+      try {
+        // The pallet may not be present on chains that haven't received
+        // the spec-213/214 runtime upgrade — guard against undefined to
+        // avoid throwing inside the .map.
+        const teeQuery = api.query?.teeAttestation?.compositeTrustScores;
+        if (typeof teeQuery !== "function") {
+          return { content_hash, receipt_id, composite_trust_score: null };
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result: any = await teeQuery(receipt_id);
+        if (result?.isEmpty === true) {
+          // OptionQuery / forward-compat path: treat as "no evidence".
+          return { content_hash, receipt_id, composite_trust_score: 0 };
+        }
+        // `CompositeTrustScore(pub u8)` — substrate may decode this as a
+        // bare number, a `{ value: number }` shape, or a Codec with
+        // `.toNumber()`. Handle all three so the gateway doesn't rev-lock
+        // to a specific @polkadot/api version.
+        const raw = result?.toJSON?.() ?? result;
+        let score: number | null = null;
+        if (typeof raw === "number") {
+          score = raw;
+        } else if (raw && typeof raw === "object") {
+          const o = raw as Record<string, unknown>;
+          const cand = o.value ?? o[0] ?? o;
+          if (typeof cand === "number") {
+            score = cand;
+          } else if (cand && typeof (cand as { toNumber?: () => number }).toNumber === "function") {
+            score = (cand as { toNumber: () => number }).toNumber();
+          }
+        }
+        if (score === null && typeof (result as { toNumber?: () => number })?.toNumber === "function") {
+          score = (result as { toNumber: () => number }).toNumber();
+        }
+        if (score === null || !Number.isFinite(score)) {
+          return { content_hash, receipt_id, composite_trust_score: null };
+        }
+        // Clamp to the expected 0..=4 band — anything else is a decode
+        // bug, not a valid score, so surface null rather than confuse the
+        // consumer with a fabricated value.
+        const intScore = Math.trunc(score);
+        if (intScore < 0 || intScore > 4) {
+          return { content_hash, receipt_id, composite_trust_score: null };
+        }
+        return { content_hash, receipt_id, composite_trust_score: intScore };
+      } catch {
+        return { content_hash, receipt_id, composite_trust_score: null };
+      }
+    }),
+  );
+
+  return out;
+}
+
 /** Test hook: clear the cached ApiPromise so the next call re-connects. */
 export function resetChainQueryForTests(): void {
   apiPromise = null;

--- a/services/blob-gateway/src/routes/billing.ts
+++ b/services/blob-gateway/src/routes/billing.ts
@@ -76,8 +76,10 @@ import {
 } from "../billing/aggregate.js";
 import {
   queryReceiptStatuses,
+  queryCompositeTrustScores,
   receiptIdFromContentHash,
   type ChainStatus,
+  type ChainTrustScore,
 } from "../billing/chain_query.js";
 import { resolveAnchorTxs } from "../billing/anchor_resolver.js";
 import { SCHEMA_HASH_HEX } from "../schemas/compute_metering_v1.js";
@@ -123,13 +125,19 @@ function badRequest(
 }
 
 /**
- * Convert a stored row + chain status + anchor tx into the per-record
- * response shape. Pure — no IO. Exported for tests.
+ * Convert a stored row + chain status + anchor tx + composite-trust score
+ * into the per-record response shape. Pure — no IO. Exported for tests.
+ *
+ * `compositeTrustScore` is `number | null`. `null` means the chain query
+ * failed; `0` means the chain confirms no TEE evidence yet (committee-
+ * attested baseline). The two are semantically distinct — see
+ * `chain_query.ts::ChainTrustScore` for the full level table.
  */
 export function rowToRecordResponse(
   row: MeteringSubmissionRow,
   chain: ChainStatus,
   anchorTx: string | null,
+  compositeTrustScore: number | null,
 ): {
   worker_id: string;
   period_start_ms: number;
@@ -140,6 +148,7 @@ export function rowToRecordResponse(
   attestation_cert_hash: string | null;
   attestation_status: AttestationStatus;
   cardano_anchor_tx: string | null;
+  composite_trust_score: number | null;
   metrics: {
     cpu_seconds: number;
     ram_gb_hours: number;
@@ -175,6 +184,7 @@ export function rowToRecordResponse(
           ? anchorTx
           : "0x" + anchorTx
         : null,
+    composite_trust_score: compositeTrustScore,
     metrics: {
       cpu_seconds: row.cpu_seconds,
       ram_gb_hours: row.ram_gb_hours,
@@ -361,15 +371,26 @@ billingRouter.get(
       });
       const gateway_db_query_ms = Date.now() - dbStart;
 
-      // ---------- chain status ----------
+      // ---------- chain queries (status + composite trust score) ----------
+      // The two queries hit independent storage maps
+      // (`orinqReceipts.receipts` and `teeAttestation.compositeTrustScores`)
+      // and don't share data dependencies, so we issue them concurrently
+      // — total latency is max(status, trust) instead of sum. Substrate's
+      // WS connection multiplexes the requests fine.
       const chainStart = Date.now();
-      const chainStatuses = await queryReceiptStatuses(
-        rows.map((r) => r.content_hash),
-      );
+      const contentHashes = rows.map((r) => r.content_hash);
+      const [chainStatuses, trustScores] = await Promise.all([
+        queryReceiptStatuses(contentHashes),
+        queryCompositeTrustScores(contentHashes),
+      ]);
       const chain_query_ms = Date.now() - chainStart;
       // Build a content_hash → status map for O(1) merge below.
       const chainByContent = new Map<string, ChainStatus>();
       for (const cs of chainStatuses) chainByContent.set(cs.content_hash, cs);
+      // Same shape for the trust scores. Use the dedicated `trustByContent`
+      // so we don't conflate the two map types in the merge below.
+      const trustByContent = new Map<string, ChainTrustScore>();
+      for (const ts of trustScores) trustByContent.set(ts.content_hash, ts);
 
       // ---------- anchor resolution ----------
       const anchorStart = Date.now();
@@ -398,6 +419,13 @@ billingRouter.get(
           chain.status === "certified" && chain.cert_hash
             ? anchorByCert.get(chain.cert_hash) ?? null
             : null;
+        // Trust score: explicit `?? null` so a missing map entry (which
+        // shouldn't happen — every input content_hash gets a row in the
+        // dedup'd query result) collapses to "unknown" rather than
+        // throwing. Default-zero would be WRONG: it would lie that the
+        // chain confirmed no evidence when in fact we never asked.
+        const trustScore =
+          trustByContent.get(r.content_hash)?.composite_trust_score ?? null;
         return {
           worker_id: r.worker_id,
           tenant_id: r.tenant_id,
@@ -411,6 +439,7 @@ billingRouter.get(
           gpu_seconds: r.gpu_seconds,
           attestation_status: chain.status,
           cardano_anchor_tx: anchor,
+          composite_trust_score: trustScore,
         };
       });
 
@@ -430,7 +459,10 @@ billingRouter.get(
               chain.status === "certified" && chain.cert_hash
                 ? anchorByCert.get(chain.cert_hash) ?? null
                 : null;
-            return rowToRecordResponse(r, chain, anchor);
+            const trustScore =
+              trustByContent.get(r.content_hash)?.composite_trust_score ??
+              null;
+            return rowToRecordResponse(r, chain, anchor, trustScore);
           })
         : undefined;
 


### PR DESCRIPTION
The Wave 3 Phase 2 Path C harness polls /billing/usage for a record matching
`composite_trust_score >= 1 AND cardano_anchor_tx != null` to confirm a
Pixel/Samsung TEE-attested run made it onto chain (see
`packages/compute-meter-sdk/tests/test_phase2_path_c_smoke.py::_wait_for_anchor`).
The chain pallet `pallet-tee-attestation::CompositeTrustScores` is live
post spec-213/214 ceremonies, but the gateway never read or surfaced the
field — the harness timed out at the 1200s deadline waiting for a value
that would never arrive.

This PR wires the storage map through. New `queryCompositeTrustScores()`
mirrors the shape of `queryReceiptStatuses()` (per-content-hash storage
query, concurrent batch, optional apiOverride for tests). The route runs
both queries in `Promise.all` so total chain-query latency is
max(status, trust) instead of the sum. Per-record response gains a
`composite_trust_score: number | null` field; aggregate gains a
`tee_attested_count` counter (records with score >= 1).

Semantic rule: `null` means the chain query failed (RPC unreachable /
pre-spec-213 runtime / decode failure); `0` means the chain confirms the
committee-attested baseline (no TEE evidence yet on chain). Downstream
consumers waiting for the field to become non-zero MUST NOT collapse the
two — `_wait_for_anchor` keeps polling on `null`, exits on `0` only when
explicitly designed to.

Until task #143 ships (the evidence-submitter daemon that calls
`TeeAttestation.submit_evidence` after the gateway accepts an attestation
evidence POST), every production record will report `composite_trust_score: 0`.

New tests: 10 in billing_chain_query.test.ts (decoding paths) + 5 in
billing_route_trust_score.test.ts (route wiring) + 2 in
billing_aggregate.test.ts (tee_attested_count math). All 568 existing
blob-gateway tests still pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

**Companion task #143:** the daemon-side wiring (cert-daemon registration + scan of `receipt_attestation_evidence.db` + `TeeAttestation.submit_evidence` extrinsic) is required for `composite_trust_score` to ever go above 0 in production. This PR is the producer side; #143 is the consumer.

**Path C harness consumer:** `packages/compute-meter-sdk/tests/test_phase2_path_c_smoke.py::test_path_c_valid_pixel_chain_attested` — the headline Wave 3 Phase 2 demo. Polls `/billing/usage` for `composite_trust_score >= 1 AND cardano_anchor_tx != null`. Test 4 today fails because gateway never returns `composite_trust_score`; this PR fixes the producer half.