### PR TITLE
fix(blob-gateway): admin attestor route accept 33-byte secp256r1 pubkey

### DIFF
--- a/services/blob-gateway/src/routes/attestation_evidence_attestors.ts
+++ b/services/blob-gateway/src/routes/attestation_evidence_attestors.ts
@@ -28,6 +28,12 @@ import {
 const SIG_ALGO_SET: ReadonlySet<string> = new Set<string>(SIG_ALGOS);
 
 const HEX64_LOOSE = /^(0x)?[0-9a-fA-F]{64}$/;
+// secp256r1 attestors use a 33-byte compressed P-256 pubkey (66 hex chars).
+// The admin POST route accepts EITHER 64 (sr25519/ed25519) OR 66 (secp256r1)
+// at the parse layer; the storage layer's `registerAttestationEvidenceAttestor`
+// enforces the exact per-algo length, so the wrong combo still gets rejected
+// — just with a more specific error (and after the algo is known).
+const HEX_PUBKEY_LOOSE = /^(0x)?[0-9a-fA-F]{64}$|^(0x)?[0-9a-fA-F]{66}$/;
 
 export interface RegisterAttestationEvidenceAttestorRoutesOpts {
   /** Admin shared secret (falls back to config.daemonNotifyToken if empty). */
@@ -76,9 +82,11 @@ export function registerAttestationEvidenceAttestorRoutes(
           notes?: unknown;
           sig_algo?: unknown;
         };
-        if (typeof body.pubkey !== "string" || !HEX64_LOOSE.test(body.pubkey)) {
+        if (typeof body.pubkey !== "string" || !HEX_PUBKEY_LOOSE.test(body.pubkey)) {
           res.status(400).json({
-            error: "pubkey is required and must be 32 bytes hex (64 chars, optional 0x prefix)",
+            error:
+              "pubkey is required and must be 32 bytes hex (64 chars, sr25519/ed25519) " +
+              "or 33 bytes hex (66 chars, secp256r1), optional 0x prefix",
           });
           return;
         }
@@ -146,9 +154,11 @@ export function registerAttestationEvidenceAttestorRoutes(
     (req: Request, res: Response) => {
       try {
         const pubkey = String(req.params.pubkey || "");
-        if (!HEX64_LOOSE.test(pubkey)) {
+        if (!HEX_PUBKEY_LOOSE.test(pubkey)) {
           res.status(400).json({
-            error: "invalid pubkey (expected 64 hex chars, optional 0x prefix)",
+            error:
+              "invalid pubkey (expected 64 hex chars sr25519/ed25519 or " +
+              "66 hex chars secp256r1, optional 0x prefix)",
           });
           return;
         }

--- a/services/blob-gateway/src/routes/attestation_evidence_attestors.ts
+++ b/services/blob-gateway/src/routes/attestation_evidence_attestors.ts
@@ -27,10 +27,9 @@ import {
 
 const SIG_ALGO_SET: ReadonlySet<string> = new Set<string>(SIG_ALGOS);
 
-const HEX64_LOOSE = /^(0x)?[0-9a-fA-F]{64}$/;
 // secp256r1 attestors use a 33-byte compressed P-256 pubkey (66 hex chars).
-// The admin POST route accepts EITHER 64 (sr25519/ed25519) OR 66 (secp256r1)
-// at the parse layer; the storage layer's `registerAttestationEvidenceAttestor`
+// The admin routes accept EITHER 64 (sr25519/ed25519) OR 66 (secp256r1) at
+// the parse layer; the storage layer's `registerAttestationEvidenceAttestor`
 // enforces the exact per-algo length, so the wrong combo still gets rejected
 // — just with a more specific error (and after the algo is known).
 const HEX_PUBKEY_LOOSE = /^(0x)?[0-9a-fA-F]{64}$|^(0x)?[0-9a-fA-F]{66}$/;


### PR DESCRIPTION
## Summary
- PR #49 added secp256r1 to the polyalg verifier + storage layer, but the `/admin/attestation-evidence-attestors` POST + DELETE handlers still hard-checked `HEX64_LOOSE` (64 hex only) at the parse layer.
- Introduces `HEX_PUBKEY_LOOSE` (64 OR 66 hex) for the parse-layer check. Storage layer's per-algo enforcement is unchanged, so wrong-algo-vs-wrong-length combos still get rejected — just with the more specific storage error.

## Discovered via
Running the live `scripts/e2e_polyalg_secp256r1_smoke.mjs` against the freshly deployed PR-#49 image:
```
[smoke] register attestor: 400 {"error":"pubkey is required and must be 32 bytes hex (64 chars, optional 0x prefix)"}
```

## Test plan
- [x] Full 51/51 attestation suite (route + attestors) still passes locally
- [ ] Image builds clean on CI
- [ ] After deploy, `e2e_polyalg_secp256r1_smoke.mjs` returns 200 OK with `status:accepted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)