### PR TITLE
fix(anchors-materios): align submitReceipt args with live runtime metadata

### DIFF
--- a/packages/anchors-materios/src/receipt.ts
+++ b/packages/anchors-materios/src/receipt.ts
@@ -71,19 +71,50 @@ export async function submitReceipt(
         .update(Buffer.from(contentHex, "hex"))
         .digest("hex");
 
+  // Positional arg order MUST track live runtime metadata exactly. Two
+  // drift hazards that have bitten us before (task #115; observed again
+  // 2026-05-11 when every orynq_trace_v1 + compute_metering_v2 receipt
+  // landed with schema_hash=0x00…):
+  //
+  //   1. arg ordering — fields 5-10 changed shape and the SDK was sending
+  //      schemaHash in the slot the runtime now decodes as
+  //      baseManifestHash. The verifier read schema_hash=0, fell through
+  //      to the legacy chunk-Merkle path, computed against the wrong
+  //      field, and rejected every receipt.
+  //   2. Option<[u8;32]> on zkRootPoseidon + poseidonParamsHash — passing
+  //      a raw 32-byte buffer for an Option<> arg corrupts SCALE encoding
+  //      because polkadot-js takes the first byte as the Option tag.
+  //      Pass `null` for None; pass the bytes directly only if Some is
+  //      genuinely intended.
+  //
+  // Live metadata as of 2026-05-11 (queried via api.tx.orinqReceipts.submitReceipt.meta):
+  //   0  receipt_id              : H256
+  //   1  content_hash            : H256
+  //   2  base_root_sha256        : [u8;32]
+  //   3  zk_root_poseidon        : Option<[u8;32]>
+  //   4  poseidon_params_hash    : Option<[u8;32]>
+  //   5  base_manifest_hash      : [u8;32]
+  //   6  safety_manifest_hash    : [u8;32]
+  //   7  monitor_config_hash     : [u8;32]
+  //   8  attestation_evidence_hash : [u8;32]
+  //   9  storage_locator_hash    : [u8;32]
+  //   10 schema_hash             : [u8;32]
+  //
+  // If you change this, add a regression test that fetches live metadata
+  // and asserts the name + type of each positional arg.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const tx = (api.tx as any).orinqReceipts.submitReceipt(
-    ensureHex(receiptId), // receipt_id: H256
-    toBytes32(contentHex), // content_hash: [u8; 32]
-    toBytes32(rootHex), // base_root_sha256: [u8; 32]
-    toBytes32("00".repeat(32)), // zk_root_poseidon: [u8; 32]
-    toBytes32("00".repeat(32)), // poseidon_params_hash: [u8; 32]
-    toBytes32(schemaHex), // schema_hash: [u8; 32]
-    toBytes32("00".repeat(32)), // storage_locator_hash: [u8; 32]
-    toBytes32(manifestHex), // base_manifest_hash: [u8; 32]
-    toBytes32("00".repeat(32)), // safety_manifest_hash: [u8; 32]
-    toBytes32("00".repeat(32)), // monitor_config_hash: [u8; 32]
-    toBytes32("00".repeat(32)), // attestation_evidence_hash: [u8; 32]
+    ensureHex(receiptId),         // 0  receipt_id
+    ensureHex(contentHex),        // 1  content_hash (H256)
+    toBytes32(rootHex),           // 2  base_root_sha256
+    null,                         // 3  zk_root_poseidon: Option<None>
+    null,                         // 4  poseidon_params_hash: Option<None>
+    toBytes32(manifestHex),       // 5  base_manifest_hash
+    toBytes32("00".repeat(32)),   // 6  safety_manifest_hash
+    toBytes32("00".repeat(32)),   // 7  monitor_config_hash
+    toBytes32("00".repeat(32)),   // 8  attestation_evidence_hash
+    toBytes32("00".repeat(32)),   // 9  storage_locator_hash
+    toBytes32(schemaHex),         // 10 schema_hash
   );
 
   // Sign the extrinsic first so dry-run can simulate the fully signed payload


### PR DESCRIPTION
## Summary

- Reorder `submitReceipt`'s 11 positional args to match the live runtime
  metadata for `pallet-orinq-receipts.submit_receipt`. Args 5-10 had
  drifted on the runtime side; the SDK was sending the old layout, so
  `schemaHash` landed on chain as `base_manifest_hash` and the
  `schema_hash` slot got zeros.
- Pass `null` (not zero buffers) for the two `Option<[u8;32]>` slots
  (`zk_root_poseidon`, `poseidon_params_hash`). A raw 32-byte buffer for
  an Option arg corrupts SCALE encoding — polkadot-js takes the first
  byte as the Option tag.

## Why this matters

Every orynq_trace_v1 and compute_metering_v2 receipt submitted with the
broken SDK landed with `schema_hash = 0x0…`. Cert-daemon's schema-aware
verifier (operator-kit PRs #18/#19/#20) read schema_hash=0, fell through
to the legacy chunk-Merkle path, recomputed Merkle against the wrong
field (the SDK's manifestHash landed in the `monitor_config_hash` slot),
and rejected every receipt with a Merkle mismatch. The cert-daemon
"long-term fix" looked broken — it wasn't, the SDK was never actually
emitting schema-tagged receipts correctly.

This is a recurrence of task #115 (the first arg-order drift fix). That
fix didn't ship the regression test that would have caught this — see
follow-ups.

## End-to-end verification (live preprod, 2026-05-11)

Test receipt `0x60c4bc0ce523bc94eed77ab252d83dae349401d2280b102c83ce4010bc217e05`
submitted via the rebuilt SDK lands with:
- `schema_hash` = `0xcab0f81814eb84c9338938e702c8e8854c6cb17b371a9fd784a08e41c75d71b5` (= `sha256("orynq_trace_v1")`) ✓
- `base_manifest_hash` matches the intended manifest hash ✓
- All other slots populated as expected ✓

Pre-fix receipts in the same window had `schema_hash = 0x0…` and other
slots populated with the wrong values.

## Live runtime metadata (pin against this)

```
0  receipt_id              : H256
1  content_hash            : H256
2  base_root_sha256        : [u8;32]
3  zk_root_poseidon        : Option<[u8;32]>
4  poseidon_params_hash    : Option<[u8;32]>
5  base_manifest_hash      : [u8;32]
6  safety_manifest_hash    : [u8;32]
7  monitor_config_hash     : [u8;32]
8  attestation_evidence_hash : [u8;32]
9  storage_locator_hash    : [u8;32]
10 schema_hash             : [u8;32]
```

## Follow-ups (deliberately not in this PR — keep it surgical)

- Add CI regression test that fetches live runtime metadata via
  `api.tx.orinqReceipts.submitReceipt.meta` and asserts the SDK's
  positional arg order matches by name and type. This must be the gate
  for future SDK releases; without it the next runtime drift recurs
  silently.
- Audit `submitAnchor` for the same kind of drift.
- Forensic check on the affected historical receipts (compute_metering_v2
  + orynq_trace_v1) — their content_hash fields are correct (same slot
  in both layouts), so billing-by-content_hash queries still work, but
  base_manifest / monitor_config / etc are scrambled. Decide what to do.

## Test plan

- [x] Confirmed schema_hash lands correctly on chain for a fresh receipt
- [x] Confirmed dry-run catches `ReceiptAlreadyExists` for pre-fix
  receipt IDs (proves SDK addresses chain correctly)
- [ ] Reviewers: please double-check the arg order in `src/receipt.ts`
  against `api.tx.orinqReceipts.submitReceipt.meta` on preprod
- [ ] Reviewers: confirm `null` is the correct polkadot-js encoding for
  `Option<[u8;32]>` None

Refs materios-node task #204 (recurrence of #115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)