### PR TITLE
feat(blob-gateway): polyalg attestor sig verification (sr25519 + ed25519)

### DIFF
--- a/services/blob-gateway/src/__tests__/attestation_evidence_attestors.test.ts
+++ b/services/blob-gateway/src/__tests__/attestation_evidence_attestors.test.ts
@@ -116,6 +116,7 @@ describe("attestation_evidence_attestors: storage", () => {
       "pubkey_hex",
       "registered_at",
       "revoked_at",
+      "sig_algo",
     ]);
   });
 

--- a/services/blob-gateway/src/__tests__/attestation_evidence_route.test.ts
+++ b/services/blob-gateway/src/__tests__/attestation_evidence_route.test.ts
@@ -962,3 +962,226 @@ describe("attestation_evidence_hash — empty vec spec pin", () => {
     expect(summary.types).toEqual([]);
   });
 });
+
+// ===========================================================================
+// ed25519 attestor support (task #242)
+//
+// Acurast Android phones expose only ed25519 as a TEE-protected signing
+// primitive (`_STD_.signers.ed25519.sign`). The gateway must accept
+// ed25519-attested evidence from registered attestors whose `sig_algo` is
+// `ed25519`. Existing sr25519 attestors stay green via the ALTER TABLE
+// default.
+//
+// These tests cover the polyalg dispatch in the route's verifier and the
+// new `sig_algo` field on the admin POST.
+// ===========================================================================
+
+describe("POST /v2/attestation_evidence — ed25519 attestor (task #242)", () => {
+  let ctx: Ctx;
+  let ed25519Keyring: Keyring;
+  beforeAll(async () => {
+    await cryptoWaitReady();
+    ed25519Keyring = new Keyring({ type: "ed25519" });
+  });
+  beforeEach(async () => {
+    ctx = await setupApp();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  /**
+   * ed25519 variant of `buildSignedEvidence`. Same byte-pinned pre-image
+   * (canonical CBOR of the payload), but signs with an ed25519 keypair so
+   * the route's dispatch needs to verify with ed25519Verify, not sr25519Verify.
+   */
+  function buildSignedEvidenceEd25519(opts: {
+    receiptIdClean: string;
+    contentHash: string;
+    evidenceType: EvidenceType;
+    payload: Record<string, unknown>;
+    attestorUri: string;
+  }): {
+    receipt_id: string;
+    evidence_type: string;
+    nonce: string;
+    payload: Record<string, unknown>;
+    attestor_pubkey: string;
+    signature: string;
+    attestorPubHex: string;
+  } {
+    // ed25519 doesn't support soft-derivation paths (`//Foo` is soft); use
+    // a raw 32-byte seed derived from the attestorUri so each test gets a
+    // distinct, deterministic ed25519 keypair without needing a mnemonic.
+    const seed = createHash("sha256")
+      .update(Buffer.from(opts.attestorUri, "utf8"))
+      .digest();
+    const pair = ed25519Keyring.addFromSeed(seed);
+    const tagged = evidenceEntryToCborValue({
+      evidence_type: opts.evidenceType,
+      nonce: deriveEvidenceNonce(opts.contentHash, opts.evidenceType),
+      payload: opts.payload,
+    });
+    if (tagged.type !== "map") throw new Error("unexpected tagged shape");
+    const payloadEntry = tagged.v.find(([k]) => k === "payload");
+    if (!payloadEntry) throw new Error("payload key missing");
+    const payloadBytes = encodeCbor(payloadEntry[1]);
+    const sig = pair.sign(payloadBytes);
+    const pubHex = u8aToHex(pair.publicKey, undefined, false);
+    return {
+      receipt_id: opts.receiptIdClean,
+      evidence_type: opts.evidenceType,
+      nonce: deriveEvidenceNonce(opts.contentHash, opts.evidenceType),
+      payload: opts.payload,
+      attestor_pubkey: pubHex,
+      signature: u8aToHex(sig, undefined, false),
+      attestorPubHex: pubHex,
+    };
+  }
+
+  test("happy_path_ed25519_accepted_when_attestor_registered_as_ed25519", async () => {
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: "ed".repeat(32),
+    });
+    const signed = buildSignedEvidenceEd25519({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device: "acurast-mock", chain_chain_id: "preprod-001" },
+      attestorUri: "//Acurast/Phone1",
+    });
+    registerAttestationEvidenceAttestor({
+      pubkey: signed.attestorPubHex,
+      label: "acurast-phone-test",
+      sig_algo: "ed25519",
+    });
+
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      {
+        receipt_id: signed.receipt_id,
+        evidence_type: signed.evidence_type,
+        nonce: signed.nonce,
+        payload: signed.payload,
+        attestor_pubkey: signed.attestor_pubkey,
+        signature: signed.signature,
+      },
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { status: string };
+    expect(body.status).toBe("accepted");
+  });
+
+  test("ed25519_sig_rejected_when_attestor_registered_as_sr25519", async () => {
+    // The pubkey is ed25519 but the registry says this attestor uses
+    // sr25519 — the dispatch should pick sr25519Verify, which will fail on
+    // the ed25519 signature. Single 401 SIGNATURE_INVALID, no algo leak.
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: "ec".repeat(32),
+    });
+    const signed = buildSignedEvidenceEd25519({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device: "mismatched-algo" },
+      attestorUri: "//Acurast/Phone2",
+    });
+    registerAttestationEvidenceAttestor({
+      pubkey: signed.attestorPubHex,
+      label: "registered-as-wrong-algo",
+      // omit sig_algo → default sr25519
+    });
+
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      {
+        receipt_id: signed.receipt_id,
+        evidence_type: signed.evidence_type,
+        nonce: signed.nonce,
+        payload: signed.payload,
+        attestor_pubkey: signed.attestor_pubkey,
+        signature: signed.signature,
+      },
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(401);
+    const body = res.body as { code: string };
+    expect(body.code).toBe("SIGNATURE_INVALID");
+  });
+
+  test("sr25519_sig_rejected_when_attestor_registered_as_ed25519", async () => {
+    // Mirror image of the above — sr25519 sig, registry says ed25519.
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: "eb".repeat(32),
+    });
+    const signed = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device: "wrong-direction" },
+      attestorUri: "//SrToEd",
+    });
+    registerAttestationEvidenceAttestor({
+      pubkey: signed.attestorPubHex,
+      label: "ed25519-registered",
+      sig_algo: "ed25519",
+    });
+
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      {
+        receipt_id: signed.receipt_id,
+        evidence_type: signed.evidence_type,
+        nonce: signed.nonce,
+        payload: signed.payload,
+        attestor_pubkey: signed.attestor_pubkey,
+        signature: signed.signature,
+      },
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(401);
+    const body = res.body as { code: string };
+    expect(body.code).toBe("SIGNATURE_INVALID");
+  });
+
+  test("sr25519_attestor_unchanged_by_polyalg_extension", async () => {
+    // Regression guard: a pre-migration sr25519 attestor (sig_algo set by
+    // the ALTER TABLE default) still verifies correctly. Locks in
+    // backward-compat for the existing fleet-operator deployments.
+    const { contentHash, receiptIdClean } = await mintV2Manifest({
+      content_hash: "ea".repeat(32),
+    });
+    const signed = buildSignedEvidence({
+      receiptIdClean,
+      contentHash,
+      evidenceType: "arm_trustzone",
+      payload: { device: "legacy-fleet-operator" },
+      attestorUri: "//LegacySr",
+    });
+    registerAttestationEvidenceAttestor({
+      pubkey: signed.attestorPubHex,
+      label: "legacy-sr25519",
+      // No sig_algo passed → registers as sr25519 (the default the
+      // ALTER TABLE migration writes for pre-existing rows).
+    });
+
+    const res = await postJson(
+      ctx.app,
+      "/v2/attestation_evidence",
+      {
+        receipt_id: signed.receipt_id,
+        evidence_type: signed.evidence_type,
+        nonce: signed.nonce,
+        payload: signed.payload,
+        attestor_pubkey: signed.attestor_pubkey,
+        signature: signed.signature,
+      },
+      { headers: { authorization: `Bearer ${ctx.bearerToken}` } },
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/services/blob-gateway/src/attestation_evidence_attestors.ts
+++ b/services/blob-gateway/src/attestation_evidence_attestors.ts
@@ -71,8 +71,32 @@ export function initAttestationEvidenceAttestorsDb(
     CREATE INDEX IF NOT EXISTS idx_aea_active
       ON attestation_evidence_attestors(pubkey_hex) WHERE revoked_at IS NULL;
   `);
+  migrateSigAlgoColumn(handle);
   if (!db) db = handle;
   return handle;
+}
+
+/** Signature algorithms the gateway will accept on POST /v2/attestation_evidence. */
+export const SIG_ALGOS = ["sr25519", "ed25519"] as const;
+export type SigAlgo = (typeof SIG_ALGOS)[number];
+const SIG_ALGO_SET: ReadonlySet<string> = new Set<string>(SIG_ALGOS);
+
+/**
+ * Add `sig_algo` column to existing tables. Older rows default to "sr25519"
+ * so the existing SEV-SNP / TDX / cert-daemon attestors keep working without
+ * a re-register pass. New rows (Acurast phones, etc.) declare their algo
+ * explicitly via the admin POST.
+ */
+export function migrateSigAlgoColumn(handle: Database.Database): void {
+  const cols = handle
+    .prepare(`PRAGMA table_info(attestation_evidence_attestors)`)
+    .all() as Array<{ name: string }>;
+  if (!cols.some((c) => c.name === "sig_algo")) {
+    handle.exec(`
+      ALTER TABLE attestation_evidence_attestors
+      ADD COLUMN sig_algo TEXT NOT NULL DEFAULT 'sr25519'
+    `);
+  }
 }
 
 export interface AttestationEvidenceAttestorRow {
@@ -82,6 +106,7 @@ export interface AttestationEvidenceAttestorRow {
   registered_at: number;
   revoked_at: number | null;
   notes: string | null;
+  sig_algo: SigAlgo;
 }
 
 const HEX64 = /^[0-9a-f]{64}$/;
@@ -96,6 +121,13 @@ export interface RegisterAttestorInput {
   pubkey: string;
   label?: string | null;
   notes?: string | null;
+  /**
+   * Signature algorithm the attestor will use on POST /v2/attestation_evidence.
+   * Defaults to "sr25519" so existing call sites and back-compat ALTER TABLE
+   * defaults agree. Acurast Android phones MUST pass "ed25519" — the only
+   * TEE primitive the Acurast `_STD_.signers` API exposes.
+   */
+  sig_algo?: SigAlgo;
   /** Unix seconds override; used in tests for determinism. */
   now?: number;
 }
@@ -112,14 +144,20 @@ export function registerAttestationEvidenceAttestor(
   }
   const label = input.label ? String(input.label).slice(0, 256) : null;
   const notes = input.notes ? String(input.notes).slice(0, 1024) : null;
+  const sigAlgo: SigAlgo = input.sig_algo ?? "sr25519";
+  if (!SIG_ALGO_SET.has(sigAlgo)) {
+    throw new TypeError(
+      `registerAttestationEvidenceAttestor: sig_algo must be one of [${SIG_ALGOS.join(", ")}], got "${sigAlgo}"`,
+    );
+  }
   const registeredAt = input.now ?? Math.floor(Date.now() / 1000);
 
   const info = db
     .prepare(
-      `INSERT INTO attestation_evidence_attestors (pubkey_hex, label, registered_at, notes)
-       VALUES (?, ?, ?, ?)`,
+      `INSERT INTO attestation_evidence_attestors (pubkey_hex, label, registered_at, notes, sig_algo)
+       VALUES (?, ?, ?, ?, ?)`,
     )
-    .run(normalized, label, registeredAt, notes);
+    .run(normalized, label, registeredAt, notes, sigAlgo);
 
   return {
     id: Number(info.lastInsertRowid),
@@ -128,6 +166,7 @@ export function registerAttestationEvidenceAttestor(
     registered_at: registeredAt,
     revoked_at: null,
     notes,
+    sig_algo: sigAlgo,
   };
 }
 
@@ -154,7 +193,7 @@ export function getAttestationEvidenceAttestor(
   const normalized = normalizePubkey(pubkey);
   const row = db
     .prepare(
-      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes
+      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes, sig_algo
        FROM attestation_evidence_attestors WHERE pubkey_hex = ?`,
     )
     .get(normalized) as AttestationEvidenceAttestorRow | undefined;
@@ -178,6 +217,27 @@ export function isAttestationEvidenceAttestorActive(pubkey: string): boolean {
   return row !== undefined;
 }
 
+/**
+ * Hot-path lookup used by the v2/attestation_evidence route to decide which
+ * signature primitive to verify against. Returns the registered algo when
+ * the attestor is active, null when revoked or unregistered. Rows that
+ * pre-date the sig_algo migration default to "sr25519" via the ALTER TABLE
+ * column default, so this never returns an unrecognised string.
+ */
+export function getActiveAttestorSigAlgo(pubkey: string): SigAlgo | null {
+  if (!db) return null;
+  const normalized = normalizePubkey(pubkey);
+  const row = db
+    .prepare(
+      `SELECT sig_algo AS algo FROM attestation_evidence_attestors
+       WHERE pubkey_hex = ? AND revoked_at IS NULL`,
+    )
+    .get(normalized) as { algo: string } | undefined;
+  if (!row) return null;
+  if (!SIG_ALGO_SET.has(row.algo)) return null;
+  return row.algo as SigAlgo;
+}
+
 export interface ListAttestorsOpts {
   active?: boolean;
 }
@@ -189,7 +249,7 @@ export function listAttestationEvidenceAttestors(
   const where = opts.active ? "WHERE revoked_at IS NULL" : "";
   const rows = db
     .prepare(
-      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes
+      `SELECT id, pubkey_hex, label, registered_at, revoked_at, notes, sig_algo
        FROM attestation_evidence_attestors
        ${where}
        ORDER BY registered_at DESC, id DESC`,

--- a/services/blob-gateway/src/routes/attestation_evidence.ts
+++ b/services/blob-gateway/src/routes/attestation_evidence.ts
@@ -66,7 +66,7 @@
  */
 
 import { Router, type Request, type Response } from "express";
-import { signatureVerify } from "@polkadot/util-crypto";
+import { ed25519Verify, sr25519Verify } from "@polkadot/util-crypto";
 import { hexToU8a } from "@polkadot/util";
 import { createHash } from "crypto";
 import { readFile } from "fs/promises";
@@ -82,7 +82,11 @@ import {
   evidenceEntryToCborValue,
   type AttestationEvidenceEntry,
 } from "../schemas/compute_metering_v2.js";
-import { isAttestationEvidenceAttestorActive } from "../attestation_evidence_attestors.js";
+import {
+  isAttestationEvidenceAttestorActive,
+  getActiveAttestorSigAlgo,
+  type SigAlgo,
+} from "../attestation_evidence_attestors.js";
 import {
   insertReceiptEvidence,
   recomputeReceiptEvidenceHash,
@@ -106,6 +110,7 @@ export type AttestationEvidenceErrorCode =
   | "RECEIPT_NOT_FOUND"
   | "NONCE_MISMATCH"
   | "ATTESTOR_UNKNOWN"
+  | "ATTESTOR_ALGO_UNKNOWN"
   | "SIGNATURE_INVALID"
   | "INTERNAL";
 
@@ -195,19 +200,35 @@ async function lookupContentHashForReceiptId(
 }
 
 /**
- * Verify an sr25519 signature, swallowing any malformed-input throws as a
- * `false` return. Mirrors the helper in `metering_v2.ts`.
+ * Verify an attestor signature with the algorithm registered for that
+ * attestor. Dispatches to the appropriate primitive — sr25519 for the
+ * existing SEV-SNP/TDX/cert-daemon attestors that pre-date this change,
+ * ed25519 for Acurast Android-phone attestors (the Acurast `_STD_.signers`
+ * runtime only exposes ed25519 as a TEE primitive).
+ *
+ * Malformed inputs (wrong length, bad hex) and any panic inside the underlying
+ * verifier swallow to `false` — the route returns a single uniform 401 in
+ * those cases rather than leaking internals.
  */
-function verifySr25519(
+function verifyAttestorSig(
   preimage: Uint8Array,
   pubkeyHex: string,
   sigHex: string,
+  algo: SigAlgo,
 ): boolean {
   try {
     const pub = hexToU8a("0x" + pubkeyHex);
     const sig = hexToU8a("0x" + sigHex);
-    const r = signatureVerify(preimage, sig, pub);
-    return r.isValid;
+    switch (algo) {
+      case "sr25519":
+        return sr25519Verify(preimage, sig, pub);
+      case "ed25519":
+        return ed25519Verify(preimage, sig, pub);
+      default:
+        // Compile-time exhaustiveness — adding a new SigAlgo without a case
+        // here triggers TS2367 here, forcing the route author to wire it up.
+        return ((_x: never) => false)(algo);
+    }
   } catch {
     return false;
   }
@@ -376,15 +397,36 @@ attestationEvidenceRouter.post(
         return;
       }
 
-      // ---- 4. attestor registered ----
-      if (!isAttestationEvidenceAttestorActive(attestorPubHex)) {
-        reject(
-          res,
-          403,
-          "ATTESTOR_UNKNOWN",
-          "attestor_pubkey is not registered or has been revoked",
-          "attestor_pubkey",
-        );
+      // ---- 4. attestor registered (+ resolve algo for §5 dispatch) ----
+      // Single lookup pulls both presence and algo so the verifier in §5
+      // dispatches on the algorithm the operator registered for this
+      // attestor — sr25519 for the existing fleet, ed25519 for Acurast
+      // Android phones. `getActiveAttestorSigAlgo` returns null when the
+      // pubkey is revoked or never registered, so the existing 403 path
+      // still triggers for those.
+      const attestorAlgo = getActiveAttestorSigAlgo(attestorPubHex);
+      if (!attestorAlgo) {
+        // Fall back to the legacy presence check for the error message —
+        // mostly defensive (the two helpers would only disagree if a row's
+        // sig_algo got stored as some string outside the SIG_ALGOS set,
+        // which the register function rejects today).
+        if (!isAttestationEvidenceAttestorActive(attestorPubHex)) {
+          reject(
+            res,
+            403,
+            "ATTESTOR_UNKNOWN",
+            "attestor_pubkey is not registered or has been revoked",
+            "attestor_pubkey",
+          );
+        } else {
+          reject(
+            res,
+            403,
+            "ATTESTOR_ALGO_UNKNOWN",
+            "attestor_pubkey is registered but its sig_algo is not recognised by this gateway",
+            "attestor_pubkey",
+          );
+        }
         return;
       }
 
@@ -423,12 +465,19 @@ attestationEvidenceRouter.post(
         return;
       }
 
-      if (!verifySr25519(payloadCborBytes, attestorPubHex, signatureHex)) {
+      if (
+        !verifyAttestorSig(
+          payloadCborBytes,
+          attestorPubHex,
+          signatureHex,
+          attestorAlgo,
+        )
+      ) {
         reject(
           res,
           401,
           "SIGNATURE_INVALID",
-          "signature does not verify against attestor_pubkey over canonical(payload)",
+          `signature does not verify against attestor_pubkey (${attestorAlgo}) over canonical(payload)`,
           "signature",
         );
         return;

--- a/services/blob-gateway/src/routes/attestation_evidence_attestors.ts
+++ b/services/blob-gateway/src/routes/attestation_evidence_attestors.ts
@@ -20,8 +20,12 @@ import {
   revokeAttestationEvidenceAttestor,
   getAttestationEvidenceAttestor,
   listAttestationEvidenceAttestors,
+  SIG_ALGOS,
   type AttestationEvidenceAttestorRow,
+  type SigAlgo,
 } from "../attestation_evidence_attestors.js";
+
+const SIG_ALGO_SET: ReadonlySet<string> = new Set<string>(SIG_ALGOS);
 
 const HEX64_LOOSE = /^(0x)?[0-9a-fA-F]{64}$/;
 
@@ -38,6 +42,7 @@ function rowToJson(row: AttestationEvidenceAttestorRow): Record<string, unknown>
     registered_at: row.registered_at,
     revoked_at: row.revoked_at,
     notes: row.notes,
+    sig_algo: row.sig_algo,
   };
 }
 
@@ -69,6 +74,7 @@ export function registerAttestationEvidenceAttestorRoutes(
           pubkey?: unknown;
           label?: unknown;
           notes?: unknown;
+          sig_algo?: unknown;
         };
         if (typeof body.pubkey !== "string" || !HEX64_LOOSE.test(body.pubkey)) {
           res.status(400).json({
@@ -84,6 +90,20 @@ export function registerAttestationEvidenceAttestorRoutes(
           typeof body.notes === "string" && body.notes.trim()
             ? body.notes.trim()
             : null;
+        // sig_algo is optional — defaults to sr25519 to preserve the existing
+        // fleet-operator onboarding flow. Acurast Android phones MUST pass
+        // "ed25519" since that's the only TEE primitive their `_STD_.signers`
+        // runtime exposes.
+        let sigAlgo: SigAlgo = "sr25519";
+        if (body.sig_algo !== undefined) {
+          if (typeof body.sig_algo !== "string" || !SIG_ALGO_SET.has(body.sig_algo)) {
+            res.status(400).json({
+              error: `sig_algo must be one of [${SIG_ALGOS.join(", ")}]`,
+            });
+            return;
+          }
+          sigAlgo = body.sig_algo as SigAlgo;
+        }
 
         const existing = getAttestationEvidenceAttestor(body.pubkey);
         if (existing) {
@@ -98,10 +118,11 @@ export function registerAttestationEvidenceAttestorRoutes(
           pubkey: body.pubkey,
           label,
           notes,
+          sig_algo: sigAlgo,
         });
 
         console.log(
-          `[blob-gateway] attestation-evidence-attestor registered pubkey_prefix=${row.pubkey_hex.slice(0, 16)} label=${label ?? "-"}`,
+          `[blob-gateway] attestation-evidence-attestor registered pubkey_prefix=${row.pubkey_hex.slice(0, 16)} algo=${sigAlgo} label=${label ?? "-"}`,
         );
 
         res.status(200).json({


### PR DESCRIPTION
## Summary
- Unblocks Acurast Android phone TEE attestors on `POST /v2/attestation_evidence` — Acurast `_STD_.signers` only exposes ed25519, the route was sr25519-only.
- Adds `sig_algo` column to `attestation_evidence_attestors` (defaults `sr25519` via ALTER TABLE so existing fleet operators stay green) and dispatches to `sr25519Verify` / `ed25519Verify` per-attestor.
- New admin POST body field `sig_algo` to register Acurast phones with `"ed25519"`.

## Why
Task #242, blocks task #138 phase-B (live Materios job deployment to a TEE-attested Acurast Android phone — phase-A done, six successful TEE executions logged, phase-B was held by this exact gateway gap). Full discovery write-up in `feedback_acurast_phone_attestor_blocked_on_sig_algo.md`.

The pallet `TeeAttestation.submit_evidence` has the same sr25519-only assumption and is tracked as a separate follow-up (task #243).

## What changed
- `src/attestation_evidence_attestors.ts` — `sig_algo` column + migration + `getActiveAttestorSigAlgo()` lookup + `SIG_ALGOS` constant.
- `src/routes/attestation_evidence.ts` — replaced hardcoded `verifySr25519` with `verifyAttestorSig(preimage, pubkey, sig, algo)`; uses direct `sr25519Verify` / `ed25519Verify` primitives. New error code `ATTESTOR_ALGO_UNKNOWN` for the defensive case.
- `src/routes/attestation_evidence_attestors.ts` — admin POST accepts optional `sig_algo`, validated against `SIG_ALGOS`.
- Tests — 4 new ed25519 cases (happy path, ed25519-sig-on-sr25519-row, sr25519-sig-on-ed25519-row, sr25519 regression guard) + 1 pinned-schema test updated.

## Test plan
- [x] All 22 pre-existing `attestation_evidence_route` tests pass
- [x] All 23 pre-existing `attestation_evidence_attestors` tests pass
- [x] 4 new ed25519 acceptance/rejection tests pass
- [x] Full blob-gateway suite: 608/609 (the 1 failure is unrelated pre-existing `prom-client` resolution in `metrics.ts`)
- [ ] Live preprod deploy + register Acurast phone ed25519 pubkey → re-fire deploy 58860-style → confirm 200 accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)