### PR TITLE
fix(blob-gateway): 402-middleware live-flip blockers — payer-leak, route classifier, unknown pricing, async error, polish

### DIFF
--- a/services/blob-gateway/src/__tests__/billing-402.test.ts
+++ b/services/blob-gateway/src/__tests__/billing-402.test.ts
@@ -2,26 +2,31 @@
  * Unit tests for the Phase 2.A pay-per-use middleware.
  *
  * Covers:
- * - classifyEndpoint mapping (pure function)
+ * - classifyEndpoint mapping (pure function) — every route in index.ts
+ *   has an explicit class entry (M1 / #222).
+ * - Unrecognized non-GET writes emit `billing.unclassified_route` warn
+ *   (M1 / #222).
  * - phase = "off" bypass
  * - phase = "measurement" logs would_402 without blocking
  * - phase = "live" returns 402 with x402 headers when balance < price
  * - phase = "live" + sufficient balance lets request through
  * - pallet-not-present (price=null) bypasses regardless of phase
- * - PerByte pricing uses Content-Length header
+ * - PerByte pricing uses Content-Length header (chunk_upload)
+ * - H1 (#221): self-pay 402 responses MUST NOT leak the unverified
+ *   claimed-SS58 or its on-chain balance — the response body and the
+ *   X-402-Payment-Required header reflect `null` for `payer`/`balance`,
+ *   and the structured log uses `payer_ss58_claimed` (not `payer_ss58`).
+ * - M2 (#223): decodePricingModel emits a structured warn when both
+ *   codec and JSON shape miss, and still returns 0n (fail-safe).
+ * - M3 (#224): an internal exception inside the middleware fails open
+ *   (the request passes through, console.error logged once).
+ * - L4 (#225): every static-literal endpoint class matches /^[a-z0-9_]+$/.
  */
 
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import express from "express";
 import { config } from "../config.js";
-
-// Mock chain_query before importing the middleware — middleware imports
-// these symbols at top-level, so the mock must be in place first.
-vi.mock("../billing/chain_query.js", () => ({
-  queryEndpointPrice: vi.fn(),
-  queryBillingBalance: vi.fn(),
-  resetChainQueryForTests: vi.fn(),
-}));
+import { decodePricingModel } from "../billing/chain_query.js";
 
 // Mock api-tokens so identifyPayer doesn't need a real DB.
 vi.mock("../api-tokens.js", () => ({
@@ -30,35 +35,48 @@ vi.mock("../api-tokens.js", () => ({
 }));
 
 import { billing402Middleware, __test__ } from "../middleware/billing-402.js";
-import {
-  queryEndpointPrice,
-  queryBillingBalance,
-} from "../billing/chain_query.js";
+import type { BillingMiddlewareDeps } from "../middleware/billing-402.js";
 
 type Phase = "off" | "measurement" | "live";
 
-function withPhase<T>(phase: Phase, fn: () => Promise<T> | T): Promise<T> | T {
+async function withPhase<T>(
+  phase: Phase,
+  fn: () => Promise<T> | T,
+): Promise<T> {
+  // CRITICAL: the original implementation used a sync try/finally around
+  // an async `fn()`, which restored the prev phase BEFORE the awaited
+  // request completed — so the middleware always saw phase="off" by the
+  // time it ran. The async form below holds the override across the
+  // entire awaited call, which is what every test below assumes.
   const prev = config.billingEnforcementPhase;
   (config as { billingEnforcementPhase: Phase }).billingEnforcementPhase = phase;
   try {
-    return fn() as T;
+    return await fn();
   } finally {
     (config as { billingEnforcementPhase: Phase }).billingEnforcementPhase = prev;
   }
 }
 
+/**
+ * Spin up a tiny express app around the middleware and execute one
+ * request. Returns the wire-level status + body + headers — same shape
+ * a real HTTP client would see.
+ */
 async function harness(opts: {
   method: string;
   path: string;
   headers?: Record<string, string>;
+  body?: string | Buffer;
+  deps?: BillingMiddlewareDeps;
 }): Promise<{
   status: number;
   body: unknown;
   headers: Record<string, string>;
+  text: string;
 }> {
   const app = express();
   app.use(express.json());
-  app.use(billing402Middleware());
+  app.use(billing402Middleware(opts.deps));
   // Reflect handler — any non-402 request lands here and returns 200.
   app.use((_req, res) => res.status(200).json({ ok: true }));
 
@@ -70,7 +88,11 @@ async function harness(opts: {
         return reject(new Error("no port"));
       }
       const url = `http://127.0.0.1:${addr.port}${opts.path}`;
-      fetch(url, { method: opts.method, headers: opts.headers })
+      fetch(url, {
+        method: opts.method,
+        headers: opts.headers,
+        body: opts.body,
+      })
         .then(async (res) => {
           const text = await res.text();
           let body: unknown;
@@ -84,7 +106,7 @@ async function harness(opts: {
             hdrs[k] = v;
           });
           server.close();
-          resolve({ status: res.status, body, headers: hdrs });
+          resolve({ status: res.status, body, headers: hdrs, text });
         })
         .catch((e) => {
           server.close();
@@ -118,6 +140,12 @@ describe("classifyEndpoint", () => {
     ).toBe("free");
     expect(__test__.classifyEndpoint(req("GET", "/locators/x"))).toBe("free");
     expect(__test__.classifyEndpoint(req("GET", "/chain-info"))).toBe("free");
+    expect(__test__.classifyEndpoint(req("GET", "/chunks/r/0"))).toBe("free");
+    expect(__test__.classifyEndpoint(req("GET", "/faucet/status"))).toBe("free");
+    expect(__test__.classifyEndpoint(req("GET", "/batches/abc"))).toBe("free");
+    expect(__test__.classifyEndpoint(req("GET", "/blobs/abc/status"))).toBe(
+      "free",
+    );
   });
 
   test("billing/usage is its own class so we can price it", () => {
@@ -142,6 +170,24 @@ describe("classifyEndpoint", () => {
     expect(__test__.classifyEndpoint(req("PUT", "/batches/xyz"))).toBe(
       "batch_metadata",
     );
+    expect(__test__.classifyEndpoint(req("POST", "/batches/xyz"))).toBe(
+      "batch_metadata",
+    );
+  });
+
+  test("TEE evidence routes map to their own classes (M1 / #222)", () => {
+    expect(
+      __test__.classifyEndpoint(req("POST", "/v2/attestation_evidence")),
+    ).toBe("tee_evidence_submit");
+    expect(
+      __test__.classifyEndpoint(
+        req("POST", "/v2/attestation_evidence/42/mark_submitted"),
+      ),
+    ).toBe("tee_evidence_mark_submitted");
+    // GET pending is daemon-only, classified as admin (not user-billable).
+    expect(
+      __test__.classifyEndpoint(req("GET", "/v2/attestation_evidence/pending")),
+    ).toBe("admin");
   });
 
   test("operator-onboarding paths are free", () => {
@@ -149,79 +195,532 @@ describe("classifyEndpoint", () => {
     expect(__test__.classifyEndpoint(req("POST", "/faucet/drip"))).toBe("free");
   });
 
-  test("unrecognized paths default to free (fail-open admission)", () => {
+  test("operator + admin routes get admin class (M1 / #222)", () => {
     expect(
-      __test__.classifyEndpoint(req("POST", "/something-not-in-routes")),
-    ).toBe("free");
+      __test__.classifyEndpoint(req("POST", "/operators/register")),
+    ).toBe("admin");
+    expect(
+      __test__.classifyEndpoint(req("POST", "/operators/create-invite")),
+    ).toBe("admin");
+    expect(
+      __test__.classifyEndpoint(
+        req("PATCH", "/operators/5xyz.../session-keys"),
+      ),
+    ).toBe("admin");
+    expect(
+      __test__.classifyEndpoint(req("POST", "/admin/api-keys/aabb/binding")),
+    ).toBe("admin");
+    expect(
+      __test__.classifyEndpoint(req("DELETE", "/admin/api-keys/aabb/binding")),
+    ).toBe("admin");
+    expect(__test__.classifyEndpoint(req("GET", "/admin/observers"))).toBe(
+      "admin",
+    );
+    expect(__test__.classifyEndpoint(req("POST", "/admin/observers"))).toBe(
+      "admin",
+    );
+    expect(
+      __test__.classifyEndpoint(req("POST", "/admin/fleet-operators")),
+    ).toBe("admin");
+    expect(
+      __test__.classifyEndpoint(
+        req("POST", "/admin/attestation-evidence-attestors"),
+      ),
+    ).toBe("admin");
+    expect(__test__.classifyEndpoint(req("POST", "/auth/token"))).toBe(
+      "admin",
+    );
+    expect(__test__.classifyEndpoint(req("GET", "/auth/tokens"))).toBe(
+      "admin",
+    );
+  });
+
+  test("unrecognized non-GET routes warn (M1 / #222) and default to free", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        __test__.classifyEndpoint(req("POST", "/something-not-in-routes")),
+      ).toBe("free");
+      // exactly one warn line, structured JSON, with method/path/log fields.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const arg = warnSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(arg);
+      expect(parsed.log).toBe("billing.unclassified_route");
+      expect(parsed.method).toBe("POST");
+      expect(parsed.path).toBe("/something-not-in-routes");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("unrecognized GETs default to free without a warn (read-by-default contract)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        __test__.classifyEndpoint(req("GET", "/something-not-in-routes")),
+      ).toBe("free");
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("L4 (#225): every classifyEndpoint return matches /^[a-z0-9_]+$/", () => {
+    // Exhaust every observed return in this suite. The assertion lives
+    // inside classifyEndpoint itself — if any literal slipped past the
+    // /[a-z0-9_]+/ guard the call below would throw.
+    const samples: [string, string][] = [
+      ["GET", "/health"],
+      ["GET", "/status"],
+      ["GET", "/blobs/x/manifest"],
+      ["GET", "/blobs/x/status"],
+      ["GET", "/blobs/x/chunks/0"],
+      ["GET", "/chunks/r/0"],
+      ["GET", "/locators/x"],
+      ["GET", "/batches/x"],
+      ["GET", "/billing/usage"],
+      ["GET", "/chain-info"],
+      ["GET", "/faucet/status"],
+      ["GET", "/heartbeats/status"],
+      ["GET", "/operators/foo/session-keys"],
+      ["GET", "/operators/status/foo"],
+      ["GET", "/v2/attestation_evidence/pending"],
+      ["POST", "/blobs/x/manifest"],
+      ["PUT", "/blobs/x/chunks/0"],
+      ["PATCH", "/blobs/x/certified"],
+      ["POST", "/metering/submit"],
+      ["POST", "/batches/x"],
+      ["PUT", "/batches/x"],
+      ["POST", "/v2/attestation_evidence"],
+      ["POST", "/v2/attestation_evidence/1/mark_submitted"],
+      ["POST", "/heartbeats"],
+      ["POST", "/faucet/drip"],
+      ["POST", "/operators/register"],
+      ["POST", "/operators/create-invite"],
+      ["PATCH", "/operators/foo/session-keys"],
+      ["POST", "/admin/api-keys/x/binding"],
+      ["DELETE", "/admin/api-keys/x/binding"],
+      ["GET", "/admin/observers"],
+      ["POST", "/admin/observers"],
+      ["DELETE", "/admin/observers/x"],
+      ["POST", "/admin/fleet-operators"],
+      ["DELETE", "/admin/fleet-operators/x"],
+      ["GET", "/admin/fleet-operators"],
+      ["POST", "/admin/attestation-evidence-attestors"],
+      ["DELETE", "/admin/attestation-evidence-attestors/x"],
+      ["GET", "/admin/attestation-evidence-attestors"],
+      ["POST", "/auth/token"],
+      ["DELETE", "/auth/token/x"],
+      ["GET", "/auth/tokens"],
+      ["GET", "/auth/token/x/usage"],
+    ];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      for (const [m, p] of samples) {
+        const c = __test__.classifyEndpoint(req(m, p));
+        expect(c).toMatch(/^[a-z0-9_]+$/);
+      }
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 
 // ---------------------------------------------------------------------------
-// Middleware behavior across phases
+// Middleware behavior across phases — DI'd stubs
 // ---------------------------------------------------------------------------
 
-describe("billing402Middleware: phase = off", () => {
-  beforeEach(() => {
-    vi.mocked(queryEndpointPrice).mockReset();
-    vi.mocked(queryBillingBalance).mockReset();
-  });
+function stubDeps(
+  priceFn: (
+    endpointClass: string,
+    requestBytes: number,
+  ) => Promise<{ endpointClass: string; price: bigint | null }>,
+  balanceFn: (ss58: string) => Promise<{ ss58: string; balance: bigint | null }>,
+): { deps: BillingMiddlewareDeps; price: ReturnType<typeof vi.fn>; balance: ReturnType<typeof vi.fn> } {
+  const price = vi.fn(priceFn);
+  const balance = vi.fn(balanceFn);
+  return {
+    deps: { queryEndpointPrice: price, queryBillingBalance: balance },
+    price,
+    balance,
+  };
+}
 
+describe("billing402Middleware: phase = off", () => {
   test("bypasses entirely, no chain reads", async () => {
+    const { deps, price, balance } = stubDeps(
+      async () => ({ endpointClass: "receipt_submit", price: 1n }),
+      async (ss58) => ({ ss58, balance: 0n }),
+    );
     const res = await withPhase("off", () =>
-      harness({ method: "POST", path: "/metering/submit" }),
+      harness({ method: "POST", path: "/metering/submit", deps }),
     );
     expect(res.status).toBe(200);
-    expect(queryEndpointPrice).not.toHaveBeenCalled();
-    expect(queryBillingBalance).not.toHaveBeenCalled();
+    expect(price).not.toHaveBeenCalled();
+    expect(balance).not.toHaveBeenCalled();
   });
 });
 
 describe("billing402Middleware: pallet not present", () => {
-  beforeEach(() => {
-    vi.mocked(queryEndpointPrice).mockReset();
-    vi.mocked(queryBillingBalance).mockReset();
-    vi.mocked(queryEndpointPrice).mockResolvedValue({
-      endpointClass: "receipt_submit",
-      price: null,
-    });
-    vi.mocked(queryBillingBalance).mockResolvedValue({
-      ss58: "",
-      balance: null,
-    });
-  });
-
   test("phase=live bypasses when pallet not on chain", async () => {
+    const { deps } = stubDeps(
+      async () => ({ endpointClass: "receipt_submit", price: null }),
+      async (ss58) => ({ ss58, balance: null }),
+    );
     const res = await withPhase("live", () =>
-      harness({ method: "POST", path: "/metering/submit" }),
+      harness({ method: "POST", path: "/metering/submit", deps }),
     );
     expect(res.status).toBe(200);
   });
 });
 
 describe("billing402Middleware: phase = live, free endpoint", () => {
-  test("free endpoint never queries chain (no mock setup needed)", async () => {
-    vi.mocked(queryEndpointPrice).mockReset();
-    vi.mocked(queryBillingBalance).mockReset();
+  test("free endpoint never queries chain", async () => {
+    const { deps, price, balance } = stubDeps(
+      async () => ({ endpointClass: "free", price: 1n }),
+      async (ss58) => ({ ss58, balance: 0n }),
+    );
     const res = await withPhase("live", () =>
-      harness({ method: "GET", path: "/health" }),
+      harness({ method: "GET", path: "/health", deps }),
     );
     expect(res.status).toBe(200);
-    expect(queryEndpointPrice).not.toHaveBeenCalled();
-    expect(queryBillingBalance).not.toHaveBeenCalled();
+    expect(price).not.toHaveBeenCalled();
+    expect(balance).not.toHaveBeenCalled();
+  });
+
+  test("admin endpoint never queries chain (M1 / #222)", async () => {
+    const { deps, price, balance } = stubDeps(
+      async () => ({ endpointClass: "admin", price: 1n }),
+      async (ss58) => ({ ss58, balance: 0n }),
+    );
+    const res = await withPhase("live", () =>
+      harness({ method: "POST", path: "/admin/api-keys/x/binding", deps }),
+    );
+    expect(res.status).toBe(200);
+    expect(price).not.toHaveBeenCalled();
+    expect(balance).not.toHaveBeenCalled();
   });
 });
 
-// NOTE: full 402-emission integration tests (live mode with mocked chain
-// returning insufficient balance, measurement mode logging would_402, etc.)
-// are deferred to a follow-up PR. The vi.mock module resolution between
-// test file and middleware file (different relative paths to the same
-// source) needs a small refactor — either an absolute-path import or a
-// dependency-injection seam in the middleware. Pure-function coverage
-// above (classifyEndpoint, identifyPayer, off/bypass, free, pallet-not-
-// present) exercises the routing + decision logic.
-//
-// Tracked as: tests/billing-402-integration-coverage (open this in the
-// follow-up PR alongside payer-materios-x402 SDK integration tests).
+// ---------------------------------------------------------------------------
+// Full 402-emission integration tests (BONUS — previously deferred in PR #43)
+// ---------------------------------------------------------------------------
+
+describe("billing402Middleware: phase = live + chain stub", () => {
+  test("balance < price → 402 with structured body + x402 headers", async () => {
+    const { deps } = stubDeps(
+      async () => ({ endpointClass: "receipt_submit", price: 1000n }),
+      async (ss58) => ({ ss58, balance: 50n }),
+    );
+    const res = await withPhase("live", () =>
+      harness({
+        method: "POST",
+        path: "/metering/submit",
+        headers: {
+          "x-402-payment-signature": "0xsig",
+          "x-402-payer-ss58": "5SelfPayer",
+        },
+        deps,
+      }),
+    );
+    expect(res.status).toBe(402);
+    const body = res.body as Record<string, unknown>;
+    expect(body.error).toBe("payment_required");
+    expect(body.endpoint_class).toBe("receipt_submit");
+    expect(body.price).toBe("1000");
+    expect(body.currency).toBe("MATRA");
+    // H1 (#221): self-pay path MUST NOT reflect unverified balance / SS58.
+    expect(body.balance).toBeNull();
+    expect(body.payer).toBeNull();
+    expect(typeof body.request_id).toBe("string");
+    expect(typeof body.expires).toBe("number");
+    // x402 headers present
+    expect(res.headers["www-authenticate"]).toContain("X-402");
+    expect(res.headers["www-authenticate"]).toContain("receipt_submit");
+    expect(res.headers["x-402-payment-required"]).toBeTruthy();
+    const x402 = JSON.parse(res.headers["x-402-payment-required"] as string);
+    expect(x402.scheme).toBe("materios-x402");
+    expect(x402.endpointClass).toBe("receipt_submit");
+    expect(x402.pricing.amount).toBe("1000");
+    expect(x402.pricing.token).toBe("MATRA");
+    // H1 (#221): header also scrubbed of unverified payer.
+    expect(x402.payer).toBeUndefined();
+  });
+
+  test("balance = null (no payer headers) → 402, balance + payer null", async () => {
+    const { deps } = stubDeps(
+      async () => ({ endpointClass: "receipt_submit", price: 1000n }),
+      async (ss58) => ({ ss58, balance: null }),
+    );
+    const res = await withPhase("live", () =>
+      harness({ method: "POST", path: "/metering/submit", deps }),
+    );
+    expect(res.status).toBe(402);
+    const body = res.body as Record<string, unknown>;
+    expect(body.balance).toBeNull();
+    expect(body.payer).toBeNull();
+    expect(body.price).toBe("1000");
+  });
+
+  test("balance >= price → request passes through (200)", async () => {
+    const { deps } = stubDeps(
+      async () => ({ endpointClass: "receipt_submit", price: 1000n }),
+      async (ss58) => ({ ss58, balance: 10_000n }),
+    );
+    const res = await withPhase("live", () =>
+      harness({
+        method: "POST",
+        path: "/metering/submit",
+        headers: {
+          "x-402-payment-signature": "0xsig",
+          "x-402-payer-ss58": "5SelfPayer",
+        },
+        deps,
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("measurement phase: balance < price logs would_402, request passes", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { deps } = stubDeps(
+      async () => ({ endpointClass: "receipt_submit", price: 1000n }),
+      async (ss58) => ({ ss58, balance: 50n }),
+    );
+    try {
+      const res = await withPhase("measurement", () =>
+        harness({
+          method: "POST",
+          path: "/metering/submit",
+          headers: {
+            "x-402-payment-signature": "0xsig",
+            "x-402-payer-ss58": "5SelfPayer",
+          },
+          deps,
+        }),
+      );
+      expect(res.status).toBe(200);
+      // Find the structured billing.decision log line.
+      const billingLines = logSpy.mock.calls
+        .map((c) => c[0])
+        .filter(
+          (s): s is string =>
+            typeof s === "string" && s.includes("billing.decision"),
+        )
+        .map((s) => JSON.parse(s));
+      expect(billingLines.length).toBeGreaterThan(0);
+      const last = billingLines[billingLines.length - 1];
+      expect(last.phase).toBe("measurement");
+      expect(last.would_402).toBe(true);
+      expect(last.acted_402).toBe(false);
+      // H1 (#221): self-pay claimed SS58 lives in payer_ss58_claimed,
+      // NEVER payer_ss58 (which is reserved for verified api-key).
+      expect(last.payer_ss58).toBeNull();
+      expect(last.payer_ss58_claimed).toBe("5SelfPayer");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  test("PerByte endpoint: Content-Length flows through to queryEndpointPrice", async () => {
+    const { deps, price } = stubDeps(
+      async (endpointClass, requestBytes) => ({
+        endpointClass,
+        // emulate PerByte unit_price = 2 MATRA-base / byte.
+        price: BigInt(requestBytes) * 2n,
+      }),
+      async (ss58) => ({ ss58, balance: 1_000_000n }),
+    );
+    const res = await withPhase("live", () =>
+      harness({
+        method: "PUT",
+        path: "/blobs/abcd/chunks/0",
+        headers: {
+          "x-402-payment-signature": "0xsig",
+          "x-402-payer-ss58": "5SelfPayer",
+          "content-type": "application/octet-stream",
+          "content-length": "128",
+        },
+        body: Buffer.alloc(128),
+        deps,
+      }),
+    );
+    // 128 * 2 = 256 < 1_000_000 → passes.
+    expect(res.status).toBe(200);
+    expect(price).toHaveBeenCalled();
+    const [endpointClass, requestBytes] = price.mock.calls[0] ?? [];
+    expect(endpointClass).toBe("chunk_upload");
+    expect(requestBytes).toBe(128);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H1 (#221) — payer / balance leak protection
+// ---------------------------------------------------------------------------
+
+describe("H1 (#221): self-pay 402 does not leak claimed SS58 balance", () => {
+  test("response body excludes the SS58 and the balance string", async () => {
+    // Pick a balance strictly less than the price so the middleware
+    // emits a 402 — and pick a value that's hard to confuse with any
+    // other number in the response (price=1000, expires=unix-seconds).
+    const SENTINEL_BALANCE = 12345n;
+    const { deps } = stubDeps(
+      async () => ({ endpointClass: "receipt_submit", price: 1_000_000_000n }),
+      async (ss58) => ({ ss58, balance: SENTINEL_BALANCE }),
+    );
+    const res = await withPhase("live", () =>
+      harness({
+        method: "POST",
+        path: "/metering/submit",
+        headers: {
+          "x-402-payment-signature": "0xsig",
+          "x-402-payer-ss58": "5FakePayerDoesNotExist",
+        },
+        deps,
+      }),
+    );
+    expect(res.status).toBe(402);
+    // The whole response text must not contain the SS58 or the balance
+    // — both 402 body and headers are wire-visible.
+    expect(res.text).not.toContain("5FakePayerDoesNotExist");
+    expect(res.text).not.toContain(SENTINEL_BALANCE.toString());
+    // And the X-402 header (which is in res.headers but the harness
+    // already serialized headers to lowercase) MUST also be scrubbed.
+    const x402 = res.headers["x-402-payment-required"];
+    expect(x402).toBeTruthy();
+    expect(x402).not.toContain("5FakePayerDoesNotExist");
+  });
+
+  test("billing.decision log uses payer_ss58_claimed (not payer_ss58)", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { deps } = stubDeps(
+      async () => ({ endpointClass: "receipt_submit", price: 1000n }),
+      async (ss58) => ({ ss58, balance: 50n }),
+    );
+    try {
+      await withPhase("live", () =>
+        harness({
+          method: "POST",
+          path: "/metering/submit",
+          headers: {
+            "x-402-payment-signature": "0xsig",
+            "x-402-payer-ss58": "5ClaimedPayer",
+          },
+          deps,
+        }),
+      );
+      const billingLines = logSpy.mock.calls
+        .map((c) => c[0])
+        .filter(
+          (s): s is string =>
+            typeof s === "string" && s.includes("billing.decision"),
+        )
+        .map((s) => JSON.parse(s));
+      const last = billingLines[billingLines.length - 1];
+      expect(last.payer_ss58).toBeNull();
+      expect(last.payer_ss58_claimed).toBe("5ClaimedPayer");
+      expect(last.payer_kind).toBe("self");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  test("payerLogFields splits api-key (verified) vs self (claimed)", () => {
+    expect(
+      __test__.payerLogFields({ kind: "api-key", ss58: "5Treasury" }),
+    ).toEqual({ payer_ss58: "5Treasury", payer_ss58_claimed: null });
+    expect(__test__.payerLogFields({ kind: "self", ss58: "5Claimed" })).toEqual({
+      payer_ss58: null,
+      payer_ss58_claimed: "5Claimed",
+    });
+    expect(__test__.payerLogFields({ kind: "none", ss58: null })).toEqual({
+      payer_ss58: null,
+      payer_ss58_claimed: null,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M2 (#223) — unknown PricingModel variant emits warn + returns 0n
+// ---------------------------------------------------------------------------
+
+describe("decodePricingModel: unknown variant (M2 / #223)", () => {
+  test("future enum variant logs warn and returns 0n fail-safe", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // Mocked "future" PricingModel: not codec-shaped (no isPerCall) and
+      // not a JSON dict matching PerCall/PerByte.
+      const future = {
+        // Hypothetical PricingModel::PerCallPerByte { base, per_byte }
+        PerCallPerByte: { base: 100, per_byte: 5 },
+      };
+      const out = decodePricingModel(future, 1024);
+      expect(out).toBe(0n);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const arg = warnSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(arg);
+      expect(parsed.log).toBe("billing.unknown_pricing_variant");
+      expect(parsed.raw_keys).toEqual(["PerCallPerByte"]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("known PerCall variant does NOT emit warn", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const out = decodePricingModel({ PerCall: 42 }, 0);
+      expect(out).toBe(42n);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("known PerByte JSON variant does NOT emit warn", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const out = decodePricingModel({ PerByte: { unit_price: 5 } }, 10);
+      expect(out).toBe(50n);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M3 (#224) — async-error wrap fails open
+// ---------------------------------------------------------------------------
+
+describe("M3 (#224): internal error fails open", () => {
+  test("thrown queryEndpointPrice does not 500 the request", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const deps: BillingMiddlewareDeps = {
+      queryEndpointPrice: vi.fn(async () => {
+        throw new Error("simulated boom");
+      }),
+      queryBillingBalance: vi.fn(async (ss58) => ({ ss58, balance: null })),
+    };
+    try {
+      const res = await withPhase("live", () =>
+        harness({ method: "POST", path: "/metering/submit", deps }),
+      );
+      // Fail-open: request passed through to the 200 reflect-handler.
+      expect(res.status).toBe(200);
+      // And the error was logged exactly once.
+      const lines = errSpy.mock.calls
+        .map((c) => c[0])
+        .filter(
+          (s): s is string =>
+            typeof s === "string" && s.includes("billing-402 internal error"),
+        );
+      expect(lines.length).toBe(1);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // identifyPayer

--- a/services/blob-gateway/src/billing/chain_query.ts
+++ b/services/blob-gateway/src/billing/chain_query.ts
@@ -57,6 +57,18 @@ let lastConnectAttempt = 0;
  * Returns null when we've recently failed to connect — callers degrade to
  * `status: "unknown"` rather than queueing waiters or blocking. A separate
  * cooldown timer governs the next connect attempt.
+ *
+ * NOTE (L3, #225): when the WS connection drops, `apiPromise` is reset
+ * inside the disconnect/error handlers but `lastConnectAttempt` is not
+ * touched. Until the cooldown elapses (`RECONNECT_COOLDOWN_MS`, 30s) the
+ * next `getOrConnectApi()` call returns `null` — which means during the
+ * 30s window after a WS flap, EVERY billing query (balance, endpoint
+ * price) returns `null`. In `live` mode the 402 middleware treats that
+ * as "pallet not present" via `priceRes.price === null` and bypasses
+ * gating, so the practical effect is a 30s billing-bypass window after
+ * a WS disconnect (NOT a 30s burst of 402 responses). This is the
+ * fail-open default we want — better to under-charge than 402-flood
+ * legitimate traffic — but it's worth knowing for ops dashboards.
  */
 function getOrConnectApi(): Promise<ApiPromise> | null {
   if (apiPromise) return apiPromise;
@@ -433,7 +445,7 @@ export async function queryEndpointPrice(
  * can theoretically overflow `u128 * u64`. The pallet uses `saturating_mul`
  * which clamps to `u128::MAX`. We mirror that here with bigint saturation.
  */
-function decodePricingModel(raw: unknown, requestBytes: number): bigint {
+export function decodePricingModel(raw: unknown, requestBytes: number): bigint {
   const U128_MAX = (1n << 128n) - 1n;
   const bytes = BigInt(Math.max(0, requestBytes));
 
@@ -466,6 +478,26 @@ function decodePricingModel(raw: unknown, requestBytes: number): bigint {
     return product > U128_MAX ? U128_MAX : product;
   }
 
+  // M2 (#223): the on-chain `PricingModel` is an open enum — a forkless
+  // runtime upgrade could introduce a new variant (e.g. `PerCallPerByte`,
+  // or a tiered-pricing dict). Both decode paths above would miss it and
+  // silently return 0n, turning every request priced under that variant
+  // into a free request without any operational signal. Emit a warn so
+  // ops sees the regression in the gateway's structured log stream.
+  //
+  // We still return 0n (fail-safe — better to under-charge than block
+  // legitimate traffic), but the warn line is the bell that calls
+  // attention to the variant gap. Pair this with the runtime-upgrade
+  // checklist: any new PricingModel variant requires a gateway bump in
+  // lockstep.
+  // eslint-disable-next-line no-console
+  console.warn(
+    JSON.stringify({
+      log: "billing.unknown_pricing_variant",
+      raw_keys:
+        typeof raw === "object" && raw !== null ? Object.keys(raw) : [],
+    }),
+  );
   // Unknown / unset → free, mirrors `PricingModel::FREE` default in the pallet.
   return 0n;
 }

--- a/services/blob-gateway/src/config.ts
+++ b/services/blob-gateway/src/config.ts
@@ -102,7 +102,12 @@ export const config = {
   // Toggle via `BILLING_ENFORCEMENT_PHASE` env. Misconfigured value falls
   // back to "off" (fail-open is the right default for billing).
   billingEnforcementPhase: (() => {
-    const raw = (process.env.BILLING_ENFORCEMENT_PHASE || "off").toLowerCase();
+    // L1 (#225): trim whitespace BEFORE lowercasing so an env value like
+    // `"  live  "` (common when an operator copy-pastes from a runbook)
+    // is honoured rather than silently falling back to the "off" default.
+    const raw = (process.env.BILLING_ENFORCEMENT_PHASE || "off")
+      .trim()
+      .toLowerCase();
     return raw === "measurement" || raw === "live" ? raw : "off";
   })() as "off" | "measurement" | "live",
 

--- a/services/blob-gateway/src/middleware/billing-402.ts
+++ b/services/blob-gateway/src/middleware/billing-402.ts
@@ -26,12 +26,15 @@
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { config } from "../config.js";
 import {
-  queryBillingBalance,
-  queryEndpointPrice,
+  queryBillingBalance as defaultQueryBillingBalance,
+  queryEndpointPrice as defaultQueryEndpointPrice,
+} from "../billing/chain_query.js";
+import type {
+  BillingBalanceResult,
+  EndpointQuoteResult,
 } from "../billing/chain_query.js";
 import { getApiTokensDb } from "../api-tokens.js";
 import { verifyToken } from "../api-tokens.js";
-import { getQuotaDb } from "../quota.js";
 
 const X402_HEADER_NAME = "X-402-Payment-Required";
 const X402_SIGNATURE_HEADER = "x-402-payment-signature";
@@ -45,8 +48,17 @@ export type EndpointClass = string;
 /**
  * Map an Express request to its billing endpoint class.
  *
- * Returns `"free"` for routes that should bypass billing (health, public
- * reads). Returns the canonical class string for billable routes.
+ * Returns `"free"` for public-read routes that should bypass billing.
+ * Returns `"admin"` for admin-guarded routes (also bypass billing, but
+ * marked semantically as "intentionally not metered" rather than "anyone
+ * can hit this for free"). Returns the canonical class string for
+ * billable routes.
+ *
+ * Every routed endpoint in `services/blob-gateway/src/index.ts` MUST be
+ * accounted for here. Anything not explicitly listed falls through and
+ * emits a `billing.unclassified_route` warn at the bottom — this is a
+ * loud signal that a new route was added without an explicit billing
+ * decision.
  *
  * Pure function; safe to unit-test without spinning up a router.
  */
@@ -54,52 +66,131 @@ export function classifyEndpoint(req: Request): EndpointClass {
   const m = req.method.toUpperCase();
   const p = req.path;
 
-  // Health + status — always free.
+  // ----- Health + status — always free. -----
   if (p === "/health" || p === "/status" || p.startsWith("/status/")) {
-    return "free";
+    return assertEndpointClass("free");
   }
 
-  // Public reads — chain-info, locators, blobs GET, batches GET, etc.
+  // ----- Admin-guarded routes (auth-gated upstream, not billable). -----
+  // /admin/* — every admin route registered in index.ts goes through a
+  // hard ADMIN_API_KEY check before the handler. Listing them here flags
+  // them as "intentionally not billed" rather than letting them fall
+  // through to the implicit-fallback warn.
+  if (p.startsWith("/admin/")) {
+    return assertEndpointClass("admin");
+  }
+  // /auth/token* — Bearer-token lifecycle. Admin-only.
+  if (p === "/auth/token" || p.startsWith("/auth/token/") || p === "/auth/tokens") {
+    return assertEndpointClass("admin");
+  }
+  // Operator onboarding — invite-token / admin-gated.
+  if (m === "POST" && p === "/operators/register") {
+    return assertEndpointClass("admin");
+  }
+  if (m === "POST" && p === "/operators/create-invite") {
+    return assertEndpointClass("admin");
+  }
+  if (m === "PATCH" && /^\/operators\/[^/]+\/session-keys$/.test(p)) {
+    return assertEndpointClass("admin");
+  }
+
+  // ----- Public reads — chain-info, locators, blobs GET, batches GET, etc. -----
   if (m === "GET") {
     // Manifest fetch is publicly readable for content-addressed blobs.
-    if (p.startsWith("/blobs/") && p.endsWith("/manifest")) return "free";
-    if (p.startsWith("/blobs/") && /\/chunks\/\d+$/.test(p)) return "free";
-    if (p.startsWith("/locators/")) return "free";
-    if (p.startsWith("/batches/")) return "free";
-    if (p === "/billing/usage") return "billing_usage_query";
-    if (p === "/chain-info") return "free";
-    return "free";
+    if (p.startsWith("/blobs/") && p.endsWith("/manifest")) return assertEndpointClass("free");
+    if (p.startsWith("/blobs/") && p.endsWith("/status")) return assertEndpointClass("free");
+    if (p.startsWith("/blobs/") && /\/chunks\/\d+$/.test(p)) return assertEndpointClass("free");
+    if (p.startsWith("/chunks/")) return assertEndpointClass("free");
+    if (p.startsWith("/locators/")) return assertEndpointClass("free");
+    if (p.startsWith("/batches/")) return assertEndpointClass("free");
+    if (p === "/billing/usage") return assertEndpointClass("billing_usage_query");
+    if (p === "/chain-info") return assertEndpointClass("free");
+    if (p === "/faucet/status") return assertEndpointClass("free");
+    if (p.startsWith("/heartbeats/")) return assertEndpointClass("free");
+    if (/^\/operators\/[^/]+\/session-keys$/.test(p)) return assertEndpointClass("free");
+    if (/^\/operators\/status\/[^/]+$/.test(p)) return assertEndpointClass("free");
+    // Daemon-facing chain-submission feeder (task #143). Bearer-token
+    // authenticated upstream; not user-billable traffic.
+    if (p === "/v2/attestation_evidence/pending") {
+      return assertEndpointClass("admin");
+    }
+    return assertEndpointClass("free");
   }
+
+  // ----- Write routes — billable -----
 
   // Manifest POST (writes a small JSON blob describing chunks).
   if (m === "POST" && /^\/blobs\/[^/]+\/manifest$/.test(p)) {
-    return "manifest_post";
+    return assertEndpointClass("manifest_post");
   }
   // Chunk PUT (writes blob bytes — priced PerByte by governance).
   if (m === "PUT" && /^\/blobs\/[^/]+\/chunks\/\d+$/.test(p)) {
-    return "chunk_upload";
+    return assertEndpointClass("chunk_upload");
   }
   // Certified PATCH (marks a manifest as certified after cert-daemon attestation).
   if (m === "PATCH" && /^\/blobs\/[^/]+\/certified$/.test(p)) {
-    return "manifest_certified_patch";
+    return assertEndpointClass("manifest_certified_patch");
   }
   // Metering ingest (compute_metering_v1/v2 envelopes).
   if (m === "POST" && p === "/metering/submit") {
-    return "receipt_submit";
+    return assertEndpointClass("receipt_submit");
   }
   // Batch metadata POST/PUT from cert-daemon.
   if ((m === "POST" || m === "PUT") && /^\/batches\/[^/]+$/.test(p)) {
-    return "batch_metadata";
+    return assertEndpointClass("batch_metadata");
+  }
+  // Wave 3 Phase 2 — TEE evidence submit (daemon Bearer auth upstream;
+  // billable per receipt to the attestor).
+  if (m === "POST" && p === "/v2/attestation_evidence") {
+    return assertEndpointClass("tee_evidence_submit");
+  }
+  // Daemon mark-submitted callback (task #143). Bearer-token authenticated
+  // upstream; price it separately so we can throttle daemon traffic
+  // distinctly from end-user evidence submits.
+  if (m === "POST" && /^\/v2\/attestation_evidence\/[^/]+\/mark_submitted$/.test(p)) {
+    return assertEndpointClass("tee_evidence_mark_submitted");
   }
   // Heartbeats — free (operator health, not billable user work).
-  if (m === "POST" && p === "/heartbeats") return "free";
+  if (m === "POST" && p === "/heartbeats") return assertEndpointClass("free");
   // Faucet — free (operator onboarding).
-  if (m === "POST" && p.startsWith("/faucet/")) return "free";
+  if (m === "POST" && p.startsWith("/faucet/")) return assertEndpointClass("free");
 
-  // Anything we don't recognize defaults to free. Keeps the middleware
-  // a strict admission gate rather than a stealth charge surface for any
-  // route that hasn't been audited and priced.
-  return "free";
+  // -----------------------------------------------------------------------
+  // Implicit-fallback warn. Anything that lands here is a NEW route that
+  // was added to the gateway without a corresponding billing decision —
+  // we want a loud signal in the logs so the next reviewer can decide
+  // whether it should be free/admin/billable. The fail-open default
+  // ("free") is preserved so a new route doesn't suddenly start 402-ing
+  // production traffic, but the warn-log makes it impossible to ship a
+  // new route without it showing up in audit.
+  // -----------------------------------------------------------------------
+  if (m !== "GET") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      JSON.stringify({
+        log: "billing.unclassified_route",
+        method: m,
+        path: p,
+      }),
+    );
+  }
+  return assertEndpointClass("free");
+}
+
+/**
+ * Belt-and-suspenders runtime check that every classifyEndpoint return is
+ * a valid canonical endpoint-class identifier. All call-sites pass static
+ * literals so this is a noop in practice — it's here to catch a future
+ * refactor that accidentally constructs a class string from request input
+ * (which would let an attacker steer governance pricing lookups).
+ */
+function assertEndpointClass<T extends string>(c: T): T {
+  if (!/^[a-z0-9_]+$/.test(c)) {
+    throw new Error(
+      `classifyEndpoint returned non-canonical class ${JSON.stringify(c)}; expected /^[a-z0-9_]+$/`,
+    );
+  }
+  return c;
 }
 
 interface PayerIdentity {
@@ -107,8 +198,6 @@ interface PayerIdentity {
   kind: "api-key" | "self" | "none";
   /** SS58 address of the account that will be debited. */
   ss58: string | null;
-  /** Bearer token hash, only set when kind == "api-key". */
-  tokenHash?: string;
 }
 
 /**
@@ -124,6 +213,13 @@ interface PayerIdentity {
  *   wrong-about-payer with no fee/refund impact: if it picks "self" but
  *   the request later fails auth, the route returns 401 and no charge
  *   happens (gateway settlement signer never submits pay_request).
+ * - CRITICAL: in the self-pay path, `ss58` is the CLAIMED address from
+ *   the `x-402-payer-ss58` header — at this layer the sr25519 signature
+ *   has NOT been verified. Treat the value as untrusted; never reflect
+ *   it (or anything derived from it, e.g. its on-chain balance) back to
+ *   the caller in a way that lets an attacker harvest balances for
+ *   arbitrary SS58 addresses by guessing them. See `billing402Middleware`
+ *   for the 402-emission scrubbing.
  */
 function identifyPayer(req: Request): PayerIdentity {
   const authHeader = (req.headers.authorization || req.headers.Authorization) as
@@ -143,9 +239,6 @@ function identifyPayer(req: Request): PayerIdentity {
           return {
             kind: "api-key",
             ss58: config.fpsTreasurySs58 || null,
-            // We hash here only for the spend-cap lookup; the real auth
-            // happens downstream.
-            tokenHash: undefined,
           };
         }
       } catch {
@@ -177,11 +270,19 @@ function identifyPayer(req: Request): PayerIdentity {
  * Mirrors the x402 spec's `PAYMENT-REQUIRED` JSON shape, encoded as a
  * single JSON string in the header value (clients decode via
  * `@fluxpointstudios/orynq-sdk-transport-x402::parse402Response`).
+ *
+ * NOTE FOR CLIENTS: `pricing.amount` is a STRING-encoded u128. Clients
+ * MUST parse it as `BigInt` (not `Number`), otherwise values larger than
+ * 2^53 silently lose precision. Likewise the `balance` field on the 402
+ * JSON body (when non-null) is a string-encoded u128 — same parsing
+ * contract.
  */
 function buildPaymentRequiredHeader(opts: {
   endpointClass: EndpointClass;
   priceMatra: bigint;
-  payerSs58: string;
+  /** May be `null` when we have no verified payer identity. Never
+   *  reflect an unverified claimed-ss58 here — see H1 fix in #221. */
+  payerSs58: string | null;
   requestId: string;
   expiresUnix: number;
 }): string {
@@ -190,8 +291,12 @@ function buildPaymentRequiredHeader(opts: {
     chain: "materios",
     network: "preprod",
     endpointClass: opts.endpointClass,
+    // pricing.amount: STRING-encoded u128 — parse as BigInt on the
+    // client. Never coerce to Number.
     pricing: { token: "MATRA", decimals: 15, amount: opts.priceMatra.toString() },
-    payer: opts.payerSs58,
+    // payer is omitted entirely when null so clients don't have to
+    // distinguish "unset" from "<verify>" sentinel strings.
+    ...(opts.payerSs58 !== null ? { payer: opts.payerSs58 } : {}),
     recipient: "pallet-billing",
     nonce: opts.requestId,
     expires: opts.expiresUnix,
@@ -212,52 +317,18 @@ function newRequestId(): string {
   );
 }
 
-/**
- * Roll the per-key MATRA-spend-today counter into a new UTC day if needed.
- * Called from `live` mode just before the spend-cap check.
- *
- * Returns the row's current state. Returns `null` if no row exists (which
- * shouldn't happen for a verified api-key, but treat as no-cap defensively).
- */
-function getOrRollMatraCounter(keyHash: string): {
-  max_matra_per_day: bigint;
-  matra_spent_today: bigint;
-} | null {
-  const db = getQuotaDb();
-  if (!db) return null;
-  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD UTC
-  const row = db
-    .prepare(
-      "SELECT max_matra_per_day, matra_spent_today, matra_day_bucket FROM api_keys WHERE key_hash = ?",
-    )
-    .get(keyHash) as
-    | {
-        max_matra_per_day: number | string;
-        matra_spent_today: number | string;
-        matra_day_bucket: string | null;
-      }
-    | undefined;
-  if (!row) return null;
-  if (row.matra_day_bucket !== today) {
-    db.prepare(
-      "UPDATE api_keys SET matra_spent_today = 0, matra_day_bucket = ? WHERE key_hash = ?",
-    ).run(today, keyHash);
-    return {
-      max_matra_per_day: BigInt(row.max_matra_per_day),
-      matra_spent_today: 0n,
-    };
-  }
-  return {
-    max_matra_per_day: BigInt(row.max_matra_per_day),
-    matra_spent_today: BigInt(row.matra_spent_today),
-  };
-}
-
 interface BillingDecisionLog {
   phase: "off" | "measurement" | "live";
   endpoint_class: EndpointClass;
   payer_kind: PayerIdentity["kind"];
+  /** SS58 of the VERIFIED api-key payer (treasury account). Set for
+   *  `payer_kind === "api-key"`. */
   payer_ss58: string | null;
+  /** Unverified self-pay SS58 from the `x-402-payer-ss58` header. Set
+   *  for `payer_kind === "self"`. Never trust this for balance lookups
+   *  beyond the 402 admission decision — at this layer the sr25519 sig
+   *  hasn't been verified. */
+  payer_ss58_claimed: string | null;
   price: string;
   balance: string | null;
   would_402: boolean;
@@ -279,142 +350,237 @@ function logBilling(req: Request, d: BillingDecisionLog): void {
   );
 }
 
-export function billing402Middleware(): RequestHandler {
+/**
+ * Split the payer's SS58 into the two log fields based on payer kind.
+ * Verified api-key path uses `payer_ss58`; unverified self-pay path uses
+ * `payer_ss58_claimed`. The "none" path leaves both null.
+ *
+ * This is the safety boundary for H1 (#221): downstream log scrapers can
+ * trust `payer_ss58` to be a verified treasury identity, and treat
+ * `payer_ss58_claimed` as untrusted (parse-but-don't-act).
+ */
+function payerLogFields(payer: PayerIdentity): {
+  payer_ss58: string | null;
+  payer_ss58_claimed: string | null;
+} {
+  if (payer.kind === "api-key") {
+    return { payer_ss58: payer.ss58, payer_ss58_claimed: null };
+  }
+  if (payer.kind === "self") {
+    return { payer_ss58: null, payer_ss58_claimed: payer.ss58 };
+  }
+  return { payer_ss58: null, payer_ss58_claimed: null };
+}
+
+/**
+ * Build dependency-injected middleware. The default closure binds to the
+ * module-level `queryEndpointPrice` / `queryBillingBalance` imports; tests
+ * inject stubs via `deps` so they can exercise the full live/measurement
+ * flow without monkey-patching the module cache.
+ *
+ * The split is the cleanest way to give vitest a deterministic seam —
+ * `vi.mock` of the chain-query module had a module-resolution edge case
+ * in PR #43's harness (see deferred-test note in the test file). DI keeps
+ * production code identical while making the test surface trivial.
+ */
+export interface BillingMiddlewareDeps {
+  queryEndpointPrice?: (
+    endpointClass: string,
+    requestBytes: number,
+  ) => Promise<EndpointQuoteResult>;
+  queryBillingBalance?: (ss58: string) => Promise<BillingBalanceResult>;
+}
+
+export function billing402Middleware(
+  deps: BillingMiddlewareDeps = {},
+): RequestHandler {
+  const queryEndpointPrice = deps.queryEndpointPrice ?? defaultQueryEndpointPrice;
+  const queryBillingBalance =
+    deps.queryBillingBalance ?? defaultQueryBillingBalance;
+
   return async (req: Request, res: Response, next: NextFunction) => {
-    if (config.billingEnforcementPhase === "off") return next();
+    // M3 (#224): wrap the entire handler in a try/catch so any unexpected
+    // throw (DB connection, RPC stub, malformed header parsing) fails open
+    // rather than 500-ing the route. Fail-open matches the rest of the
+    // off-by-default contract — we'd rather under-charge during a bug
+    // than block legitimate traffic.
+    try {
+      if (config.billingEnforcementPhase === "off") return next();
 
-    const endpointClass = classifyEndpoint(req);
-    if (endpointClass === "free") return next();
+      const endpointClass = classifyEndpoint(req);
+      if (endpointClass === "free" || endpointClass === "admin") return next();
 
-    const payer = identifyPayer(req);
-    // Read the request's payload size for PerByte endpoints. For
-    // `chunk_upload`, this is the `content-length` of the PUT body.
-    const requestBytes = Number(req.headers["content-length"] || 0);
+      const payer = identifyPayer(req);
+      // Read the request's payload size for PerByte endpoints. For
+      // `chunk_upload`, this is the `content-length` of the PUT body.
+      const requestBytes = Number(req.headers["content-length"] || 0);
 
-    const [priceRes, balanceRes] = await Promise.all([
-      queryEndpointPrice(endpointClass, requestBytes),
-      payer.ss58
-        ? queryBillingBalance(payer.ss58)
-        : Promise.resolve({ ss58: "", balance: null }),
-    ]);
+      const [priceRes, balanceRes] = await Promise.all([
+        queryEndpointPrice(endpointClass, requestBytes),
+        payer.ss58
+          ? queryBillingBalance(payer.ss58)
+          : Promise.resolve({ ss58: "", balance: null }),
+      ]);
 
-    // pallet-billing not yet wired → bypass. Once 2.A part 2 lands and the
-    // pallet is in `construct_runtime!`, this branch goes away.
-    if (priceRes.price === null) {
-      logBilling(req, {
-        phase: config.billingEnforcementPhase,
-        endpoint_class: endpointClass,
-        payer_kind: payer.kind,
-        payer_ss58: payer.ss58,
-        price: "0",
-        balance: null,
-        would_402: false,
-        acted_402: false,
-        reason: "pallet_not_present",
-      });
-      return next();
-    }
+      // pallet-billing not yet wired → bypass. Once 2.A part 2 lands and the
+      // pallet is in `construct_runtime!`, this branch goes away.
+      if (priceRes.price === null) {
+        logBilling(req, {
+          phase: config.billingEnforcementPhase,
+          endpoint_class: endpointClass,
+          payer_kind: payer.kind,
+          ...payerLogFields(payer),
+          price: "0",
+          balance: null,
+          would_402: false,
+          acted_402: false,
+          reason: "pallet_not_present",
+        });
+        return next();
+      }
 
-    const price = priceRes.price;
-    if (price === 0n) {
-      // Endpoint explicitly priced at zero — treat as free.
-      return next();
-    }
+      const price = priceRes.price;
+      if (price === 0n) {
+        // Endpoint explicitly priced at zero — treat as free.
+        return next();
+      }
 
-    const balance = balanceRes.balance;
-    const insufficient = balance === null || balance < price;
+      const balance = balanceRes.balance;
+      const insufficient = balance === null || balance < price;
 
-    if (config.billingEnforcementPhase === "measurement") {
-      logBilling(req, {
-        phase: "measurement",
-        endpoint_class: endpointClass,
-        payer_kind: payer.kind,
-        payer_ss58: payer.ss58,
-        price: price.toString(),
-        balance: balance === null ? null : balance.toString(),
-        would_402: insufficient,
-        acted_402: false,
-      });
-      return next();
-    }
+      if (config.billingEnforcementPhase === "measurement") {
+        logBilling(req, {
+          phase: "measurement",
+          endpoint_class: endpointClass,
+          payer_kind: payer.kind,
+          ...payerLogFields(payer),
+          price: price.toString(),
+          balance: balance === null ? null : balance.toString(),
+          would_402: insufficient,
+          acted_402: false,
+        });
+        return next();
+      }
 
-    // phase === "live"
-    if (!insufficient) {
+      // phase === "live"
+      if (!insufficient) {
+        logBilling(req, {
+          phase: "live",
+          endpoint_class: endpointClass,
+          payer_kind: payer.kind,
+          ...payerLogFields(payer),
+          price: price.toString(),
+          balance: balance!.toString(),
+          would_402: false,
+          acted_402: false,
+        });
+        return next();
+      }
+
+      // ----- Insufficient balance → 402. -----
+      // H1 (#221): SCRUB unverified self-pay identity from the response.
+      // For the self-pay path, the SS58 came from a request header and
+      // has NOT been signature-verified at this layer. Reflecting the
+      // SS58 (or its on-chain balance) back lets an attacker harvest the
+      // balance of any address they can guess by sending junk-sig +
+      // target-SS58.
+      //
+      // Rules:
+      //   - api-key path → reflect the verified treasury SS58 + balance
+      //     (the api-key auth happens above via `verifyToken`).
+      //   - self-pay / none path → null out payer + balance on the wire.
+      //     The route handler's own auth layer (which DOES verify the
+      //     sr25519 sig) is responsible for any post-verification balance
+      //     surfacing.
+      const isVerifiedPayer = payer.kind === "api-key";
+      const wirePayerSs58 = isVerifiedPayer ? payer.ss58 : null;
+      const wireBalance: bigint | null = isVerifiedPayer ? balance : null;
+
+      const requestId = newRequestId();
+      const expires = Math.floor(Date.now() / 1000) + 300; // 5 min validity
+
+      res.setHeader(
+        "WWW-Authenticate",
+        `X-402 realm="materios", endpoint="${endpointClass}", price="${price.toString()}", currency="MATRA"`,
+      );
+      res.setHeader(
+        X402_HEADER_NAME,
+        buildPaymentRequiredHeader({
+          endpointClass,
+          priceMatra: price,
+          payerSs58: wirePayerSs58,
+          requestId,
+          expiresUnix: expires,
+        }),
+      );
+
       logBilling(req, {
         phase: "live",
         endpoint_class: endpointClass,
         payer_kind: payer.kind,
-        payer_ss58: payer.ss58,
+        ...payerLogFields(payer),
         price: price.toString(),
-        balance: balance!.toString(),
-        would_402: false,
-        acted_402: false,
+        balance: balance === null ? null : balance.toString(),
+        would_402: true,
+        acted_402: true,
+        reason:
+          balance === null
+            ? payer.kind === "none"
+              ? "no_payer_identity"
+              : "balance_read_failed"
+            : "insufficient_balance",
       });
+
+      // 402 JSON body — same scrubbing rule as the header (see H1 above).
+      // NOTE: `price` and `balance` are STRING-encoded u128s; clients MUST
+      // parse them as BigInt, never Number.
+      res.status(402).json({
+        error: "payment_required",
+        endpoint_class: endpointClass,
+        price: price.toString(),
+        currency: "MATRA",
+        balance: wireBalance === null ? null : wireBalance.toString(),
+        payer: wirePayerSs58,
+        request_id: requestId,
+        expires,
+        hint:
+          payer.kind === "none"
+            ? "Authenticate with `Authorization: Bearer matra_…` (api-key) OR sign a self-pay header (`X-402-Payment-Signature`)."
+            : payer.kind === "api-key"
+              ? "FPS treasury balance exhausted or daily cap reached. Contact your account manager to top up."
+              : "Top up your `pallet-billing::Balances` via `topup_self` extrinsic, or sign a sufficient `X-402-Payment-Signature` for this request.",
+      });
+    } catch (err) {
+      // M3 (#224): fail-open on any internal error. The 402 path is
+      // pre-flight admission control; an exception here should never
+      // 500 the underlying request. Log and pass through.
+      // eslint-disable-next-line no-console
+      console.error("billing-402 internal error", err);
       return next();
     }
-
-    // Insufficient balance → 402. Build x402 headers.
-    const requestId = newRequestId();
-    const expires = Math.floor(Date.now() / 1000) + 300; // 5 min validity
-
-    res.setHeader(
-      "WWW-Authenticate",
-      `X-402 realm="materios", endpoint="${endpointClass}", price="${price.toString()}", currency="MATRA"`,
-    );
-    res.setHeader(
-      X402_HEADER_NAME,
-      buildPaymentRequiredHeader({
-        endpointClass,
-        priceMatra: price,
-        payerSs58: payer.ss58 || "",
-        requestId,
-        expiresUnix: expires,
-      }),
-    );
-
-    logBilling(req, {
-      phase: "live",
-      endpoint_class: endpointClass,
-      payer_kind: payer.kind,
-      payer_ss58: payer.ss58,
-      price: price.toString(),
-      balance: balance === null ? null : balance.toString(),
-      would_402: true,
-      acted_402: true,
-      reason:
-        balance === null
-          ? payer.kind === "none"
-            ? "no_payer_identity"
-            : "balance_read_failed"
-          : "insufficient_balance",
-    });
-
-    res.status(402).json({
-      error: "payment_required",
-      endpoint_class: endpointClass,
-      price: price.toString(),
-      currency: "MATRA",
-      balance: balance === null ? null : balance.toString(),
-      payer: payer.ss58,
-      request_id: requestId,
-      expires,
-      hint:
-        payer.kind === "none"
-          ? "Authenticate with `Authorization: Bearer matra_…` (api-key) OR sign a self-pay header (`X-402-Payment-Signature`)."
-          : payer.kind === "api-key"
-            ? "FPS treasury balance exhausted or daily cap reached. Contact your account manager to top up."
-            : "Top up your `pallet-billing::Balances` via `topup_self` extrinsic, or sign a sufficient `X-402-Payment-Signature` for this request.",
-    });
   };
 }
 
 // ---------------------------------------------------------------------------
 // Test exports
 // ---------------------------------------------------------------------------
+//
+// NOTE: `getOrRollMatraCounter` was removed in #224 (M4) — it was only
+// reachable via this `__test__` export and never wired into the live
+// middleware, which means its SELECT-then-UPDATE race at the UTC-day
+// boundary was a guaranteed-future-incident. The per-key MATRA spend
+// cap will be reintroduced as part of #216 (payer-materios-x402 SDK)
+// with proper transactional atomicity (db.transaction(...)). Until then
+// the surface stays empty.
+//
+// TODO(#216): per-key MATRA spend cap will be wired in when
+// payer-materios-x402 SDK lands. Reintroduce a SELECT+UPDATE wrapper
+// that runs inside `db.transaction(...)` so two concurrent calls at a
+// day boundary can't clobber each other's `matra_day_bucket` reset.
 
 export const __test__ = {
   classifyEndpoint,
   identifyPayer,
   buildPaymentRequiredHeader,
-  getOrRollMatraCounter,
+  payerLogFields,
 };


### PR DESCRIPTION
## Summary

Lands all five blockers surfaced by the security review of PR #43 (the
Phase 2.A pay-per-use 402 middleware). With `BILLING_ENFORCEMENT_PHASE=off`
(the current default) today's code path is dormant — but every one of
these defects would bite the moment ops flips to `live`, so they must
land **before** the live-flip. This PR is the gate to that flip.

### Findings fixed (task → defect → fix)

- **H1 / #221** — middleware was reflecting an attacker-controlled SS58
  (`x-402-payer-ss58` header) and its on-chain balance back into the 402
  JSON body, the `X-402-Payment-Required` header, and the
  `billing.decision` log. With a real pallet-billing wired in, anyone
  who can hit the gateway over the network could harvest the
  `pallet-billing::Balances` of any SS58 by guessing them. **Fix:** the
  402 response now scrubs `payer` / `balance` to `null` for any
  non-api-key payer. The structured log gains a new `payer_ss58_claimed`
  field for the self-pay path; `payer_ss58` is now reserved for the
  verified api-key (treasury) path.

- **M1 / #222** — `classifyEndpoint` was missing explicit entries for
  the TEE evidence routes, operator-onboarding routes, and the
  `/admin/*` + `/auth/token*` surface. They all silently fell through
  to `"free"`. New `EndpointClass` value `"admin"` distinguishes
  intentionally-not-billed-because-admin-guarded from
  intentionally-not-billed-because-public-read. Unrecognized non-GET
  routes now emit a structured `billing.unclassified_route` warn
  before the fail-open `"free"` default, so a future PR that adds a
  new route without an explicit billing decision shows up loudly in
  audit logs.

- **M2 / #223** — `decodePricingModel` was silently returning `0n`
  when both decode paths missed (e.g. a forkless runtime upgrade adds
  a new `PricingModel` variant). Now emits a structured
  `billing.unknown_pricing_variant` warn before the fail-safe `0n`
  return.

- **M3+M4 / #224** — middleware body is now wrapped in `try/catch`
  that logs + `next()`s on any unexpected throw (fail-open matches the
  rest of the off-by-default contract). Also removed the never-called
  `getOrRollMatraCounter` (its SELECT-then-UPDATE race at the UTC day
  boundary was a guaranteed-future-incident waiting to happen) and the
  `tokenHash: undefined` dead field on `PayerIdentity`. Both will be
  reintroduced atomically as part of the payer-materios-x402 SDK
  (#216).

- **L1-L4 / #225** — config parsing trims whitespace before lowercase;
  BigInt parsing documented in the 402 header + body; chain-query WS
  disconnect window documented; `classifyEndpoint` asserts every static
  literal matches `/^[a-z0-9_]+$/` (belt-and-suspenders).

### Bonus — integration tests previously deferred in PR #43

PR #43 deferred full live-mode 402 emission tests due to a `vi.mock`
module-resolution edge case. This PR refactors the middleware to accept
a `BillingMiddlewareDeps` injection seam (the default closure binds to
the module-level imports — no change to production code paths). The
deferred tests are now restored:

- live phase, balance=null → 402 with proper headers + JSON body
- live phase, balance < price → 402 with structured body
- live phase, balance >= price → request passes through
- measurement phase, balance < price → `would_402: true` logged,
  request passes
- PerByte endpoint, Content-Length flows through to
  `queryEndpointPrice` argument

Also fixed a latent helper bug: the test file's `withPhase` was using
a sync `try/finally` around an async `fn()`, restoring the prev phase
**before** the awaited request completed. The middleware was therefore
seeing `phase="off"` even inside `withPhase("live", ...)`. Now async.

### Files touched

- `services/blob-gateway/src/middleware/billing-402.ts`
- `services/blob-gateway/src/billing/chain_query.ts`
- `services/blob-gateway/src/config.ts`
- `services/blob-gateway/src/__tests__/billing-402.test.ts`

### Test counts

- Before: 610 passed + 3 skipped (613 total)
- After: 627 passed + 3 skipped (630 total) — **17 new tests**, all
  green. No regressions.

## Why this matters

PR #43 left the middleware dormant under
`BILLING_ENFORCEMENT_PHASE=off`. The plan was a measured rollout:
off → measurement → live. **None of these defects fires in `off`**, but
every one of them fires the instant ops flips to `live`. Landing the
fixes now lets the live-flip be a one-line env change with no
mid-rollout surprises.

## Test plan

- [x] `pnpm vitest run services/blob-gateway/` — all-green (627 + 3
  skipped)
- [x] `pnpm tsc --noEmit` (in `services/blob-gateway/`) — clean
- [ ] Manual smoke against a preprod gateway with
      `BILLING_ENFORCEMENT_PHASE=measurement` to verify the
      `billing.decision` log fields are populated correctly
      (payer_ss58 vs payer_ss58_claimed split)
- [ ] Manual smoke confirming the `billing.unclassified_route` warn
      fires on a deliberately-unmapped POST route