### PR TITLE
fix(anchors-materios): hex validation + receiptId alignment (PR #38 followups)

### DIFF
--- a/packages/anchors-materios/CHANGELOG.md
+++ b/packages/anchors-materios/CHANGELOG.md
@@ -1,0 +1,43 @@
+# @fluxpointstudios/orynq-sdk-anchors-materios
+
+## Unreleased
+
+### Changes
+
+- **feat:** `ReceiptInput.schemaHash` (optional 32-byte hex). When set, threads
+  the discriminator through to the on-chain `submit_receipt_v2` extrinsic
+  instead of hardcoding the legacy zero-bytes value. Required for receipt
+  classes whose `base_root_sha256` is a semantic root rather than the
+  chunk-Merkle (`compute_metering_v2`, `compute_metering_v2_1`,
+  `orynq_trace_v1`). Omitting the field preserves the prior on-chain
+  behaviour (legacy / chunk-Merkle dispatch). Paired with operator-kit
+  PRs #18 / #19 / #20 (cert-daemon schema-aware verifier).
+
+### Behaviour changes
+
+- **`submitCertifiedReceipt` now honors a caller-supplied `input.receiptId`
+  consistently between the blob-storage path and the on-chain submit.**
+  Prior to this release, `prepareBlobData` was always called with a derived
+  `receiptId = sha256(contentHash)` even if the caller passed
+  `input.receiptId`, while the on-chain submit used the caller-supplied
+  value. The two could diverge — the gateway stored the manifest under the
+  derived id, the chain recorded the caller's id, cert-daemon's manifest
+  lookup (keyed by on-chain receiptId) then failed. Now both paths use the
+  same `effectiveReceiptId` (caller-supplied if present, derived otherwise).
+  No-op for callers that didn't pass `input.receiptId` (most of them); the
+  bug only surfaced when callers explicitly overrode `receiptId`.
+
+### Validation
+
+- **Hex-format guards at the SDK boundary.** `contentHash`, `rootHash`,
+  `manifestHash`, and `schemaHash` are now validated as exactly 32 hex
+  bytes (64 chars, with optional `0x` prefix) before the extrinsic is
+  built. Throws an explicit `Error` with the field name. Previously these
+  flowed through `toBytes32` which silently padded short input and
+  silently truncated long input — both producing a different on-chain
+  value than the caller intended. The schemaHash guard already shipped
+  in 0.3.x; this release extends the same check to the other three fields.
+
+## 0.3.x
+
+(earlier releases — see git history)

--- a/packages/anchors-materios/src/hex.ts
+++ b/packages/anchors-materios/src/hex.ts
@@ -39,3 +39,28 @@ export function zeroHash(): string {
 export function isZeroHash(h: string): boolean {
   return stripPrefix(h).replace(/0/g, "").length === 0;
 }
+
+/**
+ * Assert the input is exactly 32 bytes (64 hex chars), 0x-prefix optional.
+ * Throws on short/long/non-hex input. Use at SDK entry points to surface
+ * caller errors immediately rather than letting `toBytes32` silently pad
+ * or truncate (which produces a different on-chain value than intended).
+ *
+ * @param value the hex string to validate
+ * @param fieldName name used in the error message
+ * @returns the validated raw hex (no prefix), lower-case
+ */
+export function assertHex32(value: string, fieldName: string): string {
+  if (typeof value !== "string") {
+    throw new Error(
+      `${fieldName} must be a hex string (32 bytes / 64 chars); got ${typeof value}`,
+    );
+  }
+  const bare = stripPrefix(value);
+  if (!/^[0-9a-fA-F]{64}$/.test(bare)) {
+    throw new Error(
+      `${fieldName} must be exactly 32 hex bytes (64 chars); got ${bare.length} chars`,
+    );
+  }
+  return bare.toLowerCase();
+}

--- a/packages/anchors-materios/src/receipt.ts
+++ b/packages/anchors-materios/src/receipt.ts
@@ -19,7 +19,7 @@ import type {
   CertifiedReceiptResult,
 } from "./types.js";
 import { waitForCertification, waitForAnchor } from "./polling.js";
-import { stripPrefix, ensureHex, isZeroHash } from "./hex.js";
+import { stripPrefix, ensureHex, isZeroHash, assertHex32 } from "./hex.js";
 import { u8aToHex, stringToU8a } from "@polkadot/util";
 
 /**
@@ -45,9 +45,14 @@ export async function submitReceipt(
   const api = provider.getApi();
   const keypair = provider.getKeypair();
 
-  const contentHex = stripPrefix(input.contentHash);
-  const rootHex = stripPrefix(input.rootHash);
-  const manifestHex = stripPrefix(input.manifestHash);
+  // Validate at the SDK boundary. `toBytes32` will silently pad short
+  // input and silently truncate long input — both produce a different
+  // on-chain value than the caller intended. Surfacing format errors
+  // here as Error throws (not silent on-chain corruption) is the
+  // operator-friendly default.
+  const contentHex = assertHex32(input.contentHash, "contentHash");
+  const rootHex = assertHex32(input.rootHash, "rootHash");
+  const manifestHex = assertHex32(input.manifestHash, "manifestHash");
   // schemaHash defaults to legacy (32 zero bytes) when caller omits it,
   // preserving the prior behaviour for plain blob receipts. Callers using
   // semantic-root receipt classes (compute_metering_v2*, orynq_trace_v1)
@@ -55,18 +60,8 @@ export async function submitReceipt(
   // operator-kit daemon/schemas/, otherwise cert-daemon rejects the
   // receipt with a Merkle mismatch.
   const schemaHex = input.schemaHash
-    ? stripPrefix(input.schemaHash)
+    ? assertHex32(input.schemaHash, "schemaHash")
     : "00".repeat(32);
-  // Reject silently-truncated / silently-padded discriminator inputs.
-  // toBytes32 will pad short input or read only the first 64 chars of long
-  // input, both of which silently produce the wrong on-chain value. A
-  // discriminator must be exactly 32 bytes (64 hex chars) — anything else
-  // is operator error.
-  if (!/^[0-9a-fA-F]{64}$/.test(schemaHex)) {
-    throw new Error(
-      `schemaHash must be exactly 32 hex bytes (64 chars); got ${schemaHex.length} chars`,
-    );
-  }
 
   // Derive receipt_id from contentHash if not provided
   const receiptId =
@@ -442,14 +437,22 @@ export async function submitCertifiedReceipt(
   // Use contentHash from input if provided, otherwise derive
   const effectiveContentHash = input.contentHash || contentHashHex;
 
-  // Derive receiptId
-  const receiptIdHex = ensureHex(
+  // Derive the *default* receiptId from contentHash. If the caller passed
+  // their own `input.receiptId`, honor it for BOTH the blob-storage path
+  // (prepareBlobData) AND the on-chain submit, so the gateway and chain
+  // agree on the key. Letting these diverge — derive for blob, caller-
+  // value for chain — strands the blob: cert-daemon looks up the manifest
+  // under the on-chain receiptId, doesn't find it, fails verification.
+  const derivedReceiptIdHex = ensureHex(
     createHash("sha256")
       .update(Buffer.from(stripPrefix(effectiveContentHash), "hex"))
       .digest("hex"),
   );
+  const effectiveReceiptIdHex = input.receiptId
+    ? ensureHex(input.receiptId)
+    : derivedReceiptIdHex;
 
-  const { manifest, chunks } = prepareBlobData(receiptIdHex, content);
+  const { manifest, chunks } = prepareBlobData(effectiveReceiptIdHex, content);
 
   // 2. Upload blobs to gateway
   const uploadResult = await uploadBlobs(
@@ -471,9 +474,12 @@ export async function submitCertifiedReceipt(
     contentHash: effectiveContentHash,
     rootHash: input.rootHash || contentHashHex,
     manifestHash: uploadResult.storageLocatorHash || input.manifestHash || contentHashHex,
-    // Spread optional fields only when defined — exactOptionalPropertyTypes
-    // forbids assigning `undefined` to an omitted optional property.
-    ...(input.receiptId !== undefined ? { receiptId: input.receiptId } : {}),
+    // Always pass effectiveReceiptIdHex (derived OR caller-supplied) so
+    // the gateway-side blob path and the on-chain receipt agree on the
+    // key. submitReceipt's own derivation would re-derive from
+    // contentHash and ignore the override — pass it explicitly.
+    receiptId: effectiveReceiptIdHex,
+    // exactOptionalPropertyTypes forbids assigning `undefined`, so spread.
     ...(input.schemaHash !== undefined ? { schemaHash: input.schemaHash } : {}),
   };
   const submitResult = await submitReceipt(provider, receiptInput);

--- a/packages/anchors-materios/tests/hex-validation.test.ts
+++ b/packages/anchors-materios/tests/hex-validation.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Hex-validation tests for the anchors-materios SDK boundary.
+ *
+ * `submitReceipt` and `submitCertifiedReceipt` flow through
+ * `assertHex32` for every 32-byte hash field. The goal: surface
+ * malformed input as a thrown Error at the SDK boundary, BEFORE we
+ * silently produce a different on-chain value than the caller intended
+ * (toBytes32 pads/truncates without complaint).
+ *
+ * Followup tests from PR #38's security review.
+ */
+import { describe, it, expect } from "vitest";
+import { assertHex32, stripPrefix, ensureHex } from "../src/hex.js";
+
+describe("assertHex32", () => {
+  const valid = "00".repeat(32); // 64 hex chars
+
+  it("accepts 64-char hex without prefix", () => {
+    expect(assertHex32(valid, "field")).toBe(valid);
+  });
+
+  it("accepts 0x-prefixed 64-char hex", () => {
+    expect(assertHex32("0x" + valid, "field")).toBe(valid);
+  });
+
+  it("accepts mixed-case and lower-cases", () => {
+    const mixed = "aB".repeat(32);
+    expect(assertHex32(mixed, "field")).toBe("ab".repeat(32));
+  });
+
+  it("rejects short hex with a field-named error", () => {
+    expect(() => assertHex32("00", "contentHash")).toThrow(/contentHash/);
+    expect(() => assertHex32("00", "contentHash")).toThrow(/64 chars/);
+  });
+
+  it("rejects over-length hex (would silently truncate without guard)", () => {
+    expect(() => assertHex32(valid + "ff", "rootHash")).toThrow(/rootHash/);
+  });
+
+  it("rejects non-hex characters (would silently produce NaN bytes)", () => {
+    const withSpace = valid.slice(0, 62) + " z";
+    expect(() => assertHex32(withSpace, "schemaHash")).toThrow(/schemaHash/);
+  });
+
+  it("rejects non-string input", () => {
+    // @ts-expect-error: testing runtime contract
+    expect(() => assertHex32(null, "manifestHash")).toThrow(/manifestHash/);
+    // @ts-expect-error: testing runtime contract
+    expect(() => assertHex32(undefined, "manifestHash")).toThrow(/manifestHash/);
+    // @ts-expect-error: testing runtime contract
+    expect(() => assertHex32(123, "manifestHash")).toThrow(/manifestHash/);
+  });
+
+  it("handles all-zero hash (legacy schema_hash sentinel)", () => {
+    expect(assertHex32("0".repeat(64), "schemaHash")).toBe("0".repeat(64));
+  });
+});
+
+describe("stripPrefix / ensureHex round trip", () => {
+  it("preserves leading zeros across stripPrefix → ensureHex", () => {
+    // Regression guard for the bug noted in hex.ts header (commit 4b4f3be).
+    const h =
+      "0x0000000000000000000000000000000000000000000000000000000000000001";
+    expect(ensureHex(stripPrefix(h))).toBe(h);
+  });
+});


### PR DESCRIPTION
## Summary

Three followups from PR #38's security review:

1. **Receipt-id divergence fix.** \`submitCertifiedReceipt\` previously passed the *derived* \`receiptId = sha256(contentHash)\` to \`prepareBlobData\` while forwarding the *caller-supplied* \`receiptId\` to the on-chain submit. Result: the gateway stored the manifest under one id, the chain recorded the other, cert-daemon's manifest lookup failed. Both paths now use the same \`effectiveReceiptId\`.
2. **Broader hex validation.** Extends the schemaHash hex-format guard (PR #38) to \`contentHash\`, \`rootHash\`, \`manifestHash\` via a shared \`assertHex32(value, fieldName)\` helper.
3. **CHANGELOG entry** documenting the new field, the behaviour change, and the validation contract.

## No-op for existing callers

The receiptId-alignment fix only changes behaviour for callers that explicitly passed \`input.receiptId\` to \`submitCertifiedReceipt\` (the prior behaviour silently ignored it for blob storage). The drain daemon (the actual production caller) doesn't pass \`receiptId\`, so its on-chain receipts are unaffected.

The hex-format guards reject input that previously caused silent corruption on-chain. Callers that were passing valid 32-byte hex see no change; callers that were passing malformed input now get an immediate \`Error\` with the field name instead of a wrong chain value.

## Tests

- 9 new tests in \`tests/hex-validation.test.ts\` (valid / short / over-length / non-hex / non-string / leading-zero preservation)
- All 12 SDK tests passing
- \`pnpm typecheck\` ✓, \`pnpm build\` ✓ (dts clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)