### PR TITLE
feat(examples): add claude-code-hook reference consumer

### DIFF
--- a/examples/claude-code-hook/README.md
+++ b/examples/claude-code-hook/README.md
@@ -1,0 +1,188 @@
+# Claude Code orynq hook — reference example
+
+A thin Claude Code `PostToolUse` hook + systemd drain daemon that anchors
+**every completed task** to Materios preprod as a certified receipt.
+Reference consumer of `@fluxpointstudios/orynq-sdk-anchors-materios`.
+Survives session crashes, reboots, and multi-day Claude Code sessions.
+
+Throughout this README, `<INSTALL_DIR>` refers to wherever you place a
+copy of this directory on the operator's machine — e.g.
+`/home/alice/orynq-sdk/examples/claude-code-hook` or
+`/opt/materios-orynq-hook` after a manual copy.
+
+## Architecture (per-task drain — current)
+
+```
+PostToolUse(TaskUpdate, completed)
+        |
+        v
+   hook.mjs                                queue/<ts>-task-<id>.json
+   (atomic write, <10ms)            ----> (one bundle per task)
+                                            |
+                                            v
+                                       drain.mjs (systemd unit)
+                                            |
+                                       submitCertifiedReceipt
+                                            |
+                            success: queue/ -> done/
+                            failure: queue/ -> failed/ + .error.txt
+```
+
+The hook does NOT import the orynq SDK and does NOT touch the network — it
+just drops one self-contained bundle in `queue/` and exits. The drain daemon
+runs separately under systemd, watches `queue/` via `fs.watch` (with a 5 s
+poll fallback), and submits one receipt per file.
+
+`SessionEnd` is now a **no-op** — the per-task drain replaces the old
+session-end batching that was vulnerable to lost work on crash.
+
+## Components
+
+| File | Role |
+|---|---|
+| `hook.mjs` | Claude Code hook entrypoint. Writes one queue file per `TaskUpdate(completed)`. |
+| `drain.mjs` | Long-running daemon. Watches `queue/`, submits each entry to Materios. |
+| `flush-session.mjs` | One-shot recovery script for legacy `<sessionId>.json` event accumulators. |
+| `materios-orynq-drain.service` | systemd unit (copied to `/etc/systemd/system/`). |
+
+## State layout
+
+```
+~/.local/state/materios-orynq-hook/
+  queue/                    pending bundles (drain reads these)
+  done/                     successfully submitted (annotated with receipt info)
+  failed/                   submit failures (with sibling .error.txt)
+  <sessionId>.json          legacy event accumulator (flush-session.mjs reads)
+  <sessionId>.flushed       marker; flush-session refuses to re-run
+~/materios-orynq-hook/drain.log    daemon stdout+stderr (systemd-managed)
+```
+
+## Queue entry shape
+
+```json
+{
+  "schemaVersion": "queue/1.0",
+  "contentHash": "<sha256-hex>",
+  "rootHash":    "<sha256-hex>",
+  "manifestHash":"<sha256-hex>",
+  "publicView": {
+    "taskId": "...", "subject": "...", "sessionId": "...",
+    "timestamp": "...", "summary": "...", "cwd": "...", "hostname": "..."
+  },
+  "raw": { /* original PostToolUse payload */ }
+}
+```
+
+`rootHash` is `sha256({sessionId, taskId, timestamp, subject, summary})` —
+deterministic, so retries land the same anchor (idempotent at chain level).
+
+## Install / restart sequence
+
+1. **Install systemd unit** (one-time):
+   ```bash
+   sudo cp <INSTALL_DIR>/materios-orynq-drain.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now materios-orynq-drain
+   ```
+2. **Tail the log**:
+   ```bash
+   tail -f <INSTALL_DIR>/drain.log
+   ```
+3. **Recover legacy session events** (one-time, for the 6-day session that
+   accumulated 54 events in memory before the drain landed):
+   ```bash
+   # dry-run first
+   node <INSTALL_DIR>/flush-session.mjs --dry-run
+   # then write
+   node <INSTALL_DIR>/flush-session.mjs
+   ```
+   The drain daemon will pick up the queue files automatically.
+
+## Config (`~/.materios-orynq-hook.env`, 0600)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `MATERIOS_RPC_URL` | (unset) | Substrate WS RPC. Drain refuses to start without this. |
+| `MATERIOS_SIGNER_URI` | (unset) | `//Alice` or 12/15/24-word mnemonic. |
+| `MATERIOS_BLOB_GATEWAY_URL` | `https://materios.fluxpointstudios.com/preprod-blobs` | Blob upload endpoint. |
+| `MATERIOS_BLOB_GATEWAY_API_KEY` | (unset) | Gateway auth; falls back to sr25519-sig when absent. |
+| `ORYNQ_NO_AUTO_TRACE` | (unset) | `1` disables the hook entirely. |
+| `ORYNQ_HOOK_ENV` | `~/.materios-orynq-hook.env` | Override env-file path. |
+| `ORYNQ_SDK_PATH` | `/tmp/orynq-sdk` | Override orynq-sdk repo location. |
+| `ORYNQ_DRAIN_DRY_RUN` | (unset) | Drain daemon: `1` skips network call, just moves files. |
+| `ORYNQ_DRAIN_POLL_MS` | `5000` | Drain daemon: poll-fallback interval. |
+| `ORYNQ_FLUSH_DRY_RUN` | (unset) | flush-session: `1` counts events without writing. |
+
+## Backoff / failure modes
+
+- `submitCertifiedReceipt` timeout is 90 s per attempt (was 180 s in the old
+  hook — drain retries on next-loop iteration so a single tight timeout is
+  fine).
+- After **3 consecutive submit failures** the daemon disconnects the
+  Materios provider and sleeps 60 s (catches WS-wedge cases like the
+  RPC-cap exhaustion we saw 2026-04-25).
+- Failed entries land in `failed/` with `.error.txt`; you can move them
+  back to `queue/` after a fix to retry.
+
+## Redaction (hook-side)
+
+Before bundles hit the queue, these shapes are stripped from the summary:
+
+- `xpub…` BIP32 extended keys
+- `(mnemonic|seed phrase|private key|api key|signer uri) <value>` labels
+- Bare 64-char hex (likely seeds / root hashes)
+- 12+ consecutive 3–8-char lowercase word chunks (BIP39-shaped)
+
+Summaries are truncated to 1800 chars; subjects to 200.
+
+## Smoke tests
+
+```bash
+# 1. Hook writes a queue file
+echo '{"hook_event_name":"PostToolUse","session_id":"smoke","tool_name":"TaskUpdate","tool_input":{"taskId":"1","status":"completed","subject":"test"}}' \
+  | node <INSTALL_DIR>/hook.mjs
+ls ~/.local/state/materios-orynq-hook/queue/
+
+# 2. Drain processes without network (dry-run)
+ORYNQ_DRAIN_DRY_RUN=1 node <INSTALL_DIR>/drain.mjs &
+DRAIN=$!
+sleep 3
+kill $DRAIN
+ls ~/.local/state/materios-orynq-hook/done/   # smoke-* should appear here
+```
+
+## Opt-out
+
+- Per-launch: `ORYNQ_NO_AUTO_TRACE=1 claude`
+- Permanent: remove the `hooks` block from `~/.claude/settings.json`.
+- Anchor-only: `sudo systemctl stop materios-orynq-drain` — the hook keeps
+  queueing locally, nothing hits chain.
+
+## Why per-task instead of per-session
+
+The pre-2026-05-04 hook batched a session's spans into one finalize-on-end
+receipt. That's vulnerable: this very Gemtek session ran 6 days with 54
+unanchored task closures. A SIGKILL would have lost them all.
+
+Per-task means:
+- One anchor per closure → no batching latency.
+- File-system durability → survives crash, reboot, daemon restart.
+- Idempotent rootHash → re-running flush is safe.
+
+The cost is more chain receipts (54 vs 1 for that session), which is
+acceptable given current preprod throughput.
+
+## Known limits
+
+- Redaction is heuristic. For high-sensitivity repos, set
+  `ORYNQ_NO_AUTO_TRACE=1` or stop the drain daemon.
+- `orynq-sdk` must be built locally at `/tmp/orynq-sdk`. Rebuild with
+  `pnpm -r build` if `dist/` is stale.
+- Drain is sequential by design. With cert-daemon throttling this is fine
+  even at 100 task closures/hour.
+
+## Upstream plan
+
+Still aimed at `@orynq/claude-hook`. The drain daemon shape is the
+prototype for the SDK package — see
+`~/.claude/projects/-home-deci/memory/project_orynq_auto_trace_plan.md`.

--- a/examples/claude-code-hook/backlog-drain.mjs
+++ b/examples/claude-code-hook/backlog-drain.mjs
@@ -12,16 +12,19 @@
  * Default mode is DRY-RUN. Set BACKLOG_APPLY=1 to actually POST.
  *
  * IMPORTANT: this script imports @polkadot/api from the anchor-worker's
- * node_modules. Run from /home/deci/materios-anchor-worker:
+ * node_modules. Either run it with the anchor-worker dir as cwd, or set
+ * `ANCHOR_WORKER_DIR` so the fallback import can find @polkadot/api:
  *
- *   cd /home/deci/materios-anchor-worker
- *   node /home/deci/materios-orynq-hook/backlog-drain.mjs            # dry-run
- *   BACKLOG_APPLY=1 node /home/deci/materios-orynq-hook/backlog-drain.mjs   # apply
+ *   cd $ANCHOR_WORKER_DIR
+ *   node /path/to/examples/claude-code-hook/backlog-drain.mjs                       # dry-run
+ *   BACKLOG_APPLY=1 node /path/to/examples/claude-code-hook/backlog-drain.mjs       # apply
  *
  * Config:
  *   MATERIOS_RPC_URL                 — substrate WS endpoint (default = SDK default)
  *   ANCHOR_WORKER_URL=http://127.0.0.1:3333
- *   ANCHOR_WORKER_TOKEN_FILE=/home/deci/materios-anchor-worker/.anchor-worker-token
+ *   ANCHOR_WORKER_DIR                — directory with @polkadot/api in node_modules
+ *                                      (default $HOME/materios-anchor-worker)
+ *   ANCHOR_WORKER_TOKEN_FILE         — default $ANCHOR_WORKER_DIR/.anchor-worker-token
  *   CERT_DAEMON_HISTORY=/data/checkpoint-history.json   inside the docker container
  *   BACKLOG_APPLY=1                  — flip from dry-run to real POSTs
  *   BACKLOG_LIMIT=N                  — cap to N receipts (debug)
@@ -29,11 +32,14 @@
  */
 import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
+import path from "node:path";
 
+const HOME = process.env.HOME || process.env.USERPROFILE || "";
+const AW_DIR = process.env.ANCHOR_WORKER_DIR || path.join(HOME, "materios-anchor-worker");
 const MAT_RPC = process.env.MATERIOS_RPC_URL || "wss://materios.fluxpointstudios.com/preprod-rpc";
 const AW_URL = process.env.ANCHOR_WORKER_URL || "http://127.0.0.1:3333";
 const AW_TOKEN_FILE = process.env.ANCHOR_WORKER_TOKEN_FILE
-  || "/home/deci/materios-anchor-worker/.anchor-worker-token";
+  || path.join(AW_DIR, ".anchor-worker-token");
 const APPLY = process.env.BACKLOG_APPLY === "1";
 const LIMIT = process.env.BACKLOG_LIMIT ? Number(process.env.BACKLOG_LIMIT) : Infinity;
 const THROTTLE_MS = Number(process.env.BACKLOG_THROTTLE_MS || 2000);
@@ -45,11 +51,11 @@ function log(msg) {
 function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
 
 async function loadPolkadotApi() {
-  // Try cwd first (works when invoked from /home/deci/materios-anchor-worker)
-  // then fall back to absolute path (works from anywhere).
+  // Try cwd first (works when invoked from inside the anchor-worker dir),
+  // then fall back to ANCHOR_WORKER_DIR/node_modules.
   try { return await import("@polkadot/api"); } catch { /* fall through */ }
   const { pathToFileURL } = await import("node:url");
-  const abs = "/home/deci/materios-anchor-worker/node_modules/@polkadot/api/index.js";
+  const abs = path.join(AW_DIR, "node_modules", "@polkadot", "api", "index.js");
   return await import(pathToFileURL(abs).href);
 }
 

--- a/examples/claude-code-hook/backlog-drain.mjs
+++ b/examples/claude-code-hook/backlog-drain.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Backlog drainer: scan Materios for receipts that are Certified on-chain
+ * but absent from the cert-daemon's checkpoint-history.json, and POST each
+ * to /anchor in order.
+ *
+ * NOT triggered automatically. The user runs this manually (after reviewing
+ * the proposed list) when the standard pipeline has missed historical
+ * receipts — typically after an extended cert-daemon outage or container
+ * replacement that lost local history.
+ *
+ * Default mode is DRY-RUN. Set BACKLOG_APPLY=1 to actually POST.
+ *
+ * IMPORTANT: this script imports @polkadot/api from the anchor-worker's
+ * node_modules. Run from /home/deci/materios-anchor-worker:
+ *
+ *   cd /home/deci/materios-anchor-worker
+ *   node /home/deci/materios-orynq-hook/backlog-drain.mjs            # dry-run
+ *   BACKLOG_APPLY=1 node /home/deci/materios-orynq-hook/backlog-drain.mjs   # apply
+ *
+ * Config:
+ *   MATERIOS_RPC_URL                 — substrate WS endpoint (default = SDK default)
+ *   ANCHOR_WORKER_URL=http://127.0.0.1:3333
+ *   ANCHOR_WORKER_TOKEN_FILE=/home/deci/materios-anchor-worker/.anchor-worker-token
+ *   CERT_DAEMON_HISTORY=/data/checkpoint-history.json   inside the docker container
+ *   BACKLOG_APPLY=1                  — flip from dry-run to real POSTs
+ *   BACKLOG_LIMIT=N                  — cap to N receipts (debug)
+ *   BACKLOG_THROTTLE_MS=2000         — gap between POSTs
+ */
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+const MAT_RPC = process.env.MATERIOS_RPC_URL || "wss://materios.fluxpointstudios.com/preprod-rpc";
+const AW_URL = process.env.ANCHOR_WORKER_URL || "http://127.0.0.1:3333";
+const AW_TOKEN_FILE = process.env.ANCHOR_WORKER_TOKEN_FILE
+  || "/home/deci/materios-anchor-worker/.anchor-worker-token";
+const APPLY = process.env.BACKLOG_APPLY === "1";
+const LIMIT = process.env.BACKLOG_LIMIT ? Number(process.env.BACKLOG_LIMIT) : Infinity;
+const THROTTLE_MS = Number(process.env.BACKLOG_THROTTLE_MS || 2000);
+const CONTAINER = process.env.CERT_DAEMON_CONTAINER || "materios-node-cert-daemon-preprod-1";
+
+function log(msg) {
+  console.log(`[backlog] ${new Date().toISOString()} ${msg}`);
+}
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+async function loadPolkadotApi() {
+  // Try cwd first (works when invoked from /home/deci/materios-anchor-worker)
+  // then fall back to absolute path (works from anywhere).
+  try { return await import("@polkadot/api"); } catch { /* fall through */ }
+  const { pathToFileURL } = await import("node:url");
+  const abs = "/home/deci/materios-anchor-worker/node_modules/@polkadot/api/index.js";
+  return await import(pathToFileURL(abs).href);
+}
+
+async function fetchCertifiedFromChain() {
+  const { ApiPromise, WsProvider } = await loadPolkadotApi();
+  const api = await ApiPromise.create({ provider: new WsProvider(MAT_RPC) });
+  log(`connected to ${MAT_RPC}; chain genesis ${api.genesisHash.toHex().slice(0, 18)}...`);
+  const entries = await api.query.orinqReceipts.receipts.entries();
+  log(`enumerated ${entries.length} receipts on chain`);
+  const certified = [];
+  for (const [key, value] of entries) {
+    const args = key.args;
+    const ridBytes = args[0].toU8a();
+    const rid = "0x" + Buffer.from(ridBytes).toString("hex");
+    const r = value.toJSON();
+    const ach = r?.availability_cert_hash || r?.availabilityCertHash;
+    if (!ach) continue;
+    const achHex = Array.isArray(ach)
+      ? ach.map((b) => b.toString(16).padStart(2, "0")).join("")
+      : String(ach).replace(/^0x/, "");
+    if (/^0+$/.test(achHex)) continue;
+    const contentHash = r?.content_hash || r?.contentHash;
+    const baseRoot = r?.base_root_sha256 || r?.baseRootSha256;
+    const manifestHash = r?.storage_locator_hash || r?.storageLocatorHash;
+    const toHex = (v) => Array.isArray(v)
+      ? v.map((b) => b.toString(16).padStart(2, "0")).join("")
+      : String(v ?? "").replace(/^0x/, "");
+    certified.push({
+      receiptId: rid,
+      contentHash: "0x" + toHex(contentHash),
+      rootHash: "0x" + toHex(baseRoot || contentHash),
+      manifestHash: "0x" + toHex(manifestHash || contentHash),
+      certHash: "0x" + achHex,
+    });
+  }
+  await api.disconnect();
+  return certified;
+}
+
+function loadCheckpointHistory() {
+  // Read from inside the docker container — the file is on the cert-daemon's
+  // /data PVC and not bind-mounted to the host.
+  try {
+    const out = execSync(
+      `docker exec ${CONTAINER} cat /data/checkpoint-history.json`,
+      { encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
+    );
+    const arr = JSON.parse(out);
+    const seen = new Set();
+    for (const batch of arr) {
+      for (const leaf of batch.leaves || []) {
+        seen.add(leaf.receipt_id);
+      }
+    }
+    return seen;
+  } catch (e) {
+    log(`WARN could not read cert-daemon history (${e?.message || e}); proceeding with empty history`);
+    return new Set();
+  }
+}
+
+async function postAnchor(payload, token) {
+  const res = await fetch(`${AW_URL.replace(/\/+$/, "")}/anchor`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-internal-token": token,
+    },
+    body: JSON.stringify(payload),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text };
+}
+
+async function main() {
+  log(`mode = ${APPLY ? "APPLY (will POST /anchor)" : "DRY-RUN (no POST)"}`);
+  log(`anchor-worker target = ${AW_URL}/anchor`);
+
+  const certified = await fetchCertifiedFromChain();
+  log(`certified on chain: ${certified.length}`);
+  const seen = loadCheckpointHistory();
+  log(`receipts in cert-daemon history: ${seen.size}`);
+
+  const backlog = certified.filter((c) => !seen.has(c.receiptId));
+  log(`backlog (certified but absent from history): ${backlog.length}`);
+
+  if (backlog.length === 0) {
+    log("nothing to do — backlog is empty");
+    return;
+  }
+
+  const slice = Number.isFinite(LIMIT) ? backlog.slice(0, LIMIT) : backlog;
+  log(`will process ${slice.length} receipt(s)`);
+  for (const r of slice) {
+    log(`  ${r.receiptId.slice(0, 18)}... root=${r.rootHash.slice(0, 18)}... cert=${r.certHash.slice(0, 18)}...`);
+  }
+  if (!APPLY) {
+    log("dry-run complete; rerun with BACKLOG_APPLY=1 to POST");
+    return;
+  }
+
+  const token = readFileSync(AW_TOKEN_FILE, "utf-8").trim();
+  if (!token) throw new Error(`empty token at ${AW_TOKEN_FILE}`);
+  log(`loaded token (${token.length} chars)`);
+
+  let ok = 0, fail = 0;
+  for (let i = 0; i < slice.length; i++) {
+    const r = slice[i];
+    log(`POST ${i + 1}/${slice.length}  ${r.receiptId.slice(0, 18)}...`);
+    try {
+      const { status, body } = await postAnchor(
+        { contentHash: r.contentHash, rootHash: r.rootHash, manifestHash: r.manifestHash },
+        token,
+      );
+      if (status === 200) {
+        let parsed = {};
+        try { parsed = JSON.parse(body); } catch { /* ignore */ }
+        log(`  OK txHash=${parsed?.txHash || parsed?.cardanoTxHash || "?"}`);
+        ok++;
+      } else {
+        log(`  FAIL status=${status} body=${body.slice(0, 200)}`);
+        fail++;
+      }
+    } catch (e) {
+      log(`  ERR ${e?.message || e}`);
+      fail++;
+    }
+    if (i + 1 < slice.length) await sleep(THROTTLE_MS);
+  }
+  log(`done. ok=${ok} fail=${fail}`);
+}
+
+main().catch((e) => {
+  console.error(`[backlog] fatal: ${e?.stack || e}`);
+  process.exit(1);
+});

--- a/examples/claude-code-hook/drain.mjs
+++ b/examples/claude-code-hook/drain.mjs
@@ -101,7 +101,7 @@ const SCHEMA_HASH_ORYNQ_TRACE_V1 =
 // Anchor backstop config
 const ANCHOR_WORKER_URL = process.env.ANCHOR_WORKER_URL || "http://127.0.0.1:3333";
 const ANCHOR_WORKER_TOKEN_FILE = process.env.ANCHOR_WORKER_TOKEN_FILE
-  || "/home/deci/materios-anchor-worker/.anchor-worker-token";
+  || path.join(HOME, "materios-anchor-worker", ".anchor-worker-token");
 const ANCHOR_BACKSTOP_MS = Number(process.env.ORYNQ_DRAIN_ANCHOR_BACKSTOP_MS || 600_000);
 const ANCHOR_BACKSTOP_DISABLED = process.env.ORYNQ_DRAIN_ANCHOR_DISABLED === "1";
 const ANCHOR_BACKSTOP_SWEEP_MS = 60_000;

--- a/examples/claude-code-hook/drain.mjs
+++ b/examples/claude-code-hook/drain.mjs
@@ -1,0 +1,817 @@
+#!/usr/bin/env node
+/**
+ * Materios orynq drain daemon.
+ *
+ * Watches ~/.local/state/materios-orynq-hook/queue/ for queue entries dropped
+ * by hook.mjs (one per Claude Code task closure) and submits each one to
+ * Materios as a certified receipt via @orynq/anchors-materios.
+ *
+ * Sequential: one submit at a time (low volume + cert-daemon throttles anyway).
+ * On success: queue/<file> -> done/<file> (with receipt info appended).
+ * On failure: queue/<file> -> failed/<file> + sibling .error.txt.
+ *
+ * Watches via fs.watch; 5s poll fallback for filesystems that miss events.
+ * After 3 consecutive submit failures, sleeps 60s before retrying.
+ *
+ * Config (read from ~/.materios-orynq-hook.env, same as hook.mjs):
+ *   MATERIOS_RPC_URL, MATERIOS_SIGNER_URI, MATERIOS_BLOB_GATEWAY_URL,
+ *   MATERIOS_BLOB_GATEWAY_API_KEY (optional)
+ *
+ *   ORYNQ_SDK_PATH=/path/to/orynq-sdk (default /tmp/orynq-sdk)
+ *   ORYNQ_DRAIN_DRY_RUN=1 — log "would submit" and skip the network call
+ *   ORYNQ_DRAIN_POLL_MS=5000 — poll fallback interval
+ *
+ * Chain-aware anchor backstop (defends against cert-daemon stalls without
+ * producing duplicate Cardano anchors in healthy operation):
+ *
+ *   After successful certification we drop a sentinel into pending-anchor/
+ *   carrying { contentHash, rootHash, manifestHash, certHash, blockNum, dueAt }.
+ *   A periodic sweep treats any sentinel past dueAt
+ *   (ORYNQ_DRAIN_ANCHOR_BACKSTOP_MS, default 600_000 = 10 min) as a candidate
+ *   for the backstop. Before POSTing /anchor it consults cert-daemon's
+ *   authoritative state via two read-only sources:
+ *
+ *     1. /data/checkpoint-history.json (read via `docker exec ... cat`).
+ *        cert-daemon only appends to this file AFTER its `_submit_to_cardano`
+ *        returns 200 (see /app/daemon/checkpoint.py:209-211 in container
+ *        materios-node-cert-daemon-preprod-1). So presence of our sentinel's
+ *        certHash in any batch's leaves[].cert_hash means cert-daemon already
+ *        anchored — we must NOT POST. Sentinel is deleted, log says "skipped".
+ *
+ *     2. cert-daemon's metrics endpoint (curl http://127.0.0.1:8081/metrics).
+ *        The line `materios_cert_daemon_last_processed_block <N>` tells us how
+ *        far cert-daemon has scanned. Only when N >= sentinel.blockNum + 30 do
+ *        we treat absence-from-history as "cert-daemon had its chance and chose
+ *        not to anchor" → wedge → POST /anchor as backstop.
+ *
+ *   If either probe fails (docker exec error, metrics unreachable), we log a
+ *   warning and DO NOT POST — better to retry next sweep than risk a duplicate
+ *   anchor when our diagnostic is broken. Sentinel stays past-due.
+ *
+ *   Note: cert-daemon does NOT persist the resulting Cardano tx_hash in
+ *   checkpoint-history.json (verified 2026-05-04 against live container — the
+ *   file only has root_hash/manifest_hash/leaves; tx_hash field is absent).
+ *   So the chain-aware result reports {anchored, batchRoot, batchTimestamp,
+ *   leafBlockNum} but txHash is null.
+ *
+ *   ANCHOR_WORKER_URL=http://127.0.0.1:3333 (default)
+ *   ANCHOR_WORKER_TOKEN_FILE=/home/deci/materios-anchor-worker/.anchor-worker-token (default)
+ *   ANCHOR_WORKER_TOKEN=<token>                       — overrides the token file
+ *   ORYNQ_DRAIN_ANCHOR_BACKSTOP_MS=600000             — backstop delay (10 min)
+ *   ORYNQ_DRAIN_ANCHOR_DISABLED=1                     — disable backstop entirely
+ *   ORYNQ_DRAIN_CERT_DAEMON_CONTAINER=materios-node-cert-daemon-preprod-1
+ *   ORYNQ_DRAIN_CERT_DAEMON_METRICS_URL=http://127.0.0.1:8081/metrics
+ *   ORYNQ_DRAIN_CERT_DAEMON_LEAD_BLOCKS=30            — N: cert-daemon must be
+ *                                                       this many blocks past
+ *                                                       sentinel.blockNum to
+ *                                                       allow the backstop POST.
+ */
+
+import fs from "node:fs/promises";
+import { readFileSync, watch as fsWatch } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+const HOME = process.env.HOME || process.env.USERPROFILE || "/home/deci";
+const ENV_FILE = process.env.ORYNQ_HOOK_ENV || path.join(HOME, ".materios-orynq-hook.env");
+const ORYNQ_SDK = process.env.ORYNQ_SDK_PATH || "/tmp/orynq-sdk";
+const STATE_DIR = path.join(HOME, ".local/state/materios-orynq-hook");
+const QUEUE_DIR = path.join(STATE_DIR, "queue");
+const DONE_DIR = path.join(STATE_DIR, "done");
+const FAILED_DIR = path.join(STATE_DIR, "failed");
+const PENDING_ANCHOR_DIR = path.join(STATE_DIR, "pending-anchor");
+const POLL_MS = Number(process.env.ORYNQ_DRAIN_POLL_MS || 5000);
+const DRY_RUN = process.env.ORYNQ_DRAIN_DRY_RUN === "1";
+
+// Schema discriminator for orynq trace receipts. cert-daemon's
+// daemon/schemas/orynq_trace.py defines this same constant; the value MUST
+// stay byte-for-byte in lockstep. Computed as sha256("orynq_trace_v1") in
+// the Python module; we hardcode the pre-computed hex here to avoid a
+// runtime crypto import in this hot path. If you change this, also update:
+//   - operator-kit/daemon/schemas/orynq_trace.py::SCHEMA_HASH_ORYNQ_TRACE_V1
+//   - operator-kit TRUSTED_DISCRIMINATOR_SCHEMAS set
+// (and ship both side-by-side or cert-daemon will reject every receipt).
+const SCHEMA_HASH_ORYNQ_TRACE_V1 =
+  "0xcab0f81814eb84c9338938e702c8e8854c6cb17b371a9fd784a08e41c75d71b5";
+
+// Anchor backstop config
+const ANCHOR_WORKER_URL = process.env.ANCHOR_WORKER_URL || "http://127.0.0.1:3333";
+const ANCHOR_WORKER_TOKEN_FILE = process.env.ANCHOR_WORKER_TOKEN_FILE
+  || "/home/deci/materios-anchor-worker/.anchor-worker-token";
+const ANCHOR_BACKSTOP_MS = Number(process.env.ORYNQ_DRAIN_ANCHOR_BACKSTOP_MS || 600_000);
+const ANCHOR_BACKSTOP_DISABLED = process.env.ORYNQ_DRAIN_ANCHOR_DISABLED === "1";
+const ANCHOR_BACKSTOP_SWEEP_MS = 60_000;
+
+// Chain-aware backstop config
+const CERT_DAEMON_CONTAINER = process.env.ORYNQ_DRAIN_CERT_DAEMON_CONTAINER
+  || "materios-node-cert-daemon-preprod-1";
+const CERT_DAEMON_HISTORY_PATH = process.env.ORYNQ_DRAIN_CERT_DAEMON_HISTORY_PATH
+  || "/data/checkpoint-history.json";
+const CERT_DAEMON_METRICS_URL = process.env.ORYNQ_DRAIN_CERT_DAEMON_METRICS_URL
+  || "http://127.0.0.1:8081/metrics";
+const CERT_DAEMON_LEAD_BLOCKS = Number(process.env.ORYNQ_DRAIN_CERT_DAEMON_LEAD_BLOCKS || 30);
+
+// Reuse hook.mjs's env-loader pattern (deliberate small duplication, < 30 lines).
+function loadEnvFile(file) {
+  try {
+    for (const line of readFileSync(file, "utf-8").split(/\r?\n/)) {
+      const t = line.trim();
+      if (!t || t.startsWith("#")) continue;
+      const eq = t.indexOf("=");
+      if (eq < 0) continue;
+      const k = t.slice(0, eq).trim();
+      let v = t.slice(eq + 1).trim();
+      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+      if (!process.env[k]) process.env[k] = v;
+    }
+  } catch { /* file absent is fine */ }
+}
+loadEnvFile(ENV_FILE);
+
+function log(msg) {
+  console.log(`[orynq-drain] ${new Date().toISOString()} ${msg}`);
+}
+
+async function ensureDir(p) { await fs.mkdir(p, { recursive: true }); }
+async function ensureDirs() {
+  await ensureDir(QUEUE_DIR);
+  await ensureDir(DONE_DIR);
+  await ensureDir(FAILED_DIR);
+  await ensureDir(PENDING_ANCHOR_DIR);
+}
+
+// ---------- anchor backstop ----------
+
+let cachedAnchorToken = null;
+function getAnchorToken() {
+  if (cachedAnchorToken !== null) return cachedAnchorToken;
+  if (process.env.ANCHOR_WORKER_TOKEN) {
+    cachedAnchorToken = process.env.ANCHOR_WORKER_TOKEN.trim();
+    return cachedAnchorToken;
+  }
+  try {
+    cachedAnchorToken = readFileSync(ANCHOR_WORKER_TOKEN_FILE, "utf-8").trim();
+  } catch (e) {
+    log(`warn: could not read anchor token from ${ANCHOR_WORKER_TOKEN_FILE}: ${e?.message || e}`);
+    cachedAnchorToken = "";
+  }
+  return cachedAnchorToken;
+}
+
+/**
+ * Resolve a Materios block-hash to its block number via JSON-RPC.
+ * Returns the integer block number, or null if the lookup fails (we keep the
+ * sentinel writable in that case; the chain-aware sweep will treat blockNum
+ * absent as "skip the lead-blocks gate" and stay in conservative no-POST mode).
+ */
+async function resolveBlockNumber(blockHash) {
+  if (!blockHash || typeof blockHash !== "string") return null;
+  const rpcUrl = process.env.MATERIOS_RPC_URL;
+  if (!rpcUrl) return null;
+  // Materios RPC may be ws:// — translate to http:// for one-shot fetch.
+  const httpUrl = rpcUrl.replace(/^ws(s?):\/\//, "http$1://");
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 10_000);
+    const res = await fetch(httpUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "chain_getHeader",
+        params: [blockHash],
+      }),
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const j = await res.json().catch(() => null);
+    const numHex = j?.result?.number;
+    if (!numHex) return null;
+    return parseInt(String(numHex).replace(/^0x/, ""), 16) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a sentinel marking a receipt as awaiting anchor confirmation.
+ * Sweeper picks it up after ANCHOR_BACKSTOP_MS and runs a chain-aware check
+ * (cert-daemon's checkpoint-history + metrics) before deciding whether to POST.
+ *
+ * Sentinel filename mirrors the queue entry so we can correlate by eyeball.
+ * Body is small JSON with everything /anchor needs PLUS certHash + blockNum
+ * for the chain-aware check.
+ */
+async function writePendingAnchor(baseName, entry, anchored) {
+  if (ANCHOR_BACKSTOP_DISABLED) return;
+  // Resolve block number once at sentinel write time so the sweeper doesn't
+  // have to keep an RPC connection open. Acceptable for the hash to be null
+  // (older sentinels written before this change, or RPC unreachable).
+  const blockNum = await resolveBlockNumber(anchored?.blockHash);
+  const sentinel = {
+    schemaVersion: "pending-anchor/2.0",
+    contentHash: entry.contentHash ?? entry.rootHash,
+    rootHash: entry.rootHash,
+    manifestHash: entry.manifestHash ?? entry.rootHash,
+    certHash: anchored?.certHash || null,
+    blockHash: anchored?.blockHash || null,
+    blockNum,
+    receiptId: anchored?.receiptId || null,
+    queueEntry: baseName,
+    queuedAt: new Date().toISOString(),
+    dueAt: new Date(Date.now() + ANCHOR_BACKSTOP_MS).toISOString(),
+  };
+  const dest = path.join(PENDING_ANCHOR_DIR, baseName);
+  const tmp = `${dest}.${process.pid}.tmp`;
+  try {
+    await fs.writeFile(tmp, JSON.stringify(sentinel, null, 2), "utf-8");
+    await fs.rename(tmp, dest);
+  } catch (e) {
+    log(`warn: could not write pending-anchor sentinel for ${baseName}: ${e?.message || e}`);
+  }
+}
+
+// ---------- chain-aware backstop diagnostics ----------
+
+/**
+ * Normalize a Materios cert hash for comparison against checkpoint-history.
+ * SDK returns 0x-prefixed hex; cert-daemon writes naked hex; both are lowercase
+ * but we normalize defensively. Returns "" for falsy/non-string input.
+ */
+function normalizeCertHash(h) {
+  if (!h || typeof h !== "string") return "";
+  const t = h.trim().toLowerCase();
+  return t.startsWith("0x") ? t.slice(2) : t;
+}
+
+/**
+ * Read cert-daemon's checkpoint-history.json from inside the docker container.
+ * Returns the parsed array on success, null on any failure (caller treats null
+ * as "diagnostic broken — do not POST").
+ *
+ * Uses execFile (no shell) per the project's Cardano-tx-chaining lesson about
+ * never inlining content in shell-quoted strings.
+ */
+async function readCertDaemonHistory() {
+  try {
+    const { stdout } = await execFile(
+      "docker",
+      ["exec", CERT_DAEMON_CONTAINER, "cat", CERT_DAEMON_HISTORY_PATH],
+      { maxBuffer: 64 * 1024 * 1024, timeout: 15_000 },
+    );
+    const data = JSON.parse(stdout);
+    return Array.isArray(data) ? data : null;
+  } catch (e) {
+    log(`chain-check: docker exec / parse failed: ${e?.message || e}`);
+    return null;
+  }
+}
+
+/**
+ * Fetch cert-daemon's last_processed_block from its Prometheus-style metrics
+ * endpoint. Returns the integer block number on success, null on any failure.
+ */
+async function readCertDaemonHead() {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 5_000);
+    const res = await fetch(CERT_DAEMON_METRICS_URL, { signal: ctrl.signal });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const text = await res.text();
+    const m = text.match(/^materios_cert_daemon_last_processed_block\s+(\d+)/m);
+    if (!m) return null;
+    return parseInt(m[1], 10);
+  } catch (e) {
+    log(`chain-check: metrics fetch failed: ${e?.message || e}`);
+    return null;
+  }
+}
+
+/**
+ * Search the cert-daemon batch history for a leaf matching `certHash`.
+ * Returns the first matching {batchIndex, batchRoot, batchTimestamp,
+ * leafBlockNum} or null if not found.
+ */
+function findCertHashInHistory(history, certHash) {
+  const target = normalizeCertHash(certHash);
+  if (!target || !Array.isArray(history)) return null;
+  for (let i = 0; i < history.length; i++) {
+    const batch = history[i];
+    const leaves = Array.isArray(batch?.leaves) ? batch.leaves : [];
+    for (const leaf of leaves) {
+      if (normalizeCertHash(leaf?.cert_hash) === target) {
+        return {
+          batchIndex: i,
+          batchRoot: batch.root_hash || null,
+          batchTimestamp: batch.timestamp ?? null,
+          leafBlockNum: leaf.block_num ?? null,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Chain-aware check: should we POST /anchor for this sentinel?
+ *
+ * Returns one of:
+ *   { decision: "skip-anchored", anchored: { batchRoot, batchTimestamp,
+ *                                             leafBlockNum, txHash: null } }
+ *   { decision: "skip-too-early", certDaemonHead, leadShortBy }
+ *   { decision: "skip-diagnostic-broken", reason }
+ *   { decision: "post", certDaemonHead, leadBlocks, anchored: null }
+ *
+ * Notes:
+ *   - txHash is always null because cert-daemon does not persist the resulting
+ *     Cardano tx_hash to checkpoint-history.json (verified 2026-05-04 against
+ *     live container — only root_hash + manifest + leaves are stored). Callers
+ *     that need the tx_hash must look it up via the anchor-worker's status
+ *     endpoint or block-explorer; the chain-aware check only confirms anchor
+ *     completion (presence in history ⇒ /anchor returned 200 to cert-daemon).
+ *   - Sentinels missing certHash (legacy schemaVersion < 2.0) get
+ *     skip-diagnostic-broken so they fall through to the next sweep without
+ *     risking a dupe POST.
+ */
+async function chainAwareDecision(sentinel) {
+  if (!sentinel?.certHash) {
+    return { decision: "skip-diagnostic-broken", reason: "sentinel missing certHash (legacy v1?)" };
+  }
+
+  const history = await readCertDaemonHistory();
+  if (history === null) {
+    return { decision: "skip-diagnostic-broken", reason: "cert-daemon history unreadable" };
+  }
+  const hit = findCertHashInHistory(history, sentinel.certHash);
+  if (hit) {
+    return {
+      decision: "skip-anchored",
+      anchored: {
+        batchRoot: hit.batchRoot,
+        batchTimestamp: hit.batchTimestamp,
+        leafBlockNum: hit.leafBlockNum,
+        txHash: null,
+      },
+    };
+  }
+
+  const head = await readCertDaemonHead();
+  if (head === null) {
+    return { decision: "skip-diagnostic-broken", reason: "cert-daemon metrics unreachable" };
+  }
+
+  // If we don't know the receipt's block number, we can't apply the lead-blocks
+  // gate safely. Stay conservative — don't POST.
+  if (!Number.isFinite(sentinel.blockNum) || sentinel.blockNum == null) {
+    return { decision: "skip-diagnostic-broken", reason: "sentinel missing blockNum" };
+  }
+
+  const required = sentinel.blockNum + CERT_DAEMON_LEAD_BLOCKS;
+  if (head < required) {
+    return {
+      decision: "skip-too-early",
+      certDaemonHead: head,
+      leadShortBy: required - head,
+    };
+  }
+
+  return {
+    decision: "post",
+    certDaemonHead: head,
+    leadBlocks: head - sentinel.blockNum,
+    anchored: null,
+  };
+}
+
+/**
+ * POST /anchor as backstop. Anchor-worker rejects payloads containing BIP39
+ * mnemonic-shaped strings; our payload only carries hex hashes so we're safe.
+ * Returns true on 200, false otherwise (caller decides whether to retry).
+ */
+async function postAnchorBackstop(sentinel) {
+  const token = getAnchorToken();
+  if (!token) {
+    log("backstop POST aborted: anchor-worker token unreadable");
+    return false;
+  }
+  const url = `${ANCHOR_WORKER_URL.replace(/\/+$/, "")}/anchor`;
+  const body = JSON.stringify({
+    contentHash: sentinel.contentHash,
+    rootHash: sentinel.rootHash,
+    manifestHash: sentinel.manifestHash,
+  });
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 90_000);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-internal-token": token,
+      },
+      body,
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    if (res.status === 200) {
+      const data = await res.json().catch(() => ({}));
+      log(`backstop OK ${sentinel.queueEntry} root=${sentinel.rootHash.slice(0, 10)}... txHash=${data?.txHash || data?.cardanoTxHash || "?"}`);
+      return true;
+    }
+    const text = await res.text().catch(() => "");
+    log(`backstop FAIL ${sentinel.queueEntry} status=${res.status} body=${text.slice(0, 200)}`);
+    return false;
+  } catch (e) {
+    log(`backstop ERROR ${sentinel.queueEntry}: ${e?.message || e}`);
+    return false;
+  }
+}
+
+let sweeping = false;
+
+/**
+ * Sweep pending-anchor/ for sentinels past their dueAt. For each, run a
+ * chain-aware decision against cert-daemon's checkpoint-history + metrics:
+ *
+ *   - Already anchored by cert-daemon  → delete sentinel, no POST.
+ *   - Past due but cert-daemon hasn't reached our block + lead-blocks → wait.
+ *   - Diagnostic broken (docker exec / metrics fail / missing fields) → wait.
+ *   - Past due AND cert-daemon should have anchored but didn't → POST /anchor.
+ *
+ * Single-pass per sweep tick. No exponential backoff: in healthy operation the
+ * backstop never fires; if it does fire repeatedly the operator needs a real
+ * diagnosis, not auto-recovery.
+ */
+async function sweepPendingAnchors() {
+  if (sweeping || ANCHOR_BACKSTOP_DISABLED) return;
+  sweeping = true;
+  try {
+    let entries;
+    try { entries = await fs.readdir(PENDING_ANCHOR_DIR); }
+    catch { return; }
+    const now = Date.now();
+    for (const name of entries) {
+      if (!name.endsWith(".json")) continue;
+      const sentinelPath = path.join(PENDING_ANCHOR_DIR, name);
+      let sentinel;
+      try {
+        sentinel = JSON.parse(await fs.readFile(sentinelPath, "utf-8"));
+      } catch (e) {
+        log(`sweep: unreadable sentinel ${name}: ${e?.message || e} — moving aside`);
+        try { await fs.rename(sentinelPath, sentinelPath + ".broken"); } catch { /* ignore */ }
+        continue;
+      }
+      const dueAt = Date.parse(sentinel.dueAt || "");
+      if (!Number.isFinite(dueAt) || dueAt > now) continue;
+
+      const certShort = (sentinel.certHash || "").slice(0, 12);
+      const decision = await chainAwareDecision(sentinel);
+      switch (decision.decision) {
+        case "skip-anchored": {
+          const a = decision.anchored || {};
+          log(
+            `chain-check ${name} cert=${certShort}... already anchored by cert-daemon `
+            + `(batchRoot=${(a.batchRoot || "").slice(0, 10)}..., leafBlock=${a.leafBlockNum}) — deleting sentinel`,
+          );
+          try { await fs.unlink(sentinelPath); }
+          catch (e) { log(`sweep: could not unlink ${name}: ${e?.message || e}`); }
+          break;
+        }
+        case "skip-too-early": {
+          log(
+            `chain-check ${name} cert=${certShort}... cert-daemon head=${decision.certDaemonHead} `
+            + `< sentinel.blockNum+${CERT_DAEMON_LEAD_BLOCKS} (short by ${decision.leadShortBy}) — wait`,
+          );
+          break;
+        }
+        case "skip-diagnostic-broken": {
+          log(`chain-check ${name} cert=${certShort}... DIAGNOSTIC BROKEN: ${decision.reason} — not posting (will retry)`);
+          break;
+        }
+        case "post": {
+          log(
+            `backstop firing for ${name} (queued ${sentinel.queuedAt}, root=${(sentinel.rootHash || "").slice(0, 10)}..., `
+            + `cert=${certShort}..., cert-daemon head=${decision.certDaemonHead} leadBlocks=${decision.leadBlocks})`,
+          );
+          const ok = await postAnchorBackstop(sentinel);
+          if (ok) {
+            try { await fs.unlink(sentinelPath); }
+            catch (e) { log(`sweep: could not unlink ${name}: ${e?.message || e}`); }
+          }
+          break;
+        }
+        default:
+          log(`chain-check ${name}: unknown decision ${decision.decision} — staying conservative (no POST)`);
+      }
+    }
+  } catch (e) {
+    log(`sweep: unexpected error: ${e?.stack || e}`);
+  } finally {
+    sweeping = false;
+  }
+}
+
+let cachedSdk = null;
+async function importOrynq() {
+  if (cachedSdk) return cachedSdk;
+  const am = await import(pathToFileURL(path.join(ORYNQ_SDK, "packages/anchors-materios/dist/index.js")).href);
+  cachedSdk = { am };
+  return cachedSdk;
+}
+
+let cachedProvider = null;
+async function getProvider() {
+  if (cachedProvider) return cachedProvider;
+  const { am } = await importOrynq();
+  const rpcUrl = process.env.MATERIOS_RPC_URL;
+  const signerUri = process.env.MATERIOS_SIGNER_URI;
+  if (!rpcUrl || !signerUri) {
+    throw new Error("MATERIOS_RPC_URL or MATERIOS_SIGNER_URI not set");
+  }
+  const provider = new am.MateriosProvider({ rpcUrl, signerUri });
+  await provider.connect();
+  cachedProvider = provider;
+  return provider;
+}
+
+async function disconnectProvider() {
+  if (!cachedProvider) return;
+  try { await cachedProvider.disconnect(); } catch { /* ignore */ }
+  cachedProvider = null;
+}
+
+/** Atomic move (rename) with conflict-resolving suffix. */
+async function moveFile(src, destDir, baseName) {
+  let dest = path.join(destDir, baseName);
+  try {
+    await fs.rename(src, dest);
+    return dest;
+  } catch (e) {
+    if (e.code === "EEXIST") {
+      dest = path.join(destDir, `${baseName}.${Date.now()}`);
+      await fs.rename(src, dest);
+      return dest;
+    }
+    throw e;
+  }
+}
+
+/**
+ * Submit one queue entry to Materios.
+ * Returns { ok: true, anchored } or { ok: false, error }.
+ */
+async function submitQueueEntry(filePath) {
+  let entry;
+  try {
+    const text = await fs.readFile(filePath, "utf-8");
+    entry = JSON.parse(text);
+  } catch (e) {
+    return { ok: false, error: `unreadable: ${e?.message || e}` };
+  }
+
+  if (!entry.rootHash || !entry.publicView) {
+    return { ok: false, error: "malformed queue entry: missing rootHash or publicView" };
+  }
+
+  if (DRY_RUN) {
+    log(`DRY-RUN would submit ${path.basename(filePath)} rootHash=${entry.rootHash} task=${entry.publicView.taskId}`);
+    return { ok: true, anchored: { dryRun: true } };
+  }
+
+  const { am } = await importOrynq();
+  const provider = await getProvider();
+
+  // Canonical content: exactly the bytes hook.mjs hashed into
+  // entry.contentHash. cert-daemon's schema-aware verifier requires
+  // sha256(uploaded bytes) == on-chain content_hash, so we MUST upload
+  // the same bytes the hook hashed — not a derived envelope. For
+  // queue/2.0 entries the hook ships `entry.content` directly. Older
+  // queue/1.0 entries pre-date this convention; their on-chain
+  // content_hash was computed over a different shape and the chunk-merkle
+  // check can never satisfy. Skip them out to the failure path.
+  if (!entry.content) {
+    return {
+      ok: false,
+      error: "queue entry missing `content` (pre-2026-05-11 queue/1.0 shape); cert-daemon chunk-merkle pin cannot be satisfied — dropping",
+    };
+  }
+  const content = Buffer.from(entry.content, "utf-8");
+
+  const gatewayUrl = process.env.MATERIOS_BLOB_GATEWAY_URL || "https://materios.fluxpointstudios.com/preprod-blobs";
+  const gatewayApiKey = process.env.MATERIOS_BLOB_GATEWAY_API_KEY;
+
+  const keypair = provider.getKeypair();
+  const blobGateway = { baseUrl: gatewayUrl };
+  if (gatewayApiKey) blobGateway.apiKey = gatewayApiKey;
+  else blobGateway.signerKeypair = {
+    address: keypair.address,
+    sign: (msg) => keypair.sign(msg),
+  };
+
+  const result = await am.submitCertifiedReceipt(
+    provider,
+    {
+      contentHash: entry.contentHash ?? entry.rootHash,
+      rootHash: entry.rootHash,
+      manifestHash: entry.manifestHash ?? entry.rootHash,
+      // Tag this receipt class for cert-daemon's schema-aware verifier
+      // (operator-kit daemon/schemas/orynq_trace.py). Without this tag,
+      // cert-daemon recomputes chunk-Merkle of the JSON-encoded publicView
+      // and rejects because the gateway's chunk-Merkle != rootHash (the
+      // semantic trace Merkle). Tagging routes us to the trust-the-
+      // discriminator path where chunk integrity pins the JSON bytes and
+      // base_root_sha256 is accepted as the trace's semantic Merkle root.
+      // Value = sha256("orynq_trace_v1"); MUST stay byte-for-byte in
+      // lockstep with daemon/schemas/orynq_trace.SCHEMA_HASH_ORYNQ_TRACE_V1.
+      schemaHash: SCHEMA_HASH_ORYNQ_TRACE_V1,
+    },
+    content,
+    {
+      blobGateway,
+      certificationPollOpts: { timeoutMs: 90_000 },
+    }
+  );
+  return {
+    ok: true,
+    anchored: {
+      receiptId: result.receiptId,
+      certHash: result.certHash || null,
+      blockHash: result.blockHash || null,
+      confirmed: result.confirmed !== false,
+    },
+  };
+}
+
+/** List queue/ entries (chronologically by filename). */
+async function listQueue() {
+  let entries;
+  try { entries = await fs.readdir(QUEUE_DIR); }
+  catch { return []; }
+  return entries
+    .filter((n) => n.endsWith(".json"))
+    .sort()
+    .map((n) => path.join(QUEUE_DIR, n));
+}
+
+let consecutiveFailures = 0;
+let processing = false;
+
+/** Drain the queue once, sequentially. */
+async function drainOnce() {
+  if (processing) return;
+  processing = true;
+  try {
+    while (true) {
+      const list = await listQueue();
+      if (list.length === 0) break;
+      const file = list[0];
+      const baseName = path.basename(file);
+      log(`processing ${baseName} (queue depth ${list.length})`);
+
+      let result;
+      try {
+        result = await submitQueueEntry(file);
+      } catch (e) {
+        result = { ok: false, error: e?.stack || String(e) };
+      }
+
+      if (result.ok) {
+        consecutiveFailures = 0;
+        // Snapshot the entry once for both annotation + backstop sentinel.
+        let parsedEntry = null;
+        try {
+          const text = await fs.readFile(file, "utf-8");
+          parsedEntry = JSON.parse(text);
+        } catch (e) {
+          log(`warn: could not read ${baseName} for annotation: ${e?.message || e}`);
+        }
+        // Annotate with receipt info before moving.
+        if (parsedEntry) {
+          try {
+            parsedEntry.anchored = result.anchored;
+            parsedEntry.anchoredAt = new Date().toISOString();
+            await fs.writeFile(file, JSON.stringify(parsedEntry, null, 2), "utf-8");
+          } catch (e) {
+            log(`warn: could not annotate ${baseName}: ${e?.message || e}`);
+          }
+        }
+        const moved = await moveFile(file, DONE_DIR, baseName);
+        log(`done ${baseName} -> ${moved}  receipt=${result.anchored?.receiptId || "(dry-run)"}`);
+        // Drop a backstop sentinel — the cert-daemon will normally anchor
+        // within 2-3 min, but if it's wedged the sweeper POSTs /anchor at
+        // dueAt. Skipped for dry-run to keep the queue clean.
+        if (parsedEntry && !DRY_RUN) {
+          await writePendingAnchor(baseName, parsedEntry, result.anchored);
+        }
+      } else {
+        consecutiveFailures += 1;
+        log(`FAIL ${baseName}: ${result.error}`);
+        const errPath = path.join(FAILED_DIR, `${baseName}.error.txt`);
+        try { await fs.writeFile(errPath, String(result.error), "utf-8"); } catch { /* best-effort */ }
+        try { await moveFile(file, FAILED_DIR, baseName); } catch (e) {
+          log(`warn: could not move failed entry: ${e?.message || e}`);
+        }
+
+        if (consecutiveFailures >= 3) {
+          log(`backing off 60s (consecutive failures = ${consecutiveFailures})`);
+          // Drop the WS provider — it may be wedged.
+          await disconnectProvider();
+          await sleep(60_000);
+          consecutiveFailures = 0;
+        }
+      }
+    }
+  } finally {
+    processing = false;
+  }
+}
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+let drainScheduled = false;
+function scheduleDrain() {
+  if (drainScheduled) return;
+  drainScheduled = true;
+  setImmediate(async () => {
+    drainScheduled = false;
+    try { await drainOnce(); }
+    catch (e) { log(`drain loop error: ${e?.stack || e}`); }
+  });
+}
+
+async function main() {
+  await ensureDirs();
+  log(`starting; queue=${QUEUE_DIR} sdk=${ORYNQ_SDK} dryRun=${DRY_RUN}`);
+
+  // Initial drain.
+  scheduleDrain();
+
+  // fs.watch: trigger a drain whenever a new file appears.
+  let watcher;
+  try {
+    watcher = fsWatch(QUEUE_DIR, { persistent: true }, (eventType, filename) => {
+      if (filename && filename.endsWith(".json")) scheduleDrain();
+    });
+  } catch (e) {
+    log(`warn: fs.watch failed (${e?.message || e}); relying on poll fallback`);
+  }
+
+  // Poll fallback: covers filesystems that miss inotify events (NFS, etc).
+  setInterval(() => scheduleDrain(), POLL_MS).unref();
+
+  // Anchor backstop sweeper. Independent of drain so a wedged provider
+  // never starves the L1 backstop path.
+  if (!ANCHOR_BACKSTOP_DISABLED) {
+    log(
+      `chain-aware-backstop-armed delay=${ANCHOR_BACKSTOP_MS}ms sweep=${ANCHOR_BACKSTOP_SWEEP_MS}ms `
+      + `target=${ANCHOR_WORKER_URL}/anchor cert-daemon=${CERT_DAEMON_CONTAINER} `
+      + `metrics=${CERT_DAEMON_METRICS_URL} leadBlocks=${CERT_DAEMON_LEAD_BLOCKS}`,
+    );
+    // Initial sweep covers any sentinels left over from a prior process.
+    setImmediate(() => { sweepPendingAnchors().catch((e) => log(`sweep init: ${e?.stack || e}`)); });
+    setInterval(() => {
+      sweepPendingAnchors().catch((e) => log(`sweep tick: ${e?.stack || e}`));
+    }, ANCHOR_BACKSTOP_SWEEP_MS).unref();
+  } else {
+    log("anchor backstop DISABLED via ORYNQ_DRAIN_ANCHOR_DISABLED=1");
+  }
+
+  // Graceful shutdown.
+  const shutdown = async (sig) => {
+    log(`received ${sig}, shutting down`);
+    if (watcher) { try { watcher.close(); } catch { /* ignore */ } }
+    await disconnectProvider();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+}
+
+// Named exports for the test harness. Runtime code never imports drain.mjs;
+// the daemon entry path is the bottom guard below. Exporting these doesn't
+// change runtime behavior.
+export {
+  chainAwareDecision,
+  findCertHashInHistory,
+  normalizeCertHash,
+  readCertDaemonHistory,
+  readCertDaemonHead,
+  resolveBlockNumber,
+};
+
+// Run as daemon only when invoked as the main module (node drain.mjs ...).
+// Importing this file from a test harness must NOT spawn the daemon.
+const isMainModule = import.meta.url === pathToFileURL(process.argv[1] || "").href;
+if (isMainModule) {
+  main().catch((e) => {
+    console.error(`[orynq-drain] fatal: ${e?.stack || e}`);
+    process.exit(1); // systemd will Restart=always
+  });
+}

--- a/examples/claude-code-hook/drain.mjs
+++ b/examples/claude-code-hook/drain.mjs
@@ -55,7 +55,7 @@
  *   leafBlockNum} but txHash is null.
  *
  *   ANCHOR_WORKER_URL=http://127.0.0.1:3333 (default)
- *   ANCHOR_WORKER_TOKEN_FILE=/home/deci/materios-anchor-worker/.anchor-worker-token (default)
+ *   ANCHOR_WORKER_TOKEN_FILE=$HOME/materios-anchor-worker/.anchor-worker-token (default)
  *   ANCHOR_WORKER_TOKEN=<token>                       — overrides the token file
  *   ORYNQ_DRAIN_ANCHOR_BACKSTOP_MS=600000             — backstop delay (10 min)
  *   ORYNQ_DRAIN_ANCHOR_DISABLED=1                     — disable backstop entirely

--- a/examples/claude-code-hook/flush-session.mjs
+++ b/examples/claude-code-hook/flush-session.mjs
@@ -15,8 +15,9 @@
  * Env:
  *   ORYNQ_FLUSH_DRY_RUN=1 — count events but write nothing
  *
- * Default sessionId is the active session (93582ed9-742f-45d3-9e79-74b6bf1ef9fa)
- * to make the recovery path one command for the user.
+ * Usage: pass the Claude Code sessionId as the first positional argument.
+ *   node flush-session.mjs 93582ed9-742f-45d3-9e79-74b6bf1ef9fa
+ *   node flush-session.mjs <session-id> --dry-run
  */
 
 import fs from "node:fs/promises";
@@ -24,16 +25,20 @@ import path from "node:path";
 import crypto from "node:crypto";
 import os from "node:os";
 
-const HOME = process.env.HOME || process.env.USERPROFILE || "/home/deci";
+const HOME = process.env.HOME || process.env.USERPROFILE || "";
 const STATE_DIR = path.join(HOME, ".local/state/materios-orynq-hook");
 const QUEUE_DIR = path.join(STATE_DIR, "queue");
-const DEFAULT_SESSION = "93582ed9-742f-45d3-9e79-74b6bf1ef9fa";
 
 const args = process.argv.slice(2);
 const FORCE = args.includes("--force");
 const DRY_RUN = args.includes("--dry-run") || process.env.ORYNQ_FLUSH_DRY_RUN === "1";
 const positional = args.filter((a) => !a.startsWith("--"));
-const SESSION_ID = positional[0] || DEFAULT_SESSION;
+const SESSION_ID = positional[0];
+if (!SESSION_ID) {
+  console.error("usage: flush-session.mjs <sessionId> [--force] [--dry-run]");
+  console.error("       Pass the Claude Code session UUID as the first positional arg.");
+  process.exit(2);
+}
 
 function sha256Hex(s) {
   return crypto.createHash("sha256").update(s, "utf-8").digest("hex");

--- a/examples/claude-code-hook/flush-session.mjs
+++ b/examples/claude-code-hook/flush-session.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * One-shot flush of legacy session-state JSON to the per-task queue.
+ *
+ * Reads ~/.local/state/materios-orynq-hook/<sessionId>.json (written by the
+ * pre-drain hook), iterates run.events, and writes one queue entry per
+ * task_completed event using the same format hook.mjs now emits.
+ *
+ * Idempotent: writes a sibling .flushed marker. Re-running for the same
+ * session refuses unless --force is passed.
+ *
+ * Usage:
+ *   node flush-session.mjs [<sessionId>] [--force] [--dry-run]
+ *
+ * Env:
+ *   ORYNQ_FLUSH_DRY_RUN=1 — count events but write nothing
+ *
+ * Default sessionId is the active session (93582ed9-742f-45d3-9e79-74b6bf1ef9fa)
+ * to make the recovery path one command for the user.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import crypto from "node:crypto";
+import os from "node:os";
+
+const HOME = process.env.HOME || process.env.USERPROFILE || "/home/deci";
+const STATE_DIR = path.join(HOME, ".local/state/materios-orynq-hook");
+const QUEUE_DIR = path.join(STATE_DIR, "queue");
+const DEFAULT_SESSION = "93582ed9-742f-45d3-9e79-74b6bf1ef9fa";
+
+const args = process.argv.slice(2);
+const FORCE = args.includes("--force");
+const DRY_RUN = args.includes("--dry-run") || process.env.ORYNQ_FLUSH_DRY_RUN === "1";
+const positional = args.filter((a) => !a.startsWith("--"));
+const SESSION_ID = positional[0] || DEFAULT_SESSION;
+
+function sha256Hex(s) {
+  return crypto.createHash("sha256").update(s, "utf-8").digest("hex");
+}
+async function ensureDir(p) { await fs.mkdir(p, { recursive: true }); }
+
+function truncate(s, max = 2048) {
+  if (!s) return s;
+  const str = String(s);
+  return str.length <= max ? str : str.slice(0, max) + `... [+${str.length - max} chars]`;
+}
+
+/** Build the canonical queue entry from a legacy task_completed event. */
+function buildEntryFromLegacy(ev, sessionId) {
+  const data = ev.data || {};
+  const taskId = String(data.taskId ?? "unknown");
+  const subject = data.subject || `Task ${taskId}`;
+  const summary = data.summary || "";
+  const timestamp = ev.timestamp || new Date().toISOString();
+
+  // Same pre-image formula as hook.mjs::buildQueueEntry — keeps rootHash stable.
+  const preImage = JSON.stringify({ sessionId, taskId, timestamp, subject, summary });
+  const rootHash = sha256Hex(preImage);
+
+  const publicView = {
+    taskId,
+    subject: truncate(subject, 200),
+    sessionId,
+    timestamp,
+    summary,
+    cwd: null,
+    hostname: os.hostname(),
+    flushedFromLegacy: true,
+  };
+
+  return {
+    schemaVersion: "queue/1.0",
+    contentHash: rootHash,
+    rootHash,
+    manifestHash: rootHash,
+    publicView,
+    raw: {
+      hook_event_name: "PostToolUse",
+      tool_name: "TaskUpdate",
+      tool_input: { taskId, status: "completed", subject },
+      tool_response: { subject, summary },
+      legacyEventId: ev.id || null,
+      legacySeq: ev.seq ?? null,
+    },
+  };
+}
+
+async function writeQueueEntry(entry) {
+  await ensureDir(QUEUE_DIR);
+  const stamp = entry.publicView.timestamp.replace(/[:.]/g, "-");
+  const tid = entry.publicView.taskId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const base = `${stamp}-task-${tid}`;
+  const finalPath = path.join(QUEUE_DIR, `${base}.json`);
+  const tmpPath = path.join(QUEUE_DIR, `${base}.${process.pid}.tmp`);
+  await fs.writeFile(tmpPath, JSON.stringify(entry, null, 2), "utf-8");
+  await fs.rename(tmpPath, finalPath);
+  return finalPath;
+}
+
+async function main() {
+  const statePath = path.join(STATE_DIR, `${SESSION_ID}.json`);
+  const flushedMarker = path.join(STATE_DIR, `${SESSION_ID}.flushed`);
+
+  if (!FORCE && !DRY_RUN) {
+    try {
+      await fs.access(flushedMarker);
+      console.error(`refusing to re-flush: ${flushedMarker} exists. Pass --force to override.`);
+      process.exit(2);
+    } catch { /* not flushed yet */ }
+  }
+
+  let raw;
+  try { raw = await fs.readFile(statePath, "utf-8"); }
+  catch (e) {
+    console.error(`cannot read ${statePath}: ${e?.message || e}`);
+    process.exit(1);
+  }
+
+  let state;
+  try { state = JSON.parse(raw); }
+  catch (e) {
+    console.error(`cannot parse ${statePath}: ${e?.message || e}`);
+    process.exit(1);
+  }
+
+  const events = state?.run?.events || [];
+  let flushed = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const ev of events) {
+    if (ev.kind !== "observation" || ev.observation !== "task_completed") {
+      skipped += 1;
+      continue;
+    }
+    try {
+      const entry = buildEntryFromLegacy(ev, SESSION_ID);
+      if (DRY_RUN) {
+        console.log(`[dry-run] would write task=${entry.publicView.taskId} ts=${entry.publicView.timestamp} rootHash=${entry.rootHash}`);
+      } else {
+        const wp = await writeQueueEntry(entry);
+        console.log(`flushed task=${entry.publicView.taskId} -> ${path.basename(wp)}`);
+      }
+      flushed += 1;
+    } catch (e) {
+      errors += 1;
+      console.error(`error flushing event seq=${ev.seq}: ${e?.message || e}`);
+    }
+  }
+
+  // Count the queue dir afterward.
+  let queueCount = 0;
+  try {
+    const entries = await fs.readdir(QUEUE_DIR);
+    queueCount = entries.filter((n) => n.endsWith(".json")).length;
+  } catch { /* dir not yet present */ }
+
+  console.log("");
+  console.log(`session:        ${SESSION_ID}`);
+  console.log(`state file:     ${statePath}`);
+  console.log(`flushed:        ${flushed}`);
+  console.log(`skipped:        ${skipped}`);
+  console.log(`errors:         ${errors}`);
+  console.log(`queue depth:    ${queueCount}`);
+  console.log(`dry-run:        ${DRY_RUN}`);
+
+  if (!DRY_RUN && errors === 0 && flushed > 0) {
+    await fs.writeFile(flushedMarker, JSON.stringify({
+      flushedAt: new Date().toISOString(),
+      sessionId: SESSION_ID,
+      eventCount: flushed,
+    }, null, 2), "utf-8");
+    console.log(`wrote marker:   ${flushedMarker}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(`flush-session failed: ${e?.stack || e}`);
+  process.exit(1);
+});

--- a/examples/claude-code-hook/hook.mjs
+++ b/examples/claude-code-hook/hook.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * Materios orynq auto-trace hook for Claude Code.
+ *
+ * Persistent per-task anchoring: every PostToolUse(TaskUpdate, status=completed)
+ * event atomically writes ONE bundle to the queue/ directory. A separate drain
+ * daemon (drain.mjs) submits the queue to Materios as certified receipts.
+ *
+ * This survives session crashes, multi-day Claude Code sessions, and reboots —
+ * the hook returns in <10ms (file-write only, no network IO, no SDK imports).
+ *
+ * Config:
+ *   ORYNQ_NO_AUTO_TRACE=1               disable entirely
+ *   ORYNQ_HOOK_ENV=/path/to/envfile     override env file path (default: ~/.materios-orynq-hook.env)
+ *   ORYNQ_SDK_PATH=/path/to/orynq-sdk   (read by drain.mjs, ignored here)
+ *
+ *   MATERIOS_RPC_URL, MATERIOS_SIGNER_URI, MATERIOS_BLOB_GATEWAY_URL
+ *     — only consumed by drain.mjs. The hook just queues.
+ */
+
+import fs from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import os from "node:os";
+
+if (process.env.ORYNQ_NO_AUTO_TRACE === "1") process.exit(0);
+
+const HOME = process.env.HOME || process.env.USERPROFILE || "/home/deci";
+const ENV_FILE = process.env.ORYNQ_HOOK_ENV || path.join(HOME, ".materios-orynq-hook.env");
+const STATE_DIR = path.join(HOME, ".local/state/materios-orynq-hook");
+const QUEUE_DIR = path.join(STATE_DIR, "queue");
+
+function loadEnvFile(file) {
+  try {
+    for (const line of readFileSync(file, "utf-8").split(/\r?\n/)) {
+      const t = line.trim();
+      if (!t || t.startsWith("#")) continue;
+      const eq = t.indexOf("=");
+      if (eq < 0) continue;
+      const k = t.slice(0, eq).trim();
+      let v = t.slice(eq + 1).trim();
+      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+      if (!process.env[k]) process.env[k] = v;
+    }
+  } catch { /* file absent is fine */ }
+}
+loadEnvFile(ENV_FILE);
+
+// ---------- redaction ----------
+const REDACT_PATTERNS = [
+  { re: /\bxpub[A-HJ-NP-Za-km-z1-9]{79,}\b/g, rep: "[REDACTED-XPUB]" },
+  { re: /\b(mnemonic|seed[ _]phrase|private[ _]key|api[ _]key|signer[ _]uri)\s*[:=]\s*\S+/gi, rep: "[REDACTED-SECRET]" },
+  { re: /\b[a-f0-9]{64}\b/gi, rep: "[REDACTED-32B-HEX]" },
+];
+function looksLikeBip39(s) {
+  const m = s.match(/\b([a-z]+\s+){11,}[a-z]+\b/g);
+  if (!m) return null;
+  return m.find((chunk) => {
+    const words = chunk.trim().split(/\s+/);
+    return words.length >= 12 && words.every((w) => w.length >= 3 && w.length <= 8);
+  });
+}
+function redact(s) {
+  if (!s || typeof s !== "string") return s;
+  let out = s;
+  for (const { re, rep } of REDACT_PATTERNS) out = out.replace(re, rep);
+  const mn = looksLikeBip39(out);
+  if (mn) out = out.replace(mn, "[REDACTED-MNEMONIC-SHAPED]");
+  return out;
+}
+function truncate(s, max = 2048) {
+  if (!s) return s;
+  const str = String(s);
+  return str.length <= max ? str : str.slice(0, max) + `... [+${str.length - max} chars]`;
+}
+
+// ---------- I/O helpers ----------
+async function readStdinJson() {
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  const s = Buffer.concat(chunks).toString("utf-8").trim();
+  return s ? JSON.parse(s) : {};
+}
+async function ensureDir(p) { await fs.mkdir(p, { recursive: true }); }
+
+function isTaskUpdateCompleted(input) {
+  if (input.tool_name !== "TaskUpdate") return false;
+  const ti = input.tool_input || {};
+  return ti.status === "completed";
+}
+
+// ---------- queue write (the load-bearing path) ----------
+function sha256Hex(s) {
+  return crypto.createHash("sha256").update(s, "utf-8").digest("hex");
+}
+
+/**
+ * Build a deterministic queue entry from a TaskUpdate completed event.
+ *
+ * Determinism: rootHash is sha256 of {sessionId, taskId, timestamp, subject, summary}.
+ * Re-running the same closure produces the same hash → idempotent at chain level.
+ */
+export function buildQueueEntry(input, nowIso) {
+  const ti = input.tool_input || {};
+  const resp = input.tool_response || {};
+  const sessionId = input.session_id || "unknown-session";
+  const taskId = String(ti.taskId ?? ti.task_id ?? "unknown");
+  const subject = resp.subject || ti.subject || `Task ${taskId}`;
+  const activeForm = resp.activeForm || ti.activeForm || "";
+  const timestamp = nowIso || new Date().toISOString();
+
+  const summary = redact(truncate(JSON.stringify({
+    taskId,
+    subject,
+    activeForm,
+    description: resp.description || ti.description || null,
+    owner: resp.owner || ti.owner || null,
+    blocks: resp.blocks || null,
+    blockedBy: resp.blockedBy || null,
+  }), 1800));
+
+  const publicView = {
+    taskId,
+    subject: redact(truncate(subject, 200)),
+    sessionId,
+    timestamp,
+    summary,
+    cwd: input.cwd || null,
+    hostname: os.hostname(),
+  };
+
+  // Canonical content: the exact bytes the drain daemon uploads to the
+  // blob gateway. cert-daemon's schema-aware verifier (operator-kit
+  // daemon/schemas/orynq_trace.py) requires sha256(uploaded bytes) ==
+  // on-chain content_hash so the JSON bytes are byte-pinned by the
+  // receipt. The hook must therefore hash exactly what drain uploads —
+  // not a different envelope shape. Drain reads `entry.content` and
+  // uploads it verbatim; doing the construction here keeps both sides
+  // in lockstep without duplicating field-selection logic.
+  //
+  // Five fields chosen to give the trace a stable closure-defining
+  // identity (same task closed twice → same hash → idempotent on chain).
+  // Fields use publicView's redacted forms so the upload + on-chain
+  // commitment never expose redacted content.
+  const content = JSON.stringify({
+    sessionId: publicView.sessionId,
+    taskId: publicView.taskId,
+    timestamp: publicView.timestamp,
+    subject: publicView.subject,
+    summary: publicView.summary,
+  });
+  const contentHash = sha256Hex(content);
+
+  return {
+    schemaVersion: "queue/2.0",
+    content,
+    contentHash,
+    rootHash: contentHash,
+    manifestHash: contentHash,
+    publicView,
+    raw: {
+      hook_event_name: input.hook_event_name,
+      tool_name: input.tool_name,
+      tool_input: ti,
+      tool_response: resp,
+    },
+  };
+}
+
+/**
+ * Atomically write a queue entry under STATE_DIR/queue/.
+ * Filename: <ISO-timestamp>-task-<taskId>.json (sortable chronologically).
+ * Uses .tmp + rename for atomicity (drain daemon may be polling concurrently).
+ */
+export async function writeQueueEntry(entry) {
+  await ensureDir(QUEUE_DIR);
+  const stamp = entry.publicView.timestamp.replace(/[:.]/g, "-");
+  const tid = entry.publicView.taskId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const base = `${stamp}-task-${tid}`;
+  const finalPath = path.join(QUEUE_DIR, `${base}.json`);
+  const tmpPath = path.join(QUEUE_DIR, `${base}.${process.pid}.tmp`);
+  await fs.writeFile(tmpPath, JSON.stringify(entry, null, 2), "utf-8");
+  await fs.rename(tmpPath, finalPath);
+  return finalPath;
+}
+
+// ---------- main ----------
+async function main() {
+  const input = await readStdinJson();
+  const event = input.hook_event_name;
+  if (!event) return;
+
+  if (event === "PostToolUse" && isTaskUpdateCompleted(input)) {
+    const entry = buildQueueEntry(input);
+    const written = await writeQueueEntry(entry);
+    // Single-line log; harmless if Claude Code captures stderr.
+    console.error(`[orynq-hook] queued ${path.basename(written)}`);
+    return;
+  }
+
+  if (event === "SessionEnd") {
+    // Per-task drain replaces SessionEnd batching. No-op kept for backward-compat:
+    // legacy session state files (~/.local/state/materios-orynq-hook/<sid>.json)
+    // are intentionally left in place — flush-session.mjs handles them.
+    console.error(`[orynq-hook] SessionEnd is now a no-op (per-task drain in effect)`);
+    return;
+  }
+
+  // Other events: silently ignore.
+}
+
+main().catch((e) => {
+  console.error(`[orynq-hook] fatal: ${e?.stack || e}`);
+  process.exit(0); // never break the user's workflow
+});

--- a/examples/claude-code-hook/materios-orynq-drain.service
+++ b/examples/claude-code-hook/materios-orynq-drain.service
@@ -1,0 +1,38 @@
+# Materios orynq drain daemon — systemd unit template.
+#
+# Copy to /etc/systemd/system/materios-orynq-drain.service after substituting
+# the four placeholders below for your install:
+#
+#   __USER__         e.g. deci
+#   __GROUP__        e.g. deci  (usually same as user)
+#   __INSTALL_DIR__  absolute path to the checked-out examples/claude-code-hook/
+#                    e.g. /home/deci/orynq-sdk/examples/claude-code-hook
+#   __NODE_BIN__     absolute path to a Node ≥20 binary
+#                    e.g. /home/deci/.nvm/versions/node/v24.15.0/bin/node
+#
+# Then: sudo systemctl daemon-reload && sudo systemctl enable --now materios-orynq-drain
+#
+# Drop-ins under /etc/systemd/system/materios-orynq-drain.service.d/ are the
+# right place to set ORYNQ_SDK_PATH, ORYNQ_DRAIN_ANCHOR_DISABLED, and other
+# per-host config — keeps this unit file portable.
+
+[Unit]
+Description=Materios orynq drain daemon (per-task certified-receipt anchor)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__USER__
+Group=__GROUP__
+WorkingDirectory=__INSTALL_DIR__
+Environment=PATH=__NODE_BIN__:/usr/bin:/bin
+Environment=NODE_ENV=production
+ExecStart=__NODE_BIN__/node drain.mjs
+Restart=always
+RestartSec=5
+StandardOutput=append:__INSTALL_DIR__/drain.log
+StandardError=append:__INSTALL_DIR__/drain.log
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/claude-code-hook/materios-orynq-drain.service
+++ b/examples/claude-code-hook/materios-orynq-drain.service
@@ -1,14 +1,16 @@
 # Materios orynq drain daemon — systemd unit template.
 #
 # Copy to /etc/systemd/system/materios-orynq-drain.service after substituting
-# the four placeholders below for your install:
+# the placeholders below for your install:
 #
-#   __USER__         e.g. deci
-#   __GROUP__        e.g. deci  (usually same as user)
+#   __USER__         e.g. alice
+#   __GROUP__        e.g. alice  (usually same as user)
 #   __INSTALL_DIR__  absolute path to the checked-out examples/claude-code-hook/
-#                    e.g. /home/deci/orynq-sdk/examples/claude-code-hook
-#   __NODE_BIN__     absolute path to a Node ≥20 binary
-#                    e.g. /home/deci/.nvm/versions/node/v24.15.0/bin/node
+#                    e.g. /home/alice/orynq-sdk/examples/claude-code-hook
+#   __NODE_BIN__     absolute path to the dir containing the Node ≥20 binary
+#                    e.g. /home/alice/.nvm/versions/node/v24.15.0/bin
+#   __STATE_DIR__    durable state dir for the queue/done/failed trees
+#                    e.g. /home/alice/.local/state/materios-orynq-hook
 #
 # Then: sudo systemctl daemon-reload && sudo systemctl enable --now materios-orynq-drain
 #
@@ -31,8 +33,35 @@ Environment=NODE_ENV=production
 ExecStart=__NODE_BIN__/node drain.mjs
 Restart=always
 RestartSec=5
-StandardOutput=append:__INSTALL_DIR__/drain.log
-StandardError=append:__INSTALL_DIR__/drain.log
+
+# Log to journal so the install dir can be mounted read-only (see ProtectHome
+# below). Tail with `journalctl -u materios-orynq-drain -f`.
+StandardOutput=journal
+StandardError=journal
+
+# ─── Sandboxing ────────────────────────────────────────────────────────────
+# The daemon needs: network egress, read access to its own scripts, and
+# read/write access to its queue/done/failed directories. Everything else
+# is locked down.
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=__STATE_DIR__
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+# AF_INET/AF_INET6 for blob-gateway + RPC; AF_UNIX kept for nodejs internals.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/claude-code-hook/test-chain-aware.mjs
+++ b/examples/claude-code-hook/test-chain-aware.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Test harness for the chain-aware backstop check.
+ *
+ * Read-only against cert-daemon (docker exec cat + curl /metrics) and
+ * Materios RPC. Posts NOTHING. Runs cleanly without ORYNQ_DRAIN_DRY_RUN
+ * since chainAwareDecision itself never POSTs — we just don't invoke
+ * postAnchorBackstop here.
+ *
+ * Two cases:
+ *   1. Synthetic sentinel with task #105's certHash (known-anchored)
+ *      → expect decision === "skip-anchored", anchored.batchRoot present.
+ *   2. Synthetic sentinel with a fake certHash + recent blockNum
+ *      → expect decision === "post" if cert-daemon's head is far enough
+ *        ahead of the fake block, else "skip-too-early" (still a pass —
+ *        we just want to confirm post-would-fire-when-conditions-met).
+ *
+ * Exit 0 on both pass. Non-zero with a labeled assertion failure otherwise.
+ */
+
+import { chainAwareDecision } from "./drain.mjs";
+
+const TASK_105_CERT_HASH = "0x802b71c8e3206adb58a7636b820d7b5c5a10bf8347ad013b4bc93d360ff1852e";
+const FAKE_CERT_HASH = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+function assertEqual(label, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    console.error(`FAIL  ${label}: expected ${e}, got ${a}`);
+    return false;
+  }
+  console.log(`PASS  ${label}`);
+  return true;
+}
+
+function assert(label, cond, detail = "") {
+  if (!cond) {
+    console.error(`FAIL  ${label}${detail ? ` (${detail})` : ""}`);
+    return false;
+  }
+  console.log(`PASS  ${label}`);
+  return true;
+}
+
+async function main() {
+  let allPass = true;
+
+  // -------- Case 1: known-anchored cert_hash (task #105) --------
+  console.log("\n=== Case 1: task #105 cert_hash should be found in cert-daemon history ===");
+  const anchoredSentinel = {
+    schemaVersion: "pending-anchor/2.0",
+    contentHash: "b5bb383e7badbc343a4a7802ea1205f5c7e712d734e24a7c9875c8ef477ce3dd",
+    rootHash: "b5bb383e7badbc343a4a7802ea1205f5c7e712d734e24a7c9875c8ef477ce3dd",
+    manifestHash: "b5bb383e7badbc343a4a7802ea1205f5c7e712d734e24a7c9875c8ef477ce3dd",
+    certHash: TASK_105_CERT_HASH,
+    blockHash: "0x635906b65bea350acaf15d1209124b2f8e2bc802f93cd883c800ba704368d1fd",
+    blockNum: 66259, // from checkpoint-history.json batch 559
+    receiptId: "0x9c71e89973a6cfa4b66341314c41a199cb58d379a9db74f1f17c4fdda1b71b57",
+    queueEntry: "test-task-105.json",
+    queuedAt: new Date(Date.now() - 12 * 60_000).toISOString(),
+    dueAt: new Date(Date.now() - 2 * 60_000).toISOString(), // past due
+  };
+
+  const r1 = await chainAwareDecision(anchoredSentinel);
+  console.log("  decision:", JSON.stringify(r1, null, 2));
+
+  allPass = assertEqual("Case 1: decision == skip-anchored", r1.decision, "skip-anchored") && allPass;
+  allPass = assert(
+    "Case 1: anchored.batchRoot present",
+    typeof r1.anchored?.batchRoot === "string" && r1.anchored.batchRoot.length === 64,
+    `got ${r1.anchored?.batchRoot}`,
+  ) && allPass;
+  allPass = assert(
+    "Case 1: anchored.leafBlockNum == 66259",
+    r1.anchored?.leafBlockNum === 66259,
+    `got ${r1.anchored?.leafBlockNum}`,
+  ) && allPass;
+  // txHash is intentionally null — cert-daemon doesn't persist it.
+  allPass = assertEqual("Case 1: anchored.txHash == null", r1.anchored?.txHash, null) && allPass;
+
+  // Behavioral assertions: sentinel-would-be-deleted = true, post-would-fire = false.
+  // These flow from decision === "skip-anchored" — the sweep code unlinks and skips POST.
+  allPass = assert(
+    "Case 1: sentinel-would-be-deleted (skip-anchored ⇒ unlink in sweep)",
+    r1.decision === "skip-anchored",
+  ) && allPass;
+  allPass = assert(
+    "Case 1: post-would-fire = false (no 'post' decision)",
+    r1.decision !== "post",
+  ) && allPass;
+
+  // -------- Case 2: fake cert_hash, low blockNum so cert-daemon head is far ahead --------
+  console.log("\n=== Case 2: fake cert_hash (NOT in history) should yield 'post' or 'skip-too-early' ===");
+  // blockNum=1 forces head >> blockNum + 30, so we expect 'post' (assuming
+  // cert-daemon's metrics are up). If metrics endpoint were down we'd get
+  // 'skip-diagnostic-broken' — also documented as the failsafe path.
+  const fakeSentinel = {
+    schemaVersion: "pending-anchor/2.0",
+    contentHash: "0".repeat(64),
+    rootHash: "0".repeat(64),
+    manifestHash: "0".repeat(64),
+    certHash: FAKE_CERT_HASH,
+    blockHash: null,
+    blockNum: 1, // ancient — cert-daemon head should be way past this
+    receiptId: null,
+    queueEntry: "test-fake.json",
+    queuedAt: new Date(Date.now() - 12 * 60_000).toISOString(),
+    dueAt: new Date(Date.now() - 2 * 60_000).toISOString(),
+  };
+
+  const r2 = await chainAwareDecision(fakeSentinel);
+  console.log("  decision:", JSON.stringify(r2, null, 2));
+
+  allPass = assert(
+    "Case 2: not 'skip-anchored' (fake cert_hash absent from history)",
+    r2.decision !== "skip-anchored",
+    `got ${r2.decision}`,
+  ) && allPass;
+  allPass = assertEqual("Case 2: decision == 'post'", r2.decision, "post") && allPass;
+  allPass = assert(
+    "Case 2: certDaemonHead numeric and > 30",
+    Number.isInteger(r2.certDaemonHead) && r2.certDaemonHead > 30,
+    `got ${r2.certDaemonHead}`,
+  ) && allPass;
+  allPass = assert(
+    "Case 2: post-would-fire = true",
+    r2.decision === "post",
+  ) && allPass;
+
+  console.log("\n" + (allPass ? "ALL CASES PASS" : "SOME CASES FAILED"));
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("test harness fatal:", e?.stack || e);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Imports the Claude Code task-closure hook + systemd drain daemon as
`examples/claude-code-hook/`. Reference consumer of
`@fluxpointstudios/orynq-sdk-anchors-materios` — sits next to the
existing reference examples (`self-anchor`, `materios-certified`,
`materios-e2e`, `materios-loadtest`).

This has been running in production on a single workstation since
2026-05-04, producing the Claude Code trace history that the
`schemaHash: SCHEMA_HASH_ORYNQ_TRACE_V1` plumbing in PR #40 is
designed for. Importing it now so the lockstep contract between the SDK
caller, the hook producer, and the cert-daemon verifier is documented
and reviewable in one place.

## What's new vs the previously-local copy

- **`queue/2.0` schema** (2026-05-11) — hook now ships an explicit
  `content` field with the canonical bytes the drain must upload to the
  blob gateway. cert-daemon's schema-aware verifier requires
  `merkle_root(uploaded chunks) == on-chain content_hash`, so producer
  and consumer have to agree on byte-shape. Pre-2026-05-11 `queue/1.0`
  entries had a contentHash computed over a different shape; drain.mjs
  refuses them with a clear error.
- **Generalized systemd unit** — replaced operator-specific paths with
  four named placeholders (`__USER__`, `__GROUP__`, `__INSTALL_DIR__`,
  `__NODE_BIN__`) so the unit file is a portable template.
- **README** points at `<INSTALL_DIR>` instead of one operator's home.

## End-to-end verification (2026-05-11)

Probe receipt `0x80aaaacc4e922936101d163df8f4d90e8929d331fe5722e5ec718eb558141431`:
- Materios on-chain `schema_hash` = `0xcab0f818…` (= sha256("orynq_trace_v1")) ✓
- cert-daemon: ROOT_VERIFIED (chunks=1, chunk_root == content_hash) ✓
- attestation status via RPC: `"Certified"` ✓
- Cardano L1 anchor tx: `e96e0832f0a17bdba8277ce19f700512f2f40b94a184867415430c3ccecf36a0` (mainnet, metadata label 8746)
- Hook fire → Cardano mempool: ~5 minutes

## Test plan

- [x] Confirmed `hook.mjs` produces queue/2.0 entries with `content` and
  `sha256(content) == contentHash`
- [x] Confirmed `drain.mjs` uploads `entry.content` verbatim and
  cert-daemon accepts under the schema-discriminator path
- [x] Confirmed `drain.mjs` rejects queue/1.0 entries with a clear error
- [ ] Reviewers: check that the schemaHash constant in `drain.mjs:99`
  matches both `packages/anchors-materios/src/receipt.ts` plumbing (the
  caller side) and operator-kit `daemon/schemas/orynq_trace.py`
  (the verifier side). Drift between any of these three locations
  silently breaks every receipt — same class of bug as #115/#204.

Refs materios-node task #105 (the drain daemon design) and #195/#204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)