### PR TITLE
feat(anchors-materios): thread schemaHash through submitReceipt (task #200)

### DIFF
--- a/packages/anchors-materios/src/receipt.ts
+++ b/packages/anchors-materios/src/receipt.ts
@@ -57,6 +57,16 @@ export async function submitReceipt(
   const schemaHex = input.schemaHash
     ? stripPrefix(input.schemaHash)
     : "00".repeat(32);
+  // Reject silently-truncated / silently-padded discriminator inputs.
+  // toBytes32 will pad short input or read only the first 64 chars of long
+  // input, both of which silently produce the wrong on-chain value. A
+  // discriminator must be exactly 32 bytes (64 hex chars) — anything else
+  // is operator error.
+  if (!/^[0-9a-fA-F]{64}$/.test(schemaHex)) {
+    throw new Error(
+      `schemaHash must be exactly 32 hex bytes (64 chars); got ${schemaHex.length} chars`,
+    );
+  }
 
   // Derive receipt_id from contentHash if not provided
   const receiptId =

--- a/packages/anchors-materios/src/receipt.ts
+++ b/packages/anchors-materios/src/receipt.ts
@@ -48,6 +48,15 @@ export async function submitReceipt(
   const contentHex = stripPrefix(input.contentHash);
   const rootHex = stripPrefix(input.rootHash);
   const manifestHex = stripPrefix(input.manifestHash);
+  // schemaHash defaults to legacy (32 zero bytes) when caller omits it,
+  // preserving the prior behaviour for plain blob receipts. Callers using
+  // semantic-root receipt classes (compute_metering_v2*, orynq_trace_v1)
+  // MUST pass the matching discriminator from
+  // operator-kit daemon/schemas/, otherwise cert-daemon rejects the
+  // receipt with a Merkle mismatch.
+  const schemaHex = input.schemaHash
+    ? stripPrefix(input.schemaHash)
+    : "00".repeat(32);
 
   // Derive receipt_id from contentHash if not provided
   const receiptId =
@@ -64,7 +73,7 @@ export async function submitReceipt(
     toBytes32(rootHex), // base_root_sha256: [u8; 32]
     toBytes32("00".repeat(32)), // zk_root_poseidon: [u8; 32]
     toBytes32("00".repeat(32)), // poseidon_params_hash: [u8; 32]
-    toBytes32("00".repeat(32)), // schema_hash: [u8; 32]
+    toBytes32(schemaHex), // schema_hash: [u8; 32]
     toBytes32("00".repeat(32)), // storage_locator_hash: [u8; 32]
     toBytes32(manifestHex), // base_manifest_hash: [u8; 32]
     toBytes32("00".repeat(32)), // safety_manifest_hash: [u8; 32]
@@ -443,11 +452,19 @@ export async function submitCertifiedReceipt(
     throw new Error(`Blob upload failed: ${uploadResult.error}`);
   }
 
-  // 3. Submit receipt on-chain
+  // 3. Submit receipt on-chain. Forward `schemaHash` and `receiptId`
+  // from the caller's input so semantic-root receipt classes
+  // (compute_metering_v2*, orynq_trace_v1) land on chain with the right
+  // discriminator. Omitting schemaHash falls back to legacy (zero bytes)
+  // = chunk-Merkle path, preserving pre-existing behaviour.
   const receiptInput: ReceiptInput = {
     contentHash: effectiveContentHash,
     rootHash: input.rootHash || contentHashHex,
     manifestHash: uploadResult.storageLocatorHash || input.manifestHash || contentHashHex,
+    // Spread optional fields only when defined — exactOptionalPropertyTypes
+    // forbids assigning `undefined` to an omitted optional property.
+    ...(input.receiptId !== undefined ? { receiptId: input.receiptId } : {}),
+    ...(input.schemaHash !== undefined ? { schemaHash: input.schemaHash } : {}),
   };
   const submitResult = await submitReceipt(provider, receiptInput);
 

--- a/packages/anchors-materios/src/types.ts
+++ b/packages/anchors-materios/src/types.ts
@@ -70,6 +70,24 @@ export interface ReceiptInput {
   manifestHash: string;
   /** Optional pre-computed receipt ID. If omitted, derived from contentHash. */
   receiptId?: string;
+  /**
+   * Optional schema discriminator hash (32 bytes hex). Identifies the receipt
+   * class to cert-daemon's verifier. Default (omitted/zero) = legacy blob
+   * (chunk-Merkle must equal `rootHash`).
+   *
+   * Set to one of the registered discriminator values when the receipt's
+   * `base_root_sha256` is a *semantic* root (not the chunk-Merkle of the
+   * uploaded bytes):
+   *
+   *   sha256("compute_metering_v2")    — Wave 1+2 metering envelopes
+   *   sha256("compute_metering_v2_1")  — Wave 3 Phase 2 (with attestation_evidence)
+   *   sha256("orynq_trace_v1")         — orynq trace receipts (drain.mjs)
+   *
+   * The cert-daemon's TRUSTED_DISCRIMINATOR_SCHEMAS set (operator-kit
+   * daemon/schemas/__init__.py) enumerates accepted values. Receipts with
+   * unknown schemaHash are rejected by the verifier.
+   */
+  schemaHash?: string;
 }
 
 /** Result of a receipt submission. */


### PR DESCRIPTION
## Summary

Pairs with operator-kit PRs #18 (schema-aware dispatch) and #19 (orynq_trace_v1 registration). \`submitReceipt\` previously hardcoded \`schema_hash\` to 32 zero bytes at the extrinsic call site, giving every receipt the legacy chunk-Merkle discriminator regardless of class. With the cert-daemon side now schema-aware, callers (notably the orynq-drain daemon) need a way to pass the right discriminator through.

## Changes

- \`types.ts\`: add optional \`schemaHash: string\` to \`ReceiptInput\` with docs pointing at the registered discriminator values
- \`receipt.ts:67\`: replace hardcoded zero with caller-supplied schemaHash (defaults to zero when omitted, preserving prior behaviour for plain blob receipts)
- \`receipt.ts submitCertifiedReceipt\`: forward \`schemaHash\` and \`receiptId\` from caller's input to the inner \`submitReceipt\` call. Uses conditional spread because \`exactOptionalPropertyTypes\` forbids assigning \`undefined\` to an omitted optional.

## Backward compat

Callers that don't pass \`schemaHash\` see no behaviour change — the field falls back to 32 zeros (legacy schema), same as before this PR. Only receipts whose class needs a discriminator (\`compute_metering_v2\`, \`compute_metering_v2_1\`, \`orynq_trace_v1\`) need to be updated to set it.

## Tests

- \`pnpm typecheck\` ✓
- \`pnpm test\` ✓ (3 passing)
- \`pnpm build\` ✓ (dts build success)

## Follow-up

\`materios-orynq-hook/drain.mjs\` will be updated in a separate change to pass \`schemaHash: SCHEMA_HASH_ORYNQ_TRACE_V1\` to \`submitCertifiedReceipt\`. Without that, this PR is a no-op for the orynq path (still produces legacy-schema receipts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)