### PR TITLE
feat(payer-materios-x402): Phase 2.A part 4 — Materios-native x402 payer package

### DIFF
--- a/packages/payer-materios-x402/CHANGELOG.md
+++ b/packages/payer-materios-x402/CHANGELOG.md
@@ -1,0 +1,38 @@
+# @fluxpointstudios/orynq-sdk-payer-materios-x402
+
+## 0.1.0 (2026-05-12)
+
+Initial release — Phase 2.A part 4 of the Materios prepaid-balance pipeline.
+
+### Surface
+
+- `createMateriosPayer({ apiKey })` — api-key passthrough payer. The
+  caller authorizes via `Authorization: Bearer matra_…`; `pay()` throws
+  on 402 because the api-key path doesn't participate in the x402
+  signature exchange (a 402 here means treasury or per-key cap is
+  exhausted, not that auth was missing).
+- `createMateriosPayer({ signerUri })` — sr25519 self-pay payer.
+  Signs the canonical materios-x402 preimage with the caller's own
+  keypair (mnemonic / raw seed / `//Alice` derivation). The gateway
+  later debits `pallet-billing::Balances` for the signing SS58.
+- `buildMateriosPayPreimage(payload)` — pure preimage builder, exported
+  so downstream verifiers (Rust pallet, Python daemons, third-party
+  TypeScript) can share the byte-for-byte wire-format contract.
+- `parseMateriosPaymentRequired(headerValue)` — parse + validate a
+  gateway-emitted `X-402-Payment-Required` JSON header.
+- `verifyMateriosPaymentSignature(...)` — sr25519 signature verifier
+  using the canonical preimage hash. Test helper + standalone verifier.
+
+### Wire-format contract (v1)
+
+Domain separator: `materios-x402-v1` (16-byte UTF-8 prefix). Layout
+documented in `src/preimage.ts`; byte-pinned in
+`src/__tests__/preimage.test.ts`. Rolling the format = bump the domain
+separator (e.g. `v2`); old signatures naturally become invalid.
+
+### Pipeline
+
+Closes the client side of Phase 2.A:
+- `pallet-billing` (Materios runtime, PRs #19/#20/#21) — on-chain state
+- gateway 402 middleware (orynq-sdk PRs #43, #44) — emits the headers
+- **this package** — generates the signed retry payload

--- a/packages/payer-materios-x402/README.md
+++ b/packages/payer-materios-x402/README.md
@@ -1,0 +1,109 @@
+# @fluxpointstudios/orynq-sdk-payer-materios-x402
+
+Materios-native sr25519 x402 payer + api-key passthrough for the Materios
+billing gateway.
+
+This package closes the client-side x402 loop for Materios billing. The
+gateway 402 middleware
+([services/blob-gateway/src/middleware/billing-402.ts][gw]) emits an
+`X-402-Payment-Required` header on requests that lack sufficient
+`pallet-billing::Balances`; this package generates the matching
+`x-402-payment-signature` + `x-402-payer-ss58` headers the client returns
+on the retry.
+
+[gw]: ../../services/blob-gateway/src/middleware/billing-402.ts
+
+## Install
+
+```bash
+pnpm add @fluxpointstudios/orynq-sdk-payer-materios-x402
+```
+
+## Quick start
+
+### Self-pay (sr25519)
+
+The caller signs the canonical materios-x402 preimage with their own
+sr25519 key. The gateway debits `pallet-billing::Balances` for the SS58
+that signed.
+
+```ts
+import {
+  createMateriosPayer,
+  parseMateriosPaymentRequired,
+  unpackPaymentProofHeaders,
+} from "@fluxpointstudios/orynq-sdk-payer-materios-x402";
+
+const payer = createMateriosPayer({
+  // mnemonic, raw `0x<64-hex>` seed, or `//Alice` dev derivation
+  signerUri: process.env.MATERIOS_SIGNER_URI!,
+});
+
+// Original request returns 402:
+const response = await fetch(url, originalOpts);
+if (response.status === 402) {
+  const payload = parseMateriosPaymentRequired(
+    response.headers.get("X-402-Payment-Required")!,
+  );
+  const proof = await payer.pay({
+    protocol: "x402",
+    chain: "materios:preprod",
+    asset: "MATRA",
+    amountUnits: payload.pricing.amount,
+    payTo: payload.recipient,
+    raw: payload,
+  });
+  const headers = unpackPaymentProofHeaders(proof.signature);
+  // Retry the original request with the headers attached:
+  await fetch(url, {
+    ...originalOpts,
+    headers: { ...originalOpts.headers, ...headers },
+  });
+}
+```
+
+### API-key (FPS-sponsored)
+
+If you have an FPS-issued `matra_…` Bearer token, you don't sign — the
+api-key already authorizes the FPS treasury to sponsor your request. If
+the gateway still 402s while a valid api-key is attached, the treasury or
+your per-key cap is exhausted; `pay()` throws with an actionable message.
+
+```ts
+const payer = createMateriosPayer({ apiKey: process.env.MATRA_API_KEY! });
+// Attach `Authorization: Bearer ${apiKey}` to your requests as usual.
+// On 402, `payer.pay(...)` throws — surface the message to the user.
+```
+
+## Wire-format contract
+
+The canonical preimage signed by the self-pay path is **v1** and matches
+the layout documented in [`src/preimage.ts`](./src/preimage.ts) and
+byte-pinned by [`src/__tests__/preimage.test.ts`](./src/__tests__/preimage.test.ts):
+
+```
+canonical_preimage = concat(
+  utf8("materios-x402-v1"),               // 16-byte domain separator
+  u32_le(len(endpointClass)) || utf8(endpointClass),
+  u128_le(BigInt(pricing.amount)),
+  bytes32(payload.nonce),                 // 32 raw bytes from "0x<64-hex>"
+  u64_le(payload.expires)
+)
+```
+
+The signed message is `blake2_256(canonical_preimage)`. Verifiers MUST
+mirror this layout byte-for-byte; bumping the domain separator (e.g.
+`materios-x402-v2`) is the canonical way to roll the format without risk
+of cross-version replay.
+
+## Provenance
+
+- Phase 2.A part 4 of the prepaid-balance pipeline. Design ref:
+  `/home/deci/work/phase-2-prepaid-balance-design.md`.
+- Pairs with:
+  - `pallet-billing` (Materios runtime, PRs #19/#20/#21)
+  - gateway 402 middleware (orynq-sdk PRs #43, #44)
+
+## License
+
+MIT.

--- a/packages/payer-materios-x402/package.json
+++ b/packages/payer-materios-x402/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@fluxpointstudios/orynq-sdk-payer-materios-x402",
+  "version": "0.1.0",
+  "description": "Materios-native sr25519 x402 payer + api-key passthrough for Materios billing gateway.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "clean": "rimraf dist"
+  },
+  "keywords": [
+    "orynq",
+    "materios",
+    "x402",
+    "402",
+    "payments",
+    "billing",
+    "sr25519",
+    "substrate"
+  ],
+  "author": "Flux Point Studios",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Flux-Point-Studios/orynq-sdk",
+    "directory": "packages/payer-materios-x402"
+  },
+  "homepage": "https://github.com/Flux-Point-Studios/orynq-sdk#readme",
+  "bugs": "https://github.com/Flux-Point-Studios/orynq-sdk/issues",
+  "dependencies": {
+    "@fluxpointstudios/orynq-sdk-core": "workspace:*",
+    "@fluxpointstudios/orynq-sdk-transport-x402": "workspace:*",
+    "@polkadot/keyring": "^13.0.0",
+    "@polkadot/util": "^13.0.0",
+    "@polkadot/util-crypto": "^13.0.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.2.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "sideEffects": false
+}

--- a/packages/payer-materios-x402/src/__tests__/payer.test.ts
+++ b/packages/payer-materios-x402/src/__tests__/payer.test.ts
@@ -1,0 +1,294 @@
+/**
+ * @summary Behavioral tests for the materios-x402 payer factory + paths.
+ *
+ * Covers:
+ *  - factory routing (api-key vs self-pay)
+ *  - api-key path fail-fast
+ *  - self-pay validation (scheme, expires, nonce, amount)
+ *  - self-pay sign → verify roundtrip against //Alice
+ *  - PaymentProof header shape (sig hex, ss58 prefix-42)
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  cryptoWaitReady,
+  sr25519Verify,
+  blake2AsU8a,
+  decodeAddress,
+  encodeAddress,
+} from "@polkadot/util-crypto";
+import { Keyring } from "@polkadot/keyring";
+import {
+  createMateriosPayer,
+  MateriosApiKeyPayer,
+  MateriosSelfPayPayer,
+  parseMateriosPaymentRequired,
+  validatePayload,
+  unpackPaymentProofHeaders,
+  verifyMateriosPaymentSignature,
+  buildMateriosPayPreimage,
+} from "../index.js";
+import type { MateriosPaymentPayload } from "../types.js";
+import type { PaymentRequest } from "@fluxpointstudios/orynq-sdk-core";
+
+const NONCE_FIXED =
+  "0x" +
+  "00112233445566778899aabbccddeeff" +
+  "00112233445566778899aabbccddeeff";
+
+// Build a fresh payload with `expires` always 60s in the future relative
+// to the test wall-clock. Tests that need an expired payload pass a
+// negative offset.
+function freshPayload(opts?: Partial<MateriosPaymentPayload> & {
+  expiresOffsetSec?: number;
+}): MateriosPaymentPayload {
+  const offset = opts?.expiresOffsetSec ?? 60;
+  const base: MateriosPaymentPayload = {
+    scheme: "materios-x402",
+    chain: "materios",
+    network: "preprod",
+    endpointClass: "receipt_submit",
+    pricing: { token: "MATRA", decimals: 15, amount: "1000000" },
+    recipient: "pallet-billing",
+    nonce: NONCE_FIXED,
+    expires: Math.floor(Date.now() / 1000) + offset,
+  };
+  return { ...base, ...(opts ?? {}) };
+}
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Factory routing
+// ---------------------------------------------------------------------------
+
+describe("createMateriosPayer factory", () => {
+  it("routes { apiKey } to MateriosApiKeyPayer", () => {
+    const payer = createMateriosPayer({ apiKey: "matra_abcdefgh" });
+    expect(payer).toBeInstanceOf(MateriosApiKeyPayer);
+  });
+
+  it("routes { signerUri } to MateriosSelfPayPayer", () => {
+    const payer = createMateriosPayer({ signerUri: "//Alice" });
+    expect(payer).toBeInstanceOf(MateriosSelfPayPayer);
+  });
+
+  it("throws when neither apiKey nor signerUri is provided", () => {
+    expect(() =>
+      // @ts-expect-error — intentional invalid call shape
+      createMateriosPayer({}),
+    ).toThrow(/either \{ apiKey \}|signerUri/);
+  });
+
+  it("throws when both apiKey and signerUri are provided", () => {
+    expect(() =>
+      // @ts-expect-error — intentional invalid call shape
+      createMateriosPayer({ apiKey: "matra_x", signerUri: "//Alice" }),
+    ).toThrow(/not both/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. api-key path
+// ---------------------------------------------------------------------------
+
+describe("MateriosApiKeyPayer", () => {
+  it("pay() throws a descriptive PaymentFailedError mentioning the api-key situation", async () => {
+    const payer = createMateriosPayer({ apiKey: "matra_abcdefgh" });
+    const req: PaymentRequest = {
+      protocol: "x402",
+      chain: "materios:preprod",
+      asset: "MATRA",
+      amountUnits: "1000000",
+      payTo: "pallet-billing",
+    };
+    await expect(payer.pay(req)).rejects.toThrow(
+      /api-key|treasury|cap|self-pay/i,
+    );
+  });
+
+  it("supports() returns true for materios x402 requests", () => {
+    const payer = createMateriosPayer({ apiKey: "matra_abcdefgh" });
+    expect(
+      payer.supports({
+        protocol: "x402",
+        chain: "materios:preprod",
+        asset: "MATRA",
+        amountUnits: "1",
+        payTo: "x",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a malformed api key", () => {
+    expect(() => new MateriosApiKeyPayer({ apiKey: "not-prefixed" })).toThrow(
+      /matra_/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Self-pay parsing + validation
+// ---------------------------------------------------------------------------
+
+describe("parseMateriosPaymentRequired / validatePayload", () => {
+  it("parses a valid header value", () => {
+    const payload = freshPayload();
+    const headerValue = JSON.stringify(payload);
+    const parsed = parseMateriosPaymentRequired(headerValue);
+    expect(parsed.scheme).toBe("materios-x402");
+    expect(parsed.endpointClass).toBe("receipt_submit");
+  });
+
+  it("rejects a header with scheme !== 'materios-x402'", () => {
+    const headerValue = JSON.stringify({
+      ...freshPayload(),
+      scheme: "x402-evm",
+    });
+    expect(() => parseMateriosPaymentRequired(headerValue)).toThrow(
+      /materios-x402/,
+    );
+  });
+
+  it("rejects a payload with expires in the past", () => {
+    const payload = freshPayload({ expiresOffsetSec: -60 });
+    expect(() => validatePayload(payload)).toThrow(/expired/);
+  });
+
+  it("rejects a payload with malformed nonce (not 0x + 64-hex)", () => {
+    const payload = freshPayload({ nonce: "0xdeadbeef" });
+    expect(() => validatePayload(payload)).toThrow(/nonce/);
+  });
+
+  it("rejects a payload with non-numeric pricing.amount", () => {
+    const payload = freshPayload({
+      pricing: { token: "MATRA", decimals: 15, amount: "abc" },
+    });
+    expect(() => validatePayload(payload)).toThrow(/pricing\.amount/);
+  });
+
+  it("rejects malformed JSON in the header value", () => {
+    expect(() => parseMateriosPaymentRequired("not-json-at-all")).toThrow(
+      /not valid JSON/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Self-pay sign + verify roundtrip
+// ---------------------------------------------------------------------------
+
+describe("MateriosSelfPayPayer sign/verify roundtrip", () => {
+  it("signs a known-good payload and the signature verifies against the keypair's public key", async () => {
+    const payer = new MateriosSelfPayPayer({ signerUri: "//Alice" });
+    const payload = freshPayload();
+    const result = await payer.signMateriosPaymentRequest(payload);
+
+    // sr25519 signatures are non-deterministic — we cannot pin the sig
+    // bytes themselves. Instead, verify the signature.
+    expect(result.headers["x-402-payment-signature"]).toMatch(
+      /^0x[0-9a-f]{128}$/,
+    );
+
+    // Decode the SS58 to grab the raw public key (32 bytes) for verification.
+    const publicKey = decodeAddress(result.headers["x-402-payer-ss58"]);
+    expect(publicKey.length).toBe(32);
+
+    const preimage = buildMateriosPayPreimage(payload);
+    const message = blake2AsU8a(preimage, 256);
+    const sig = hexToBytes(result.headers["x-402-payment-signature"]);
+    expect(sr25519Verify(message, sig, publicKey)).toBe(true);
+  });
+
+  it("the convenience verifier accepts a valid sig", async () => {
+    const payer = new MateriosSelfPayPayer({ signerUri: "//Alice" });
+    const payload = freshPayload();
+    const result = await payer.signMateriosPaymentRequest(payload);
+    const publicKey = decodeAddress(result.headers["x-402-payer-ss58"]);
+    expect(
+      verifyMateriosPaymentSignature({
+        payload,
+        signatureHex: result.headers["x-402-payment-signature"],
+        publicKey,
+      }),
+    ).toBe(true);
+  });
+
+  it("the convenience verifier rejects a sig from a different signer", async () => {
+    const alicePayer = new MateriosSelfPayPayer({ signerUri: "//Alice" });
+    const payload = freshPayload();
+    const result = await alicePayer.signMateriosPaymentRequest(payload);
+
+    // Derive Bob's public key — different signer, sig must NOT verify.
+    const keyring = new Keyring({ type: "sr25519", ss58Format: 42 });
+    const bob = keyring.addFromUri("//Bob");
+    expect(
+      verifyMateriosPaymentSignature({
+        payload,
+        signatureHex: result.headers["x-402-payment-signature"],
+        publicKey: bob.publicKey,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns a PaymentProof.signature that unpacks into the two header values", async () => {
+    const payer = new MateriosSelfPayPayer({ signerUri: "//Alice" });
+    const payload = freshPayload();
+    const req: PaymentRequest = {
+      protocol: "x402",
+      chain: "materios:preprod",
+      asset: "MATRA",
+      amountUnits: payload.pricing.amount,
+      payTo: payload.recipient,
+      raw: payload,
+    };
+    const proof = await payer.pay(req);
+    expect(proof.kind).toBe("x402-signature");
+    const headers = unpackPaymentProofHeaders((proof as { signature: string }).signature);
+    expect(headers["x-402-payment-signature"]).toMatch(/^0x[0-9a-f]{128}$/);
+    // Re-encode the ss58 with prefix-42 to make the test independent of
+    // any default-prefix drift in @polkadot/keyring.
+    const pk = decodeAddress(headers["x-402-payer-ss58"]);
+    expect(encodeAddress(pk, 42)).toBe(headers["x-402-payer-ss58"]);
+  });
+
+  it("pay() throws if request.raw is missing or malformed", async () => {
+    const payer = new MateriosSelfPayPayer({ signerUri: "//Alice" });
+    const req: PaymentRequest = {
+      protocol: "x402",
+      chain: "materios:preprod",
+      asset: "MATRA",
+      amountUnits: "1",
+      payTo: "pallet-billing",
+      // raw is intentionally undefined
+    };
+    await expect(payer.pay(req)).rejects.toThrow(/materios-x402 payment payload/);
+  });
+
+  it("pay() throws when protocol !== 'x402'", async () => {
+    const payer = new MateriosSelfPayPayer({ signerUri: "//Alice" });
+    const req = {
+      protocol: "flux",
+      chain: "materios:preprod",
+      asset: "MATRA",
+      amountUnits: "1",
+      payTo: "pallet-billing",
+    } as unknown as PaymentRequest;
+    await expect(payer.pay(req)).rejects.toThrow(/only supports x402/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hexToBytes(s: string): Uint8Array {
+  const body = s.startsWith("0x") ? s.slice(2) : s;
+  const out = new Uint8Array(body.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(body.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}

--- a/packages/payer-materios-x402/src/__tests__/preimage.test.ts
+++ b/packages/payer-materios-x402/src/__tests__/preimage.test.ts
@@ -97,6 +97,8 @@ describe("buildMateriosPayPreimage", () => {
   it("BYTE-PIN: matches the canonical layout for the fixed test vector", () => {
     // Layout assembly (LE everywhere except UTF-8 strings):
     //   domain        = "materios-x402-v1"                                            (16 bytes)
+    //   networkLen    = 0x07000000  (= 7 LE)
+    //   networkBytes  = "preprod"                                                     (7 bytes)
     //   endpointLen   = 0x0e000000  (= 14 LE)
     //   endpointBytes = "receipt_submit"                                              (14 bytes)
     //   amount(u128)  = 1000000  -> 40 42 0f 00 00 ... (16 bytes, LE)
@@ -105,6 +107,10 @@ describe("buildMateriosPayPreimage", () => {
     const expectedHex =
       // domain "materios-x402-v1"
       "6d6174657269" + "6f732d783430" + "322d7631" +
+      // u32 LE 7
+      "07000000" +
+      // "preprod" (7 bytes ASCII)
+      "70726570726f64" +
       // u32 LE 14
       "0e000000" +
       // "receipt_submit" (14 bytes ASCII)
@@ -119,8 +125,17 @@ describe("buildMateriosPayPreimage", () => {
     const got = toHex(buildMateriosPayPreimage(PAYLOAD_FIXED));
     expect(got).toBe(expectedHex);
 
-    // Sanity-check total length: 16 + 4 + 14 + 16 + 32 + 8 = 90 bytes = 180 hex chars.
-    expect(got.length).toBe(180);
+    // Sanity-check total length: 16 + 4 + 7 + 4 + 14 + 16 + 32 + 8 = 101 bytes = 202 hex chars.
+    expect(got.length).toBe(202);
+  });
+
+  it("produces a different preimage when network changes (cross-network replay defense)", () => {
+    const preprod = buildMateriosPayPreimage(PAYLOAD_FIXED);
+    const mainnet = buildMateriosPayPreimage({
+      ...PAYLOAD_FIXED,
+      network: "mainnet",
+    });
+    expect(toHex(preprod)).not.toBe(toHex(mainnet));
   });
 
   it("rejects a malformed nonce (not 0x + 64 hex)", () => {

--- a/packages/payer-materios-x402/src/__tests__/preimage.test.ts
+++ b/packages/payer-materios-x402/src/__tests__/preimage.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @summary Byte-pinned tests for the materios-x402 canonical preimage.
+ *
+ * These tests are the WIRE-FORMAT CONTRACT for any downstream verifier.
+ * If a refactor breaks one of the byte-pin assertions below, the format
+ * has shifted and every verifier (gateway settlement signer, future Rust
+ * pallet check, Python daemons, etc) must update in lockstep — or, the
+ * domain separator must bump from `v1` to `v2`.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildMateriosPayPreimage,
+  PREIMAGE_DOMAIN_SEPARATOR,
+} from "../preimage.js";
+import type { MateriosPaymentPayload } from "../types.js";
+
+const NONCE_FIXED =
+  "0x" +
+  "00112233445566778899aabbccddeeff" +
+  "00112233445566778899aabbccddeeff";
+
+const PAYLOAD_FIXED: MateriosPaymentPayload = {
+  scheme: "materios-x402",
+  chain: "materios",
+  network: "preprod",
+  endpointClass: "receipt_submit",
+  pricing: { token: "MATRA", decimals: 15, amount: "1000000" },
+  recipient: "pallet-billing",
+  nonce: NONCE_FIXED,
+  expires: 1700000000,
+};
+
+/**
+ * Hex-encode a Uint8Array for human-readable assertions.
+ */
+function toHex(b: Uint8Array): string {
+  return Array.from(b)
+    .map((n) => n.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+describe("PREIMAGE_DOMAIN_SEPARATOR", () => {
+  it("is exactly the UTF-8 bytes of 'materios-x402-v1' (16 bytes)", () => {
+    expect(PREIMAGE_DOMAIN_SEPARATOR.length).toBe(16);
+    expect(toHex(PREIMAGE_DOMAIN_SEPARATOR)).toBe(
+      // m a t e r i o s - x 4 0 2 - v 1
+      "6d6174657269" + "6f732d783430" + "322d7631",
+    );
+  });
+});
+
+describe("buildMateriosPayPreimage", () => {
+  it("is byte-deterministic across two calls with the same input", () => {
+    const a = buildMateriosPayPreimage(PAYLOAD_FIXED);
+    const b = buildMateriosPayPreimage(PAYLOAD_FIXED);
+    expect(toHex(a)).toBe(toHex(b));
+  });
+
+  it("produces a different preimage when endpointClass changes (anti-collision)", () => {
+    const a = buildMateriosPayPreimage(PAYLOAD_FIXED);
+    const b = buildMateriosPayPreimage({
+      ...PAYLOAD_FIXED,
+      endpointClass: "chunk_upload",
+    });
+    expect(toHex(a)).not.toBe(toHex(b));
+  });
+
+  it("produces a different preimage when pricing.amount changes", () => {
+    const a = buildMateriosPayPreimage(PAYLOAD_FIXED);
+    const b = buildMateriosPayPreimage({
+      ...PAYLOAD_FIXED,
+      pricing: { ...PAYLOAD_FIXED.pricing, amount: "1000001" },
+    });
+    expect(toHex(a)).not.toBe(toHex(b));
+  });
+
+  it("produces a different preimage when nonce changes", () => {
+    const a = buildMateriosPayPreimage(PAYLOAD_FIXED);
+    const altNonce = "0x" + "ff".repeat(32);
+    const b = buildMateriosPayPreimage({
+      ...PAYLOAD_FIXED,
+      nonce: altNonce,
+    });
+    expect(toHex(a)).not.toBe(toHex(b));
+  });
+
+  it("produces a different preimage when expires changes", () => {
+    const a = buildMateriosPayPreimage(PAYLOAD_FIXED);
+    const b = buildMateriosPayPreimage({
+      ...PAYLOAD_FIXED,
+      expires: PAYLOAD_FIXED.expires + 1,
+    });
+    expect(toHex(a)).not.toBe(toHex(b));
+  });
+
+  it("BYTE-PIN: matches the canonical layout for the fixed test vector", () => {
+    // Layout assembly (LE everywhere except UTF-8 strings):
+    //   domain        = "materios-x402-v1"                                            (16 bytes)
+    //   endpointLen   = 0x0e000000  (= 14 LE)
+    //   endpointBytes = "receipt_submit"                                              (14 bytes)
+    //   amount(u128)  = 1000000  -> 40 42 0f 00 00 ... (16 bytes, LE)
+    //   nonce(32)     = 00112233445566778899aabbccddeeff (×2)
+    //   expires(u64)  = 1_700_000_000 = 0x6553F100 -> LE 00 F1 53 65 00 00 00 00
+    const expectedHex =
+      // domain "materios-x402-v1"
+      "6d6174657269" + "6f732d783430" + "322d7631" +
+      // u32 LE 14
+      "0e000000" +
+      // "receipt_submit" (14 bytes ASCII)
+      "726563656970745f7375626d6974" +
+      // u128 LE 1_000_000 (0x0F4240)
+      "40420f00000000000000000000000000" +
+      // nonce 32 bytes
+      "00112233445566778899aabbccddeeff" +
+      "00112233445566778899aabbccddeeff" +
+      // u64 LE 1_700_000_000 (0x6553F100)
+      "00f1536500000000";
+    const got = toHex(buildMateriosPayPreimage(PAYLOAD_FIXED));
+    expect(got).toBe(expectedHex);
+
+    // Sanity-check total length: 16 + 4 + 14 + 16 + 32 + 8 = 90 bytes = 180 hex chars.
+    expect(got.length).toBe(180);
+  });
+
+  it("rejects a malformed nonce (not 0x + 64 hex)", () => {
+    expect(() =>
+      buildMateriosPayPreimage({ ...PAYLOAD_FIXED, nonce: "0xdeadbeef" }),
+    ).toThrow(/decodeFixedHex/);
+  });
+
+  it("rejects a pricing.amount that is not a BigInt-parseable string", () => {
+    expect(() =>
+      buildMateriosPayPreimage({
+        ...PAYLOAD_FIXED,
+        pricing: { ...PAYLOAD_FIXED.pricing, amount: "not-a-number" },
+      }),
+    ).toThrow(/pricing\.amount/);
+  });
+});

--- a/packages/payer-materios-x402/src/api-key.ts
+++ b/packages/payer-materios-x402/src/api-key.ts
@@ -1,0 +1,117 @@
+/**
+ * @summary api-key passthrough materios-x402 payer.
+ *
+ * The api-key path conveys authorization via the existing
+ * `Authorization: Bearer matra_…` header, NOT via the x402
+ * `x-402-payment-signature` mechanism. The gateway's `identifyPayer`
+ * (services/blob-gateway/src/middleware/billing-402.ts) treats the
+ * api-key as proof that the FPS treasury sponsors the request.
+ *
+ * Therefore, when the gateway emits a 402 to a client that ALREADY
+ * presented a valid api-key, retrying with the same api-key + an x402
+ * payment signature won't help — the 402 means the treasury balance or
+ * per-key cap is exhausted, not that the auth was missing.
+ *
+ * This payer's `pay()` therefore throws a descriptive error immediately
+ * so the caller can:
+ *   1. Surface the message to the user (e.g. "your sponsor's daily cap
+ *      is exhausted, contact account manager"),
+ *   2. Fall back to a `MateriosSelfPayPayer` if they have an sr25519 key
+ *      configured.
+ *
+ * Used by:
+ * - `createMateriosPayer({ apiKey })` factory in index.ts
+ */
+
+import type {
+  ChainId,
+  Payer,
+  PaymentProof,
+  PaymentRequest,
+} from "@fluxpointstudios/orynq-sdk-core";
+import { PaymentFailedError } from "@fluxpointstudios/orynq-sdk-core";
+import { MATERIOS_CHAINS } from "./self-pay.js";
+
+/**
+ * Configuration for `MateriosApiKeyPayer`.
+ */
+export interface MateriosApiKeyPayerConfig {
+  /**
+   * Bearer token issued by FPS — `matra_<base62>`. The gateway treats
+   * this as authorization for the FPS treasury to sponsor the request.
+   * Must be sent in the original request's `Authorization` header by
+   * whatever transport layer the caller uses; this payer does NOT
+   * inject it.
+   */
+  apiKey: string;
+}
+
+/**
+ * api-key materios-x402 Payer. Conforms to the generic `Payer`
+ * interface but throws on `pay()` because the api-key path doesn't
+ * participate in the x402 payment-signature protocol — see file
+ * docstring for the full rationale.
+ */
+export class MateriosApiKeyPayer implements Payer {
+  readonly supportedChains: readonly ChainId[] = MATERIOS_CHAINS;
+
+  readonly apiKey: string;
+
+  constructor(config: MateriosApiKeyPayerConfig) {
+    if (
+      typeof config.apiKey !== "string" ||
+      !config.apiKey.startsWith("matra_") ||
+      config.apiKey.length < "matra_".length + 8
+    ) {
+      throw new Error(
+        'MateriosApiKeyPayer: apiKey must be a "matra_"-prefixed string of length >= 14',
+      );
+    }
+    this.apiKey = config.apiKey;
+  }
+
+  supports(request: PaymentRequest): boolean {
+    return (
+      request.protocol === "x402" &&
+      this.supportedChains.includes(request.chain)
+    );
+  }
+
+  /**
+   * The api-key payer has no on-chain address — it authorizes against
+   * the FPS treasury account whose SS58 only the gateway knows. Returns
+   * a sentinel string so the `Payer` interface contract is honored
+   * without claiming a misleading identity.
+   */
+  async getAddress(_chain: ChainId): Promise<string> {
+    return "fps-treasury";
+  }
+
+  /**
+   * No balance probe — see file docstring. Returns 0 rather than
+   * throwing because some callers query balance speculatively before
+   * `pay()` and a throw here would noise their logs without giving
+   * them any actionable information.
+   */
+  async getBalance(_chain: ChainId, _asset: string): Promise<bigint> {
+    return 0n;
+  }
+
+  /**
+   * Fail fast — see file docstring. The error message tells the caller
+   * exactly what to do: contact account manager to top up the
+   * treasury, or switch to a self-pay flow.
+   */
+  async pay(request: PaymentRequest): Promise<PaymentProof> {
+    throw new PaymentFailedError(
+      request,
+      "MateriosApiKeyPayer cannot sign an x402 retry: the api-key conveys " +
+        "authorization via the `Authorization: Bearer matra_…` header, not " +
+        "via x402 payment-signature. A 402 returned while a valid api-key " +
+        "was attached means the FPS treasury balance is exhausted, the " +
+        "per-key daily cap was reached, or the api-key was rejected. " +
+        "Contact your account manager to top up, or switch to a " +
+        "self-pay (sr25519 signerUri) configuration.",
+    );
+  }
+}

--- a/packages/payer-materios-x402/src/index.ts
+++ b/packages/payer-materios-x402/src/index.ts
@@ -1,0 +1,198 @@
+/**
+ * @summary Public entry point for @fluxpointstudios/orynq-sdk-payer-materios-x402.
+ *
+ * This package provides a Materios-native x402 payer implementation that
+ * closes the client-side x402 loop for the Materios billing gateway. The
+ * gateway 402 middleware (services/blob-gateway/src/middleware/billing-402.ts)
+ * emits x402 headers when a request lacks sufficient `pallet-billing::Balances`
+ * — this package generates the matching payment proof a client returns to
+ * retry the request.
+ *
+ * Two configuration shapes are supported, mapped 1:1 to the two payer
+ * paths the gateway recognises:
+ *
+ * 1. **api-key path** — caller already authorizes via
+ *    `Authorization: Bearer matra_…`. The FPS treasury sponsors the
+ *    request. No x402 sign step is needed; `pay()` throws if a 402 still
+ *    arrives (treasury exhausted / per-key cap hit). See `api-key.ts`.
+ *
+ * 2. **self-pay path** — caller signs the canonical materios-x402
+ *    preimage with their own sr25519 key. The resulting headers
+ *    (`x-402-payment-signature`, `x-402-payer-ss58`) are returned on the
+ *    `PaymentProof`. The gateway verifies + submits the on-chain debit
+ *    against `pallet-billing::Balances`. See `self-pay.ts`.
+ *
+ * Usage:
+ * ```ts
+ * import { createMateriosPayer, parseMateriosPaymentRequired }
+ *   from "@fluxpointstudios/orynq-sdk-payer-materios-x402";
+ *
+ * // self-pay path
+ * const payer = createMateriosPayer({ signerUri: "//Alice" });
+ *
+ * // On a 402:
+ * const payload = parseMateriosPaymentRequired(
+ *   response.headers.get("X-402-Payment-Required")!
+ * );
+ * const proof = await payer.pay({
+ *   protocol: "x402",
+ *   chain: "materios:preprod",
+ *   asset: "MATRA",
+ *   amountUnits: payload.pricing.amount,
+ *   payTo: payload.recipient,
+ *   raw: payload,
+ * });
+ * // → proof.signature carries the headers for the retry.
+ * ```
+ *
+ * Wire-format contract:
+ * The canonical preimage layout is documented in `preimage.ts` and pinned
+ * by `__tests__/preimage.test.ts`. Gateway-side verifiers MUST mirror it
+ * byte-for-byte.
+ *
+ * Used by:
+ * - Materios billing clients (browser + Node.js)
+ * - The orynq-sdk client SDK for automatic 402 retry handling
+ * - Downstream verifiers that want to share the preimage builder
+ */
+
+import type { Payer } from "@fluxpointstudios/orynq-sdk-core";
+import {
+  MateriosApiKeyPayer,
+  type MateriosApiKeyPayerConfig,
+} from "./api-key.js";
+import {
+  MateriosSelfPayPayer,
+  MATERIOS_CHAINS,
+  parseMateriosPaymentRequired,
+  validatePayload,
+  unpackPaymentProofHeaders,
+  verifyMateriosPaymentSignature,
+  type MateriosSelfPayPayerConfig,
+} from "./self-pay.js";
+import { buildMateriosPayPreimage, PREIMAGE_DOMAIN_SEPARATOR } from "./preimage.js";
+import { isMateriosPaymentPayload } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminator-shape config for the api-key path. `{ apiKey }` (with no
+ * `signerUri`) routes to `MateriosApiKeyPayer`.
+ */
+export type MateriosApiKeyPayerOpts = MateriosApiKeyPayerConfig & {
+  signerUri?: never;
+};
+
+/**
+ * Discriminator-shape config for the self-pay path. `{ signerUri }` (with
+ * no `apiKey`) routes to `MateriosSelfPayPayer`.
+ */
+export type MateriosSelfPayPayerOpts = MateriosSelfPayPayerConfig & {
+  apiKey?: never;
+};
+
+/**
+ * Union of the two supported configuration shapes. TypeScript will narrow
+ * inside `createMateriosPayer` based on which key is present.
+ */
+export type MateriosPayerOpts =
+  | MateriosApiKeyPayerOpts
+  | MateriosSelfPayPayerOpts;
+
+/**
+ * Factory entry point. Routes to `MateriosApiKeyPayer` when `apiKey` is
+ * provided, or `MateriosSelfPayPayer` when `signerUri` is provided.
+ * Throws if neither (or both) is present — the two paths are mutually
+ * exclusive on purpose; a single caller should pick one.
+ *
+ * @example
+ * ```ts
+ * // api-key (FPS-sponsored)
+ * const payer = createMateriosPayer({ apiKey: "matra_abc123…" });
+ *
+ * // self-pay (sr25519)
+ * const payer = createMateriosPayer({ signerUri: "your mnemonic phrase here" });
+ * ```
+ */
+export function createMateriosPayer(opts: MateriosPayerOpts): Payer {
+  const hasApiKey = "apiKey" in opts && typeof opts.apiKey === "string";
+  const hasSigner =
+    "signerUri" in opts && typeof opts.signerUri === "string";
+
+  if (hasApiKey && hasSigner) {
+    throw new Error(
+      "createMateriosPayer: provide either { apiKey } or { signerUri }, not both.",
+    );
+  }
+  if (hasApiKey) {
+    return new MateriosApiKeyPayer({ apiKey: (opts as MateriosApiKeyPayerOpts).apiKey });
+  }
+  if (hasSigner) {
+    const o = opts as MateriosSelfPayPayerOpts;
+    return new MateriosSelfPayPayer({
+      signerUri: o.signerUri,
+      ...(o.ss58Prefix !== undefined ? { ss58Prefix: o.ss58Prefix } : {}),
+    });
+  }
+  throw new Error(
+    "createMateriosPayer: must provide either { apiKey: 'matra_…' } or { signerUri: '<mnemonic>' }.",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public re-exports
+// ---------------------------------------------------------------------------
+
+export {
+  MateriosApiKeyPayer,
+  type MateriosApiKeyPayerConfig,
+} from "./api-key.js";
+export {
+  MateriosSelfPayPayer,
+  MATERIOS_CHAINS,
+  parseMateriosPaymentRequired,
+  validatePayload,
+  unpackPaymentProofHeaders,
+  verifyMateriosPaymentSignature,
+  type MateriosSelfPayPayerConfig,
+} from "./self-pay.js";
+export {
+  buildMateriosPayPreimage,
+  PREIMAGE_DOMAIN_SEPARATOR,
+} from "./preimage.js";
+export {
+  isMateriosPaymentPayload,
+  type MateriosPaymentPayload,
+  type ValidatedMateriosPayload,
+  type MateriosPaymentProofHeaders,
+} from "./types.js";
+
+// Silence "unused import" — the re-exports above suffice, but keeping the
+// imports near the top of the file makes the dependency graph obvious to
+// readers. The TS compiler treats `export { … } from "./module.js"` as
+// type-and-value re-export, so the direct imports here aren't strictly
+// required at runtime — they're a deliberate documentation hint.
+void MateriosApiKeyPayer;
+void MateriosSelfPayPayer;
+void MATERIOS_CHAINS;
+void parseMateriosPaymentRequired;
+void validatePayload;
+void unpackPaymentProofHeaders;
+void verifyMateriosPaymentSignature;
+void buildMateriosPayPreimage;
+void PREIMAGE_DOMAIN_SEPARATOR;
+void isMateriosPaymentPayload;
+
+// Version constant — bumped alongside the `version` in package.json.
+// Kept in sync manually; the build does NOT auto-stamp it (tsup doesn't
+// have a built-in version-injector and we don't want a postinstall script).
+export const VERSION = "0.1.0";
+
+// Type-only re-exports require the types to be referenced somewhere for
+// the tsc cli to keep them in the .d.ts. The `type` re-exports above
+// already accomplish this, so we don't need void-references for them.
+export type {
+  MateriosPayerOpts as _MateriosPayerOpts,
+};

--- a/packages/payer-materios-x402/src/preimage.ts
+++ b/packages/payer-materios-x402/src/preimage.ts
@@ -15,12 +15,21 @@
  * ```
  * canonical_preimage = concat(
  *   utf8("materios-x402-v1"),       // 16-byte fixed domain separator
+ *   u32_le(len(network_utf8)) || utf8(payload.network),  // network binding (preprod|mainnet)
  *   utf8_length_prefix_u32_le(endpointClass) || utf8(endpointClass),
  *   u128_le_bytes(BigInt(pricing.amount)),
  *   bytes32(payload.nonce),         // 32 raw bytes from `0x<64-hex>`
  *   u64_le_bytes(payload.expires)
  * )
  * ```
+ *
+ * The `network` field is bound into the preimage so a signature scoped to
+ * preprod CANNOT verify against mainnet (or any future network), even
+ * though both share the same `materios-x402-v1` protocol domain. Without
+ * this binding, a captured preprod signature could be replayed on mainnet
+ * if the same (endpointClass, amount, nonce, expires) tuple recurred.
+ * `validatePayload` enforces `network ∈ {"preprod", "mainnet"}` so the
+ * binding can't be sidestepped by submitting a junk network string.
  *
  * The signer hashes this with blake2-256 before signing, matching the
  * substrate convention used by `pallet-billing` extrinsics. Verifiers
@@ -203,6 +212,12 @@ export function buildMateriosPayPreimage(
   // Domain-sep prefix (16 bytes).
   const domain = PREIMAGE_DOMAIN_SEPARATOR;
 
+  // Length-prefixed network (u32 LE length || utf8 bytes). Binds the
+  // signature to a single network — a preprod sig can never verify on
+  // mainnet, even with otherwise-identical fields.
+  const networkBytes = new TextEncoder().encode(payload.network);
+  const networkLen = u32LeBytes(networkBytes.length);
+
   // Length-prefixed endpoint class (u32 LE length || utf8 bytes).
   const endpointBytes = new TextEncoder().encode(payload.endpointClass);
   const endpointLen = u32LeBytes(endpointBytes.length);
@@ -226,6 +241,8 @@ export function buildMateriosPayPreimage(
 
   return concatBytes(
     domain,
+    networkLen,
+    networkBytes,
     endpointLen,
     endpointBytes,
     amountBytes,

--- a/packages/payer-materios-x402/src/preimage.ts
+++ b/packages/payer-materios-x402/src/preimage.ts
@@ -1,0 +1,235 @@
+/**
+ * @summary Canonical preimage construction for materios-x402 payment-signature.
+ *
+ * The preimage is the byte string a payer signs to prove authorization for
+ * a specific 402'd request. The gateway settlement signer (Materios runtime
+ * side) verifies the same preimage against the sr25519 signature carried in
+ * `x-402-payment-signature` before it submits `pay_request` on chain.
+ *
+ * THIS PACKAGE IS THE SINGLE SOURCE OF TRUTH for the byte layout — any
+ * gateway-side verifier (Rust pallet, Python daemon, TypeScript helper)
+ * MUST mirror it byte-for-byte. Tests pin the format against known vectors
+ * (see `__tests__/preimage.test.ts`).
+ *
+ * Wire-format contract (v1):
+ * ```
+ * canonical_preimage = concat(
+ *   utf8("materios-x402-v1"),       // 16-byte fixed domain separator
+ *   utf8_length_prefix_u32_le(endpointClass) || utf8(endpointClass),
+ *   u128_le_bytes(BigInt(pricing.amount)),
+ *   bytes32(payload.nonce),         // 32 raw bytes from `0x<64-hex>`
+ *   u64_le_bytes(payload.expires)
+ * )
+ * ```
+ *
+ * The signer hashes this with blake2-256 before signing, matching the
+ * substrate convention used by `pallet-billing` extrinsics. Verifiers
+ * MUST hash the same way.
+ *
+ * Why not just sign the raw JSON header? Two reasons:
+ *   1. JSON has multiple valid serializations (key order, whitespace,
+ *      number canonicalization). Signing JSON requires a canonicalizer
+ *      on both sides and adds an attack surface (e.g. duplicate-key
+ *      ambiguity).
+ *   2. The on-chain verifier is in Rust and decodes via SCALE, not JSON.
+ *      A binary preimage that mirrors SCALE-style concatenation keeps
+ *      both sides byte-identical without needing a JSON parser in the
+ *      hot path.
+ *
+ * Used by:
+ * - self-pay.ts to build + sign the preimage
+ * - __tests__/preimage.test.ts as the byte-pinned contract
+ */
+
+import type { MateriosPaymentPayload } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Domain separator
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed 16-byte domain separator for v1 of the materios-x402 preimage.
+ * UTF-8 of the ASCII string `materios-x402-v1`.
+ *
+ * Bumping this constant (e.g. `v2`) is the canonical way to roll the
+ * preimage format. Old signatures naturally become invalid because they
+ * were hashed under a different prefix — there is no risk of cross-version
+ * replay.
+ */
+export const PREIMAGE_DOMAIN_SEPARATOR = new TextEncoder().encode(
+  "materios-x402-v1",
+);
+
+// ---------------------------------------------------------------------------
+// Encoding primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode a u32 as little-endian 4 bytes.
+ */
+function u32LeBytes(n: number): Uint8Array {
+  if (!Number.isInteger(n) || n < 0 || n > 0xffff_ffff) {
+    throw new RangeError(`u32LeBytes: out of range u32 (${n})`);
+  }
+  const out = new Uint8Array(4);
+  out[0] = n & 0xff;
+  out[1] = (n >>> 8) & 0xff;
+  out[2] = (n >>> 16) & 0xff;
+  out[3] = (n >>> 24) & 0xff;
+  return out;
+}
+
+/**
+ * Encode a u64 as little-endian 8 bytes. Accepts `number` or `bigint`;
+ * uses bigint arithmetic to avoid the 2^53 precision cliff.
+ */
+function u64LeBytes(n: number | bigint): Uint8Array {
+  const v = typeof n === "bigint" ? n : BigInt(n);
+  if (v < 0n || v > 0xffff_ffff_ffff_ffffn) {
+    throw new RangeError(`u64LeBytes: out of range u64 (${v.toString()})`);
+  }
+  const out = new Uint8Array(8);
+  let x = v;
+  for (let i = 0; i < 8; i++) {
+    out[i] = Number(x & 0xffn);
+    x >>= 8n;
+  }
+  return out;
+}
+
+/**
+ * Encode a u128 as little-endian 16 bytes.
+ */
+function u128LeBytes(v: bigint): Uint8Array {
+  if (v < 0n || v > (1n << 128n) - 1n) {
+    throw new RangeError(`u128LeBytes: out of range u128 (${v.toString()})`);
+  }
+  const out = new Uint8Array(16);
+  let x = v;
+  for (let i = 0; i < 16; i++) {
+    out[i] = Number(x & 0xffn);
+    x >>= 8n;
+  }
+  return out;
+}
+
+/**
+ * Decode a `0x`-prefixed hex string into a `Uint8Array`. Strict — the
+ * length must be exactly `expectedBytes * 2` (after stripping `0x`) and
+ * every character must be hex. Anything else throws.
+ */
+function decodeFixedHex(s: string, expectedBytes: number): Uint8Array {
+  if (typeof s !== "string" || !s.startsWith("0x")) {
+    throw new Error(
+      `decodeFixedHex: expected "0x"-prefixed hex string, got ${JSON.stringify(s)}`,
+    );
+  }
+  const body = s.slice(2);
+  if (body.length !== expectedBytes * 2) {
+    throw new Error(
+      `decodeFixedHex: expected ${expectedBytes} bytes (${expectedBytes * 2} hex chars), got ${body.length}`,
+    );
+  }
+  if (!/^[0-9a-fA-F]*$/.test(body)) {
+    throw new Error(
+      `decodeFixedHex: non-hex characters in ${JSON.stringify(s)}`,
+    );
+  }
+  const out = new Uint8Array(expectedBytes);
+  for (let i = 0; i < expectedBytes; i++) {
+    out[i] = parseInt(body.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+/**
+ * Concatenate a variadic list of byte arrays into a single buffer. Avoids
+ * allocating intermediate copies that the spread-then-Uint8Array.from
+ * idiom would produce.
+ */
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the canonical preimage bytes for a materios-x402 payment-signature.
+ *
+ * This function is pure and deterministic — same payload bytes in, same
+ * bytes out, always. Callers can sign the returned buffer directly (after
+ * the standard blake2-256 hash step) and the gateway-side verifier will
+ * reconstruct the same bytes for verification.
+ *
+ * The function intentionally does NOT validate semantic constraints
+ * (expires-in-future, nonce length, etc) — that's `validatePayload`'s job.
+ * It does enforce byte-level invariants (nonce is exactly 32 bytes hex,
+ * amount parses as u128, expires fits in u64) so a malformed payload
+ * fails loudly at preimage-construction time rather than producing
+ * silently-wrong bytes.
+ *
+ * @param payload - validated materios-x402 payment payload
+ * @returns canonical preimage as `Uint8Array`
+ *
+ * @example
+ * ```ts
+ * import { buildMateriosPayPreimage } from "@fluxpointstudios/orynq-sdk-payer-materios-x402";
+ *
+ * const preimage = buildMateriosPayPreimage({
+ *   scheme: "materios-x402",
+ *   chain: "materios",
+ *   network: "preprod",
+ *   endpointClass: "receipt_submit",
+ *   pricing: { token: "MATRA", decimals: 15, amount: "1000000" },
+ *   recipient: "pallet-billing",
+ *   nonce: "0x" + "00".repeat(32),
+ *   expires: 1700000000,
+ * });
+ * ```
+ */
+export function buildMateriosPayPreimage(
+  payload: MateriosPaymentPayload,
+): Uint8Array {
+  // Domain-sep prefix (16 bytes).
+  const domain = PREIMAGE_DOMAIN_SEPARATOR;
+
+  // Length-prefixed endpoint class (u32 LE length || utf8 bytes).
+  const endpointBytes = new TextEncoder().encode(payload.endpointClass);
+  const endpointLen = u32LeBytes(endpointBytes.length);
+
+  // u128 LE pricing.amount.
+  let amount: bigint;
+  try {
+    amount = BigInt(payload.pricing.amount);
+  } catch {
+    throw new Error(
+      `buildMateriosPayPreimage: pricing.amount not parseable as BigInt: ${JSON.stringify(payload.pricing.amount)}`,
+    );
+  }
+  const amountBytes = u128LeBytes(amount);
+
+  // Nonce: exactly 32 raw bytes (decoded from `0x` + 64-hex).
+  const nonceBytes = decodeFixedHex(payload.nonce, 32);
+
+  // u64 LE expires.
+  const expiresBytes = u64LeBytes(payload.expires);
+
+  return concatBytes(
+    domain,
+    endpointLen,
+    endpointBytes,
+    amountBytes,
+    nonceBytes,
+    expiresBytes,
+  );
+}

--- a/packages/payer-materios-x402/src/self-pay.ts
+++ b/packages/payer-materios-x402/src/self-pay.ts
@@ -247,6 +247,15 @@ export function validatePayload(
       `materios-x402: unsupported scheme ${JSON.stringify(payload.scheme)} (expected "materios-x402")`,
     );
   }
+  // Network — must be a known Materios network. Enforced so the preimage's
+  // network binding (see preimage.ts wire-format contract) can't be
+  // sidestepped by submitting a junk string. Restrict to the canonical set
+  // we ship today; future networks need an SDK bump.
+  if (payload.network !== "preprod" && payload.network !== "mainnet") {
+    throw new Error(
+      `materios-x402: unsupported network ${JSON.stringify(payload.network)} (expected "preprod" or "mainnet")`,
+    );
+  }
   // Nonce shape
   if (
     typeof payload.nonce !== "string" ||

--- a/packages/payer-materios-x402/src/self-pay.ts
+++ b/packages/payer-materios-x402/src/self-pay.ts
@@ -1,0 +1,394 @@
+/**
+ * @summary Self-pay materios-x402 Payer — caller signs with their own sr25519 key.
+ *
+ * Given a parsed `X-402-Payment-Required` header from the Materios billing
+ * gateway, build the canonical preimage (see `preimage.ts`), sign it with
+ * sr25519, and return a `PaymentProof` whose payload carries the headers
+ * the gateway-side `identifyPayer` expects on the retry:
+ *
+ *   - `x-402-payment-signature: 0x<hex sig>`
+ *   - `x-402-payer-ss58: <ss58 prefix-42 address>`
+ *
+ * The gateway settlement signer will later debit `pallet-billing::Balances`
+ * for the SS58 in `x-402-payer-ss58`, after verifying the signature against
+ * the canonical preimage. This SDK does NOT submit the on-chain debit
+ * directly — that role belongs to the gateway, which is the trusted
+ * settlement signer.
+ *
+ * Used by:
+ * - `createMateriosPayer({ signerUri })` factory in index.ts
+ * - clients that want to drive the materios-x402 flow manually
+ */
+
+import { Keyring } from "@polkadot/keyring";
+import type { KeyringPair } from "@polkadot/keyring/types";
+import {
+  cryptoWaitReady,
+  sr25519Verify,
+  blake2AsU8a,
+} from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+import type {
+  ChainId,
+  Payer,
+  PaymentProof,
+  PaymentRequest,
+} from "@fluxpointstudios/orynq-sdk-core";
+import { PaymentFailedError } from "@fluxpointstudios/orynq-sdk-core";
+import { buildMateriosPayPreimage } from "./preimage.js";
+import {
+  isMateriosPaymentPayload,
+  type MateriosPaymentPayload,
+  type ValidatedMateriosPayload,
+} from "./types.js";
+
+/**
+ * CAIP-2-ish identifier for the Materios chain. We don't have a registered
+ * CAIP-2 namespace yet; `materios:preprod` / `materios:mainnet` are the
+ * project-internal convention.
+ */
+export const MATERIOS_CHAINS = [
+  "materios:preprod",
+  "materios:mainnet",
+] as const;
+
+/**
+ * Default SS58 prefix for Materios. Substrate convention is prefix-42 for
+ * generic substrate chains; we keep this default until Materios registers
+ * a dedicated prefix.
+ */
+const MATERIOS_SS58_PREFIX = 42;
+
+/**
+ * Configuration for `MateriosSelfPayPayer`.
+ */
+export interface MateriosSelfPayPayerConfig {
+  /**
+   * sr25519 signing URI — mnemonic phrase, raw seed `0x<64-hex>`, or a
+   * `//Alice`-style dev-key derivation URI. Forwarded directly to
+   * `Keyring.addFromUri`.
+   */
+  signerUri: string;
+
+  /**
+   * Optional SS58 prefix override. Defaults to 42 (generic substrate).
+   * Useful for testing against chains with non-default prefixes.
+   */
+  ss58Prefix?: number;
+}
+
+/**
+ * Self-pay sr25519 Payer implementation. Conforms to the generic `Payer`
+ * interface from `@fluxpointstudios/orynq-sdk-core` so it can drop into
+ * the same payer-registry plumbing as the EVM / Cardano payers.
+ */
+export class MateriosSelfPayPayer implements Payer {
+  readonly supportedChains: readonly ChainId[] = MATERIOS_CHAINS;
+
+  private readonly signerUri: string;
+  private readonly ss58Prefix: number;
+  private pair: KeyringPair | null = null;
+
+  constructor(config: MateriosSelfPayPayerConfig) {
+    this.signerUri = config.signerUri;
+    this.ss58Prefix = config.ss58Prefix ?? MATERIOS_SS58_PREFIX;
+  }
+
+  /**
+   * Lazily initialise the WASM crypto runtime + derive the keypair. Cached
+   * on first call. Throws if the URI cannot be parsed by `@polkadot/keyring`.
+   */
+  private async getPair(): Promise<KeyringPair> {
+    if (this.pair) return this.pair;
+    await cryptoWaitReady();
+    const keyring = new Keyring({ type: "sr25519", ss58Format: this.ss58Prefix });
+    this.pair = keyring.addFromUri(this.signerUri);
+    return this.pair;
+  }
+
+  supports(request: PaymentRequest): boolean {
+    return (
+      request.protocol === "x402" &&
+      this.supportedChains.includes(request.chain)
+    );
+  }
+
+  async getAddress(_chain: ChainId): Promise<string> {
+    const pair = await this.getPair();
+    return pair.address;
+  }
+
+  /**
+   * Self-pay does not expose an on-chain balance probe — querying
+   * `pallet-billing::Balances` requires the full `@polkadot/api` client
+   * which this package intentionally avoids depending on. Callers that
+   * need a balance reading should hit the gateway's `/billing/usage`
+   * endpoint or instantiate their own `ApiPromise`.
+   *
+   * Returning `0n` here would be misleading; we throw instead so a
+   * caller wiring this into a budget-tracker realises the gap rather
+   * than treating "no balance" as zero.
+   */
+  async getBalance(_chain: ChainId, _asset: string): Promise<bigint> {
+    throw new Error(
+      "MateriosSelfPayPayer.getBalance is not implemented — query the gateway's /billing/usage endpoint or use @polkadot/api directly.",
+    );
+  }
+
+  /**
+   * Execute the x402 sign step against a parsed 402 payload.
+   *
+   * The generic `Payer.pay(request: PaymentRequest)` contract is awkward
+   * for materios-x402: the protocol-neutral `PaymentRequest` doesn't
+   * carry the `endpointClass` / `nonce` / `expires` fields we need to
+   * build the preimage. We extract them from `request.raw` (which
+   * `parsePaymentRequired`-style helpers should populate with the
+   * decoded gateway JSON). Callers driving this payer directly should
+   * prefer `signMateriosPaymentRequest(payload)` below.
+   */
+  async pay(request: PaymentRequest): Promise<PaymentProof> {
+    if (request.protocol !== "x402") {
+      throw new PaymentFailedError(
+        request,
+        `MateriosSelfPayPayer only supports x402 protocol, got: ${request.protocol}`,
+      );
+    }
+    const raw = request.raw;
+    if (!isMateriosPaymentPayload(raw)) {
+      throw new PaymentFailedError(
+        request,
+        "MateriosSelfPayPayer.pay requires `request.raw` to be a materios-x402 payment payload. " +
+          'Use `parseMateriosPaymentRequired(headerValue)` or pass the decoded JSON.',
+      );
+    }
+    const result = await this.signMateriosPaymentRequest(raw);
+    return {
+      kind: "x402-signature",
+      // Pack both headers into the signature field as a `header_name=value;header_name=value`
+      // string. The PaymentProof type doesn't model HTTP headers directly;
+      // packing them here keeps the proof self-contained. Consumers parse
+      // via the exported `unpackPaymentProofHeaders` helper.
+      signature: serializeHeaders(result.headers),
+      payload: JSON.stringify({
+        endpointClass: raw.endpointClass,
+        amount: raw.pricing.amount,
+        nonce: raw.nonce,
+        expires: raw.expires,
+        payer: result.payerSs58,
+      }),
+    };
+  }
+
+  /**
+   * The materios-x402-native entry point. Parses + validates the gateway
+   * payload, builds the canonical preimage, signs it with sr25519, and
+   * returns the two headers the gateway-side `identifyPayer` reads on
+   * retry.
+   *
+   * This method is intentionally separate from `pay()` so callers don't
+   * have to construct a synthetic `PaymentRequest` just to drive the
+   * sign step.
+   */
+  async signMateriosPaymentRequest(
+    payload: MateriosPaymentPayload,
+  ): Promise<{
+    headers: {
+      "x-402-payment-signature": string;
+      "x-402-payer-ss58": string;
+    };
+    payerSs58: string;
+    preimage: Uint8Array;
+  }> {
+    const validated = validatePayload(payload);
+    const pair = await this.getPair();
+    const preimage = buildMateriosPayPreimage(validated);
+    // blake2-256 hash matches what the substrate-side verifier will
+    // re-derive. Signing the hash (not the raw preimage) bounds the
+    // signed-data size to 32 bytes regardless of endpointClass length,
+    // which keeps `sr25519Sign` fast and matches the convention used by
+    // pallet-billing extrinsics.
+    const message = blake2AsU8a(preimage, 256);
+    // `pair.sign(message)` produces the raw 64-byte sr25519 signature —
+    // exactly what `sr25519Verify(message, sig, publicKey)` consumes on
+    // the verification side, and what the gateway settlement signer will
+    // re-check before submitting the on-chain debit.
+    const sigBytes = pair.sign(message);
+    return {
+      headers: {
+        "x-402-payment-signature": u8aToHex(sigBytes),
+        "x-402-payer-ss58": pair.address,
+      },
+      payerSs58: pair.address,
+      preimage,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate the semantic constraints of a materios-x402 payment payload.
+ * Throws with a descriptive message on failure; returns a nominally-tagged
+ * `ValidatedMateriosPayload` on success.
+ *
+ * Constraints enforced (matching gateway billing-402.ts emission):
+ * - `scheme === "materios-x402"`
+ * - `nonce` is `0x` + 64 hex chars (32 bytes)
+ * - `pricing.amount` parses as BigInt (u128 range)
+ * - `expires` is a Unix-seconds timestamp in the future
+ */
+export function validatePayload(
+  payload: MateriosPaymentPayload,
+): ValidatedMateriosPayload {
+  if (payload.scheme !== "materios-x402") {
+    throw new Error(
+      `materios-x402: unsupported scheme ${JSON.stringify(payload.scheme)} (expected "materios-x402")`,
+    );
+  }
+  // Nonce shape
+  if (
+    typeof payload.nonce !== "string" ||
+    !/^0x[0-9a-fA-F]{64}$/.test(payload.nonce)
+  ) {
+    throw new Error(
+      `materios-x402: malformed nonce ${JSON.stringify(payload.nonce)} (expected "0x" + 64 hex chars)`,
+    );
+  }
+  // Amount numeric
+  if (typeof payload.pricing.amount !== "string") {
+    throw new Error(
+      `materios-x402: pricing.amount must be a string, got ${typeof payload.pricing.amount}`,
+    );
+  }
+  if (!/^[0-9]+$/.test(payload.pricing.amount)) {
+    throw new Error(
+      `materios-x402: pricing.amount not a base-10 integer string: ${JSON.stringify(payload.pricing.amount)}`,
+    );
+  }
+  let amount: bigint;
+  try {
+    amount = BigInt(payload.pricing.amount);
+  } catch {
+    throw new Error(
+      `materios-x402: pricing.amount not parseable as BigInt: ${JSON.stringify(payload.pricing.amount)}`,
+    );
+  }
+  if (amount < 0n || amount > (1n << 128n) - 1n) {
+    throw new Error(
+      `materios-x402: pricing.amount out of u128 range: ${amount.toString()}`,
+    );
+  }
+  // Expires in future (with a tiny tolerance for clock skew).
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (!Number.isInteger(payload.expires) || payload.expires < nowSec - 5) {
+    throw new Error(
+      `materios-x402: payment-required expired (expires=${payload.expires}, now=${nowSec})`,
+    );
+  }
+  return payload as ValidatedMateriosPayload;
+}
+
+/**
+ * Parse the raw `X-402-Payment-Required` header value into a typed payload.
+ * Throws on malformed JSON or wrong scheme.
+ */
+export function parseMateriosPaymentRequired(
+  headerValue: string,
+): MateriosPaymentPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(headerValue);
+  } catch (err) {
+    throw new Error(
+      `materios-x402: X-402-Payment-Required is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!isMateriosPaymentPayload(parsed)) {
+    throw new Error(
+      `materios-x402: X-402-Payment-Required does not match scheme materios-x402 (got ${
+        parsed && typeof parsed === "object" && "scheme" in parsed
+          ? JSON.stringify((parsed as Record<string, unknown>).scheme)
+          : "<missing scheme field>"
+      })`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Serialize the two materios-x402 headers into a single string suitable
+ * for `PaymentProof.signature` transport. Format:
+ * `x-402-payment-signature=0x…;x-402-payer-ss58=…`
+ *
+ * Round-trippable via `unpackPaymentProofHeaders` below.
+ */
+function serializeHeaders(h: {
+  "x-402-payment-signature": string;
+  "x-402-payer-ss58": string;
+}): string {
+  return (
+    `x-402-payment-signature=${h["x-402-payment-signature"]};` +
+    `x-402-payer-ss58=${h["x-402-payer-ss58"]}`
+  );
+}
+
+/**
+ * Round-trip helper — extract the two headers from a `PaymentProof.signature`
+ * produced by `MateriosSelfPayPayer.pay()`.
+ */
+export function unpackPaymentProofHeaders(packed: string): {
+  "x-402-payment-signature": string;
+  "x-402-payer-ss58": string;
+} {
+  const out: Record<string, string> = {};
+  for (const part of packed.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    out[part.slice(0, eq)] = part.slice(eq + 1);
+  }
+  const sig = out["x-402-payment-signature"];
+  const ss58 = out["x-402-payer-ss58"];
+  if (typeof sig !== "string" || typeof ss58 !== "string") {
+    throw new Error(
+      "unpackPaymentProofHeaders: missing x-402-payment-signature or x-402-payer-ss58",
+    );
+  }
+  return {
+    "x-402-payment-signature": sig,
+    "x-402-payer-ss58": ss58,
+  };
+}
+
+/**
+ * Verify an sr25519 signature against the canonical materios-x402 preimage
+ * hash. Helper for tests + downstream verifiers that don't want to depend
+ * on the gateway's verification path. Returns true iff the signature is
+ * valid for `(preimage, publicKey)`.
+ */
+export function verifyMateriosPaymentSignature(opts: {
+  payload: MateriosPaymentPayload;
+  signatureHex: string;
+  publicKey: Uint8Array;
+}): boolean {
+  const preimage = buildMateriosPayPreimage(opts.payload);
+  const message = blake2AsU8a(preimage, 256);
+  const sig = hexToBytes(opts.signatureHex);
+  return sr25519Verify(message, sig, opts.publicKey);
+}
+
+function hexToBytes(s: string): Uint8Array {
+  if (typeof s !== "string" || !s.startsWith("0x")) {
+    throw new Error(`hexToBytes: expected "0x"-prefixed hex, got ${JSON.stringify(s)}`);
+  }
+  const body = s.slice(2);
+  if (body.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(body)) {
+    throw new Error(`hexToBytes: malformed hex ${JSON.stringify(s)}`);
+  }
+  const out = new Uint8Array(body.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(body.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}

--- a/packages/payer-materios-x402/src/types.ts
+++ b/packages/payer-materios-x402/src/types.ts
@@ -1,0 +1,111 @@
+/**
+ * @summary Internal wire-format types for the materios-x402 payer.
+ *
+ * These types describe the JSON shape the gateway places in the
+ * `X-402-Payment-Required` response header (see
+ * `services/blob-gateway/src/middleware/billing-402.ts`).
+ *
+ * They are intentionally narrower than the generic `PaymentRequest` type in
+ * `@fluxpointstudios/orynq-sdk-core` — this payer only handles the
+ * `scheme === "materios-x402"` variant. The factory layer (index.ts) maps
+ * between this internal shape and `PaymentRequest` when implementing the
+ * generic `Payer` interface.
+ *
+ * Used by:
+ * - self-pay.ts to parse + validate the 402 header before signing
+ * - api-key.ts to detect when the gateway emitted a materios-x402 header
+ * - __tests__/ as the canonical fixture shape
+ */
+
+/**
+ * Decoded `X-402-Payment-Required` JSON payload, as emitted by the gateway.
+ *
+ * Wire format (see billing-402.ts::buildPaymentRequiredHeader):
+ * ```json
+ * {
+ *   "scheme": "materios-x402",
+ *   "chain": "materios",
+ *   "network": "preprod" | "mainnet",
+ *   "endpointClass": "receipt_submit",
+ *   "pricing": { "token": "MATRA", "decimals": 15, "amount": "1000000" },
+ *   "recipient": "pallet-billing",
+ *   "nonce": "0x<64-hex>",
+ *   "expires": 1234567890,
+ *   "payer"?: "<ss58>"   // only present when api-key path identified a verified treasury
+ * }
+ * ```
+ *
+ * CRITICAL: `pricing.amount` is a STRING-encoded u128. Always parse as
+ * `BigInt`, never `Number`. Same rule applies to any balance reflected
+ * back in the 402 body.
+ */
+export interface MateriosPaymentPayload {
+  /** Always `"materios-x402"` — used to detect this payer's wire format. */
+  scheme: "materios-x402";
+  /** Always `"materios"` for this payer. */
+  chain: "materios";
+  /** Materios network identifier. */
+  network: "preprod" | "mainnet" | string;
+  /** Canonical endpoint-class string (snake_case ASCII). */
+  endpointClass: string;
+  /** Pricing block — `amount` is a STRING-encoded u128. */
+  pricing: {
+    token: "MATRA" | string;
+    decimals: number;
+    amount: string;
+  };
+  /** Always `"pallet-billing"` for this payer. */
+  recipient: string;
+  /** Request nonce — `0x` + 64 hex chars (32 bytes). */
+  nonce: string;
+  /** Unix seconds (UTC) after which this 402 is no longer valid. */
+  expires: number;
+  /** Verified treasury SS58, present only for api-key path; never for self-pay. */
+  payer?: string;
+}
+
+/**
+ * Type guard — checks structural conformance to the materios-x402 wire
+ * format. Does NOT validate semantic constraints (nonce hex shape, amount
+ * numeric, expires in future) — those are checked by `validatePayload` in
+ * `self-pay.ts`. This guard is the cheap first-line filter that lets
+ * non-materios schemes fall through to other payers in a multi-payer setup.
+ */
+export function isMateriosPaymentPayload(
+  v: unknown,
+): v is MateriosPaymentPayload {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  if (o.scheme !== "materios-x402") return false;
+  if (typeof o.chain !== "string") return false;
+  if (typeof o.network !== "string") return false;
+  if (typeof o.endpointClass !== "string") return false;
+  if (typeof o.recipient !== "string") return false;
+  if (typeof o.nonce !== "string") return false;
+  if (typeof o.expires !== "number") return false;
+  if (!o.pricing || typeof o.pricing !== "object") return false;
+  const p = o.pricing as Record<string, unknown>;
+  if (typeof p.token !== "string") return false;
+  if (typeof p.decimals !== "number") return false;
+  if (typeof p.amount !== "string") return false;
+  return true;
+}
+
+/**
+ * The internal "validated payload" shape returned by `validatePayload` —
+ * a `MateriosPaymentPayload` whose semantic constraints (nonce, amount,
+ * expires) have been checked. Same runtime shape, distinct nominal type
+ * to make it obvious where validation has been performed.
+ */
+export type ValidatedMateriosPayload = MateriosPaymentPayload & {
+  readonly __validated: true;
+};
+
+/**
+ * The PaymentProof headers this payer attaches to a retry. Mirror the
+ * names the gateway's `identifyPayer` reads in billing-402.ts.
+ */
+export interface MateriosPaymentProofHeaders {
+  "x-402-payment-signature": string;
+  "x-402-payer-ss58": string;
+}

--- a/packages/payer-materios-x402/tsconfig.json
+++ b/packages/payer-materios-x402/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/payer-materios-x402/tsup.config.ts
+++ b/packages/payer-materios-x402/tsup.config.ts
@@ -1,0 +1,32 @@
+/**
+ * @summary Build configuration for @fluxpointstudios/orynq-sdk-payer-materios-x402.
+ *
+ * Produces dual ESM/CJS output with declaration files, ES2022 target.
+ *
+ * External dependencies (not bundled):
+ * - @fluxpointstudios/orynq-sdk-core: workspace dependency
+ * - @fluxpointstudios/orynq-sdk-transport-x402: workspace dependency
+ * - @polkadot/keyring, @polkadot/util, @polkadot/util-crypto: substrate signing
+ */
+
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  treeshake: true,
+  minify: false,
+  target: "es2022",
+  outDir: "dist",
+  external: [
+    "@fluxpointstudios/orynq-sdk-core",
+    "@fluxpointstudios/orynq-sdk-transport-x402",
+    "@polkadot/keyring",
+    "@polkadot/util",
+    "@polkadot/util-crypto",
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,34 @@ importers:
         specifier: ^1.2.0
         version: 1.6.1(@types/node@20.19.39)
 
+  packages/payer-materios-x402:
+    dependencies:
+      '@fluxpointstudios/orynq-sdk-core':
+        specifier: workspace:*
+        version: link:../core
+      '@fluxpointstudios/orynq-sdk-transport-x402':
+        specifier: workspace:*
+        version: link:../transport-x402
+      '@polkadot/keyring':
+        specifier: ^13.0.0
+        version: 13.5.9(@polkadot/util-crypto@13.5.9)(@polkadot/util@13.5.9)
+      '@polkadot/util':
+        specifier: ^13.0.0
+        version: 13.5.9
+      '@polkadot/util-crypto':
+        specifier: ^13.0.0
+        version: 13.5.9(@polkadot/util@13.5.9)
+    devDependencies:
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.2.0
+        version: 1.6.1(@types/node@20.19.39)
+
   packages/process-trace:
     dependencies:
       '@fluxpointstudios/orynq-sdk-core':

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       '@fluxpointstudios/orynq-sdk-payer-cardano-node': resolve(__dirname, 'packages/payer-cardano-node/src/index.ts'),
       '@fluxpointstudios/orynq-sdk-payer-evm-direct': resolve(__dirname, 'packages/payer-evm-direct/src/index.ts'),
       '@fluxpointstudios/orynq-sdk-payer-evm-x402': resolve(__dirname, 'packages/payer-evm-x402/src/index.ts'),
+      '@fluxpointstudios/orynq-sdk-payer-materios-x402': resolve(__dirname, 'packages/payer-materios-x402/src/index.ts'),
       '@fluxpointstudios/orynq-sdk-process-trace': resolve(__dirname, 'packages/process-trace/src/index.ts'),
       '@fluxpointstudios/orynq-sdk-server-middleware': resolve(__dirname, 'packages/server-middleware/src/index.ts'),
       '@fluxpointstudios/orynq-sdk-transport-flux': resolve(__dirname, 'packages/transport-flux/src/index.ts'),


### PR DESCRIPTION
## Summary

New package: **`@fluxpointstudios/orynq-sdk-payer-materios-x402`** (v0.1.0).

Closes the client side of Phase 2.A. The gateway 402 middleware (PRs #43 + #44) emits an `X-402-Payment-Required` header on requests that lack sufficient `pallet-billing::Balances`; this package generates the matching `x-402-payment-signature` + `x-402-payer-ss58` headers the client returns on the retry.

### Phase 2.A pipeline

| Layer | Status | Repo / PR |
| --- | --- | --- |
| pallet-billing on-chain state | merged | materios-node PRs #19/#20/#21 |
| Gateway 402 middleware | merged | orynq-sdk PRs #43, #44 |
| **Client-side x402 payer** (this PR) | this PR | orynq-sdk |

Design ref: `/home/deci/work/phase-2-prepaid-balance-design.md`.

## Public surface

- `createMateriosPayer({ apiKey })` — api-key passthrough. `pay()` throws a descriptive `PaymentFailedError` on 402 (api-key carries authorization via the existing Bearer header, NOT via x402 signature; a 402 then means treasury or per-key cap exhausted).
- `createMateriosPayer({ signerUri })` — sr25519 self-pay. Signs the canonical materios-x402 preimage with the caller's own keypair (mnemonic / raw seed / `//Alice` dev URI). Returns the two retry headers packed in `PaymentProof.signature` (unpack via `unpackPaymentProofHeaders`).
- `buildMateriosPayPreimage(payload)` — pure preimage builder, exported as the **single source of truth** for the wire format; gateway-side verifiers (and downstream Rust / Python implementations) MUST mirror it byte-for-byte.
- `parseMateriosPaymentRequired(...)` / `validatePayload(...)` — JSON header parsing + semantic validation (scheme, nonce shape, amount BigInt range, expires-in-future).
- `verifyMateriosPaymentSignature({...})` — sr25519 verifier using the canonical preimage hash. Test helper + standalone library.

## Canonical preimage (wire-format contract, v1)

The signed message is `blake2_256(canonical_preimage)` where:

```
canonical_preimage = concat(
  utf8("materios-x402-v1"),               // 16-byte fixed domain separator
  u32_le(len(endpointClass)) || utf8(endpointClass),
  u128_le(BigInt(pricing.amount)),
  bytes32(payload.nonce),                 // 32 raw bytes from "0x<64-hex>"
  u64_le(payload.expires)
)
```

Tests pin the exact byte layout. Rolling the format = bump the domain separator (e.g. `materios-x402-v2`) so old signatures naturally become invalid.

## Test plan

- [x] `pnpm vitest run packages/payer-materios-x402` — **28 passing** across 2 files
  - `preimage.test.ts`: domain separator bytes, determinism, anti-collision (4 fields), byte-pinned canonical vector (180 hex chars), malformed-input rejection
  - `payer.test.ts`: factory routing (api-key / self-pay / neither / both), api-key fail-fast, header parsing + 5 validation reject cases, sr25519 sign→verify roundtrip against `//Alice`, cross-signer rejection against `//Bob`, packed PaymentProof header shape (sig `0x[0-9a-f]{128}`, SS58 prefix-42 roundtrip), `raw`-missing + non-x402-protocol guards
- [x] `pnpm --filter @fluxpointstudios/orynq-sdk-payer-materios-x402 run build` — ESM + CJS + DTS all clean (14.3 / 14.7 / 19.7 KB)
- [x] `pnpm --filter @fluxpointstudios/orynq-sdk-payer-materios-x402 run typecheck` — clean
- [x] `npm pack --dry-run` — 58.5 kB tarball, 16 files, includes `CHANGELOG.md` (lesson from PR #42)
- [ ] `npm publish` — **intentionally NOT performed in this PR.** Manual post-merge step (mirrors the `anchors-materios@0.3.2` release flow).

## Notes for reviewers

- Mirrors `packages/payer-evm-x402` structure (package.json, tsup.config.ts, tsconfig.json layout).
- Reuses the generic `Payer` / `PaymentRequest` / `PaymentProof` types from `@fluxpointstudios/orynq-sdk-core` — no new core types needed.
- Avoids `@polkadot/api`. Uses only `@polkadot/keyring` + `@polkadot/util-crypto` + `@polkadot/util` (sr25519 sign / verify / blake2 / hex encode).
- Adds the package to `vitest.config.ts` alias table for live tests against workspace source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)