### PR TITLE
feat(blob-gateway): /v2/multisig_sigs/{kind}/{key} for M-of-N envelope coordination (#286)

### DIFF
--- a/services/blob-gateway/src/__tests__/multisig_sigs.test.ts
+++ b/services/blob-gateway/src/__tests__/multisig_sigs.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Tests for the multisig_sigs store + HTTP routes (task #286 — M-of-N
+ * sig aggregation for pallet-intent-settlement).
+ *
+ * Mirrors the witness_targets test pattern (in-memory sqlite + ephemeral
+ * `app.listen(0)` + fetch). No supertest dep.
+ */
+
+import { describe, test, expect, beforeAll } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import {
+  cryptoWaitReady,
+  sr25519PairFromSeed,
+  sr25519Sign,
+} from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+
+import {
+  cleanupMultisigSigs,
+  initMultisigSigsDb,
+  isMultisigKind,
+  listMultisigSigs,
+  parseAndValidatePayload,
+  parsePathSegments,
+  setMultisigSigsDbForTests,
+  upsertMultisigSig,
+} from "../multisig_sigs_store.js";
+import { registerMultisigSigsRoutes } from "../routes/multisig_sigs.js";
+
+function makeMemDb(): Database.Database {
+  const db = new Database(":memory:");
+  initMultisigSigsDb(db);
+  setMultisigSigsDbForTests(db);
+  return db;
+}
+
+interface Ctx {
+  app: express.Express;
+  db: Database.Database;
+}
+
+function setupApp(): Ctx {
+  const db = makeMemDb();
+  const app = express();
+  app.use(express.json({ limit: "1mb" }));
+  registerMultisigSigsRoutes(app);
+  return { app, db };
+}
+
+async function callApp(
+  app: express.Express,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const init: RequestInit = {
+        method,
+        headers: { "content-type": "application/json" },
+      };
+      if (body !== undefined) init.body = JSON.stringify(body);
+      fetch(url, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+interface Signer {
+  pubkey_hex: string;
+  sign: (digest: Uint8Array) => string; // returns 128-hex
+}
+
+function makeSigner(seedHex: string): Signer {
+  const seed = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    seed[i] = parseInt(seedHex.slice(i * 2, i * 2 + 2), 16);
+  }
+  const pair = sr25519PairFromSeed(seed);
+  return {
+    pubkey_hex: u8aToHex(pair.publicKey, undefined, false),
+    sign: (digest: Uint8Array): string =>
+      u8aToHex(sr25519Sign(digest, pair), undefined, false),
+  };
+}
+
+beforeAll(async () => {
+  await cryptoWaitReady();
+});
+
+describe("multisig_sigs path-segment validation", () => {
+  test("accepts settle kind + 32-byte key", () => {
+    const r = parsePathSegments("settle", "ab".repeat(32));
+    expect("error" in r).toBe(false);
+    if (!("error" in r)) {
+      expect(r.kind).toBe("settle");
+      expect(r.key_hex).toBe("ab".repeat(32));
+    }
+  });
+
+  test("accepts expire kind", () => {
+    const r = parsePathSegments("expire", "0xCD".repeat(32).replace(/0x/g, ""));
+    expect("error" in r).toBe(false);
+  });
+
+  test("rejects unknown kind", () => {
+    const r = parsePathSegments("batch", "ab".repeat(32));
+    expect("error" in r).toBe(true);
+  });
+
+  test("rejects short key", () => {
+    const r = parsePathSegments("settle", "ab".repeat(16));
+    expect("error" in r).toBe(true);
+  });
+
+  test("rejects non-hex key", () => {
+    const r = parsePathSegments("settle", "g".repeat(64));
+    expect("error" in r).toBe(true);
+  });
+
+  test("strips 0x prefix on key", () => {
+    const r = parsePathSegments("settle", "0x" + "ab".repeat(32));
+    expect("error" in r).toBe(false);
+    if (!("error" in r)) expect(r.key_hex).toBe("ab".repeat(32));
+  });
+});
+
+describe("multisig_sigs payload validation", () => {
+  test("happy path", () => {
+    const r = parseAndValidatePayload({
+      pubkey: "01".repeat(32),
+      sig: "02".repeat(64),
+      digest: "03".repeat(32),
+    });
+    expect("error" in r).toBe(false);
+  });
+
+  test("rejects missing fields", () => {
+    expect("error" in parseAndValidatePayload({ pubkey: "01".repeat(32) })).toBe(true);
+  });
+
+  test("rejects wrong sig length", () => {
+    const r = parseAndValidatePayload({
+      pubkey: "01".repeat(32),
+      sig: "02".repeat(32),
+      digest: "03".repeat(32),
+    });
+    expect("error" in r).toBe(true);
+  });
+
+  test("rejects non-hex pubkey", () => {
+    const r = parseAndValidatePayload({
+      pubkey: "z".repeat(64),
+      sig: "02".repeat(64),
+      digest: "03".repeat(32),
+    });
+    expect("error" in r).toBe(true);
+  });
+
+  test("lowercases hex", () => {
+    const r = parseAndValidatePayload({
+      pubkey: "AB".repeat(32),
+      sig: "02".repeat(64),
+      digest: "03".repeat(32),
+    });
+    if ("error" in r) throw new Error("expected ok");
+    expect(r.pubkey_hex).toBe("ab".repeat(32));
+  });
+});
+
+describe("multisig_sigs store", () => {
+  test("upsert preserves created_at on re-insert", () => {
+    makeMemDb();
+    const row = {
+      kind: "settle" as const,
+      key_hex: "aa".repeat(32),
+      digest_hex: "bb".repeat(32),
+      pubkey_hex: "cc".repeat(32),
+      sig_hex: "dd".repeat(64),
+    };
+    const first = upsertMultisigSig(row);
+    const second = upsertMultisigSig({ ...row, sig_hex: "ee".repeat(64) });
+    expect(second.created_at).toBe(first.created_at);
+    const rows = listMultisigSigs("settle", row.key_hex);
+    expect(rows.length).toBe(1);
+    expect(rows[0].sig_hex).toBe("ee".repeat(64)); // updated
+  });
+
+  test("different digests for same (kind,key,pubkey) coexist", () => {
+    makeMemDb();
+    upsertMultisigSig({
+      kind: "settle",
+      key_hex: "aa".repeat(32),
+      digest_hex: "11".repeat(32),
+      pubkey_hex: "cc".repeat(32),
+      sig_hex: "dd".repeat(64),
+    });
+    upsertMultisigSig({
+      kind: "settle",
+      key_hex: "aa".repeat(32),
+      digest_hex: "22".repeat(32),
+      pubkey_hex: "cc".repeat(32),
+      sig_hex: "ee".repeat(64),
+    });
+    expect(listMultisigSigs("settle", "aa".repeat(32)).length).toBe(2);
+    expect(listMultisigSigs("settle", "aa".repeat(32), "11".repeat(32)).length).toBe(1);
+  });
+
+  test("kinds are isolated", () => {
+    makeMemDb();
+    upsertMultisigSig({
+      kind: "settle",
+      key_hex: "aa".repeat(32),
+      digest_hex: "bb".repeat(32),
+      pubkey_hex: "cc".repeat(32),
+      sig_hex: "dd".repeat(64),
+    });
+    upsertMultisigSig({
+      kind: "expire",
+      key_hex: "aa".repeat(32),
+      digest_hex: "bb".repeat(32),
+      pubkey_hex: "cc".repeat(32),
+      sig_hex: "ee".repeat(64),
+    });
+    expect(listMultisigSigs("settle", "aa".repeat(32)).length).toBe(1);
+    expect(listMultisigSigs("expire", "aa".repeat(32)).length).toBe(1);
+  });
+
+  test("cleanup removes stale rows", () => {
+    const db = makeMemDb();
+    upsertMultisigSig({
+      kind: "settle",
+      key_hex: "aa".repeat(32),
+      digest_hex: "bb".repeat(32),
+      pubkey_hex: "cc".repeat(32),
+      sig_hex: "dd".repeat(64),
+    });
+    // Force created_at to be 25h old via direct UPDATE.
+    db.prepare(
+      `UPDATE multisig_sigs SET created_at = ? WHERE pubkey_hex = ?`,
+    ).run(Math.floor(Date.now() / 1000) - 90000, "cc".repeat(32));
+    expect(cleanupMultisigSigs(86400)).toBe(1);
+    expect(listMultisigSigs("settle", "aa".repeat(32)).length).toBe(0);
+  });
+});
+
+describe("isMultisigKind", () => {
+  test("settle + expire only", () => {
+    expect(isMultisigKind("settle")).toBe(true);
+    expect(isMultisigKind("expire")).toBe(true);
+    expect(isMultisigKind("batch")).toBe(false);
+    expect(isMultisigKind("")).toBe(false);
+  });
+});
+
+describe("POST /v2/multisig_sigs/:kind/:key", () => {
+  test("happy path: valid sig stored, GET returns it", async () => {
+    const { app } = setupApp();
+    const signer = makeSigner("11".repeat(32));
+    const digest = new Uint8Array(32).fill(0x77);
+    const digest_hex = u8aToHex(digest, undefined, false);
+    const key_hex = "aa".repeat(32);
+    const sig_hex = signer.sign(digest);
+
+    const postRes = await callApp(app, "POST", `/v2/multisig_sigs/settle/${key_hex}`, {
+      pubkey: signer.pubkey_hex,
+      sig: sig_hex,
+      digest: digest_hex,
+    });
+    expect(postRes.status).toBe(200);
+    expect((postRes.body as { ok: boolean }).ok).toBe(true);
+
+    const getRes = await callApp(app, "GET", `/v2/multisig_sigs/settle/${key_hex}`);
+    expect(getRes.status).toBe(200);
+    const body = getRes.body as { sigs: Array<{ pubkey: string; sig: string; digest: string }> };
+    expect(body.sigs.length).toBe(1);
+    expect(body.sigs[0].pubkey).toBe(signer.pubkey_hex);
+    expect(body.sigs[0].digest).toBe(digest_hex);
+  });
+
+  test("rejects invalid sig with 401", async () => {
+    const { app } = setupApp();
+    const signer = makeSigner("11".repeat(32));
+    const digest_hex = "77".repeat(32);
+    const wrong_sig = "00".repeat(64);
+
+    const postRes = await callApp(app, "POST", `/v2/multisig_sigs/settle/${"aa".repeat(32)}`, {
+      pubkey: signer.pubkey_hex,
+      sig: wrong_sig,
+      digest: digest_hex,
+    });
+    expect(postRes.status).toBe(401);
+  });
+
+  test("rejects sig that verifies against a DIFFERENT digest with 401", async () => {
+    // Attacker: substitutes claimed digest after producing a valid sig over
+    // a different message. Verify-failure must catch this.
+    const { app } = setupApp();
+    const signer = makeSigner("11".repeat(32));
+    const real_digest = new Uint8Array(32).fill(0x77);
+    const fake_digest_hex = "88".repeat(32);
+    const sig_hex = signer.sign(real_digest);
+
+    const postRes = await callApp(app, "POST", `/v2/multisig_sigs/settle/${"aa".repeat(32)}`, {
+      pubkey: signer.pubkey_hex,
+      sig: sig_hex,
+      digest: fake_digest_hex,
+    });
+    expect(postRes.status).toBe(401);
+  });
+
+  test("rejects unknown kind with 400", async () => {
+    const { app } = setupApp();
+    const signer = makeSigner("11".repeat(32));
+    const digest = new Uint8Array(32).fill(0x77);
+    const sig_hex = signer.sign(digest);
+    const postRes = await callApp(app, "POST", `/v2/multisig_sigs/batch/${"aa".repeat(32)}`, {
+      pubkey: signer.pubkey_hex,
+      sig: sig_hex,
+      digest: u8aToHex(digest, undefined, false),
+    });
+    expect(postRes.status).toBe(400);
+  });
+
+  test("idempotent re-POST returns same expires_at_unix", async () => {
+    const { app } = setupApp();
+    const signer = makeSigner("11".repeat(32));
+    const digest = new Uint8Array(32).fill(0x77);
+    const digest_hex = u8aToHex(digest, undefined, false);
+    const key_hex = "aa".repeat(32);
+    const sig_hex = signer.sign(digest);
+
+    const r1 = await callApp(app, "POST", `/v2/multisig_sigs/settle/${key_hex}`, {
+      pubkey: signer.pubkey_hex,
+      sig: sig_hex,
+      digest: digest_hex,
+    });
+    const r2 = await callApp(app, "POST", `/v2/multisig_sigs/settle/${key_hex}`, {
+      pubkey: signer.pubkey_hex,
+      sig: sig_hex,
+      digest: digest_hex,
+    });
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect((r1.body as { expires_at_unix: number }).expires_at_unix).toBe(
+      (r2.body as { expires_at_unix: number }).expires_at_unix,
+    );
+  });
+
+  test("M=2 aggregation: two distinct signers, both visible in GET", async () => {
+    const { app } = setupApp();
+    const a = makeSigner("11".repeat(32));
+    const b = makeSigner("22".repeat(32));
+    const digest = new Uint8Array(32).fill(0x33);
+    const digest_hex = u8aToHex(digest, undefined, false);
+    const key_hex = "ab".repeat(32);
+
+    await callApp(app, "POST", `/v2/multisig_sigs/settle/${key_hex}`, {
+      pubkey: a.pubkey_hex,
+      sig: a.sign(digest),
+      digest: digest_hex,
+    });
+    await callApp(app, "POST", `/v2/multisig_sigs/settle/${key_hex}`, {
+      pubkey: b.pubkey_hex,
+      sig: b.sign(digest),
+      digest: digest_hex,
+    });
+
+    const getRes = await callApp(
+      app,
+      "GET",
+      `/v2/multisig_sigs/settle/${key_hex}?digest=${digest_hex}`,
+    );
+    expect(getRes.status).toBe(200);
+    const body = getRes.body as { sigs: Array<{ pubkey: string }>; count: number };
+    expect(body.count).toBe(2);
+    const pubkeys = new Set(body.sigs.map((s) => s.pubkey));
+    expect(pubkeys.has(a.pubkey_hex)).toBe(true);
+    expect(pubkeys.has(b.pubkey_hex)).toBe(true);
+  });
+
+  test("GET digest filter narrows to one match", async () => {
+    const { app } = setupApp();
+    const signer = makeSigner("11".repeat(32));
+    const dA = new Uint8Array(32).fill(0xaa);
+    const dB = new Uint8Array(32).fill(0xbb);
+    const key_hex = "ab".repeat(32);
+
+    await callApp(app, "POST", `/v2/multisig_sigs/settle/${key_hex}`, {
+      pubkey: signer.pubkey_hex,
+      sig: signer.sign(dA),
+      digest: u8aToHex(dA, undefined, false),
+    });
+    await callApp(app, "POST", `/v2/multisig_sigs/settle/${key_hex}`, {
+      pubkey: signer.pubkey_hex,
+      sig: signer.sign(dB),
+      digest: u8aToHex(dB, undefined, false),
+    });
+
+    const allRes = await callApp(app, "GET", `/v2/multisig_sigs/settle/${key_hex}`);
+    expect((allRes.body as { count: number }).count).toBe(2);
+
+    const filtered = await callApp(
+      app,
+      "GET",
+      `/v2/multisig_sigs/settle/${key_hex}?digest=${u8aToHex(dA, undefined, false)}`,
+    );
+    expect((filtered.body as { count: number }).count).toBe(1);
+  });
+
+  test("GET rejects malformed digest query", async () => {
+    const { app } = setupApp();
+    const r = await callApp(
+      app,
+      "GET",
+      `/v2/multisig_sigs/settle/${"aa".repeat(32)}?digest=notHex`,
+    );
+    expect(r.status).toBe(400);
+  });
+});

--- a/services/blob-gateway/src/index.ts
+++ b/services/blob-gateway/src/index.ts
@@ -36,6 +36,11 @@ import { initObserversDb } from "./observers.js";
 import { initWitnessTargetsDb } from "./witness_targets.js";
 import { initAttestationEvidenceAttestorsDb } from "./attestation_evidence_attestors.js";
 import { initReceiptAttestationEvidenceDb } from "./receipt_attestation_evidence.js";
+import {
+  initMultisigSigsDb,
+  startMultisigSigsCleanup,
+} from "./multisig_sigs_store.js";
+import { registerMultisigSigsRoutes } from "./routes/multisig_sigs.js";
 import { registerFleetOperatorRoutes } from "./routes/fleet_operators.js";
 import { registerObserverRoutes } from "./routes/observers.js";
 import { registerWitnessTargetRoutes } from "./routes/witness_targets.js";
@@ -110,6 +115,7 @@ registerObserverRoutes(app);      // Wave 1+2: compute_metering_v2 optional co-s
 registerAttestationEvidenceAttestorRoutes(app); // Wave 3 Phase 2: TEE attestor pubkey registry (admin-only)
 registerWitnessTargetRoutes(app); // Witness Network: probe-target URL roster — public GET, admin POST/DELETE
 registerAttestorSelfRegisterRoutes(app); // Witness Network: POST /v2/attestor_self_register — phones self-onboard via Android Key Attestation cert chain
+registerMultisigSigsRoutes(app); // Task #286: GET/POST /v2/multisig_sigs/{kind}/{key} — cert-daemon M-of-N envelope coordination (settle/expire)
 
 async function start(): Promise<void> {
   // Initialize sr25519/ed25519 WASM (required for signatureVerify)
@@ -138,10 +144,17 @@ async function start(): Promise<void> {
   // Wave 3 Phase 2 — TEE attestor registry + per-receipt evidence vector.
   initAttestationEvidenceAttestorsDb();
   initReceiptAttestationEvidenceDb();
+  // Task #286 — ephemeral M-of-N sig bulletin board for settle_claim +
+  // expire_policy. Daemons publish per-pubkey sigs here so any one can
+  // assemble the full envelope before submitting the M-sig extrinsic.
+  initMultisigSigsDb();
 
   // Start cleanup timers
   startCleanupTimer();
   startHeartbeatCleanup();
+  // 24h hard TTL for multisig sig rows; on-chain SettlementRequestTtl is
+  // ~4h so this leaves margin for post-mortem queries.
+  startMultisigSigsCleanup();
 
   // Start default Node-process metrics collection (heap, event-loop lag,
   // GC). Lazy-started here so unit tests don't leak the collection timer.

--- a/services/blob-gateway/src/multisig_sigs_store.ts
+++ b/services/blob-gateway/src/multisig_sigs_store.ts
@@ -1,0 +1,239 @@
+/**
+ * Ephemeral bulletin-board for M-of-N committee signatures over the
+ * `pallet-intent-settlement` STCA (settle_claim) + EXPP (expire_policy)
+ * canonical digests.
+ *
+ * Each cert-daemon computes the canonical digest from chain state,
+ * signs it with its committee key, POSTs the (pubkey, sig, digest)
+ * triple here, GETs the union of peer sigs, and submits ONE M-sig
+ * envelope via `attest_settle` / `attest_expire_policy`. The pallet's
+ * `ensure_threshold_signatures` requires all sigs in one envelope — no
+ * cross-call accumulation — so this gateway-side aggregator closes the
+ * autopilot coordination gap (task #286 / settle-sig-aggregation-design.md).
+ *
+ * Trust model:
+ *   - Each row is self-authenticating: gateway verifies sr25519(pubkey,
+ *     sig) over the claimed `digest` before storing. Forged rows can't
+ *     pass that check.
+ *   - Gateway does NOT verify pubkey is a current committee member; the
+ *     pallet does that at submit-time. This keeps the gateway chain-
+ *     degraded-friendly (cleanup keeps running even if the RPC is down).
+ *   - 24h hard TTL via periodic cleanup. On-chain SettlementRequestTtl
+ *     is ~4h so this gives ample post-mortem window.
+ *
+ * Schema is intentionally narrow — one table, composite PK keyed by
+ * (kind, key_hex, digest_hex, pubkey_hex). Two daemons publishing the
+ * SAME digest for the same key dedupe by pubkey; two daemons publishing
+ * DIFFERENT digests (chain-state mismatch) live side-by-side so a GET
+ * caller can pick the set matching its local computation.
+ */
+
+import Database from "better-sqlite3";
+import { join } from "path";
+import { config } from "./config.js";
+
+/** Settle vs expire — the two M-of-N flows that share this storage. */
+export const MULTISIG_KINDS = ["settle", "expire"] as const;
+export type MultisigKind = (typeof MULTISIG_KINDS)[number];
+
+/** Stored sig entry. All hex fields lowercase, no `0x` prefix. */
+export interface MultisigSigRow {
+  kind: MultisigKind;
+  key_hex: string;        // 64 hex (claim_id for settle, intent_id for expire)
+  digest_hex: string;     // 64 hex (the 32 bytes that were signed)
+  pubkey_hex: string;     // 64 hex
+  sig_hex: string;        // 128 hex
+  created_at: number;     // unix seconds
+}
+
+let db: Database.Database | null = null;
+
+/** Test hook — inject a handle (typically `:memory:` for unit tests). */
+export function setMultisigSigsDbForTests(injected: Database.Database): void {
+  db = injected;
+}
+
+/** Test/debug helper — returns the current handle or throws if unset. */
+export function getMultisigSigsDb(): Database.Database {
+  if (!db) {
+    throw new Error(
+      "multisig_sigs db not initialised — call initMultisigSigsDb() first",
+    );
+  }
+  return db;
+}
+
+/**
+ * Initialise the `multisig_sigs` table. Idempotent; safe to call repeatedly.
+ * If `database` is omitted, opens (or creates) `multisig_sigs.db` at the
+ * canonical storage path.
+ */
+export function initMultisigSigsDb(database?: Database.Database): void {
+  const handle =
+    database ?? new Database(join(config.storagePath, "multisig_sigs.db"));
+  handle.exec(`
+    CREATE TABLE IF NOT EXISTS multisig_sigs (
+      kind        TEXT NOT NULL,
+      key_hex     TEXT NOT NULL,
+      digest_hex  TEXT NOT NULL,
+      pubkey_hex  TEXT NOT NULL,
+      sig_hex     TEXT NOT NULL,
+      created_at  INTEGER NOT NULL,
+      PRIMARY KEY (kind, key_hex, digest_hex, pubkey_hex)
+    );
+    CREATE INDEX IF NOT EXISTS idx_multisig_sigs_created
+      ON multisig_sigs(created_at);
+  `);
+  db = handle;
+}
+
+/** Lower + strip a `0x` prefix. Returns `null` if not pure hex of given byte length. */
+function normalizeHex(input: unknown, expectedBytes: number): string | null {
+  if (typeof input !== "string") return null;
+  const raw = input.startsWith("0x") ? input.slice(2) : input;
+  if (raw.length !== expectedBytes * 2) return null;
+  if (!/^[0-9a-fA-F]+$/.test(raw)) return null;
+  return raw.toLowerCase();
+}
+
+/** Type guard for the wire-form `kind` parameter. */
+export function isMultisigKind(s: string): s is MultisigKind {
+  return (MULTISIG_KINDS as readonly string[]).includes(s);
+}
+
+/**
+ * Idempotent upsert. On conflict (same kind/key/digest/pubkey) replaces
+ * the sig but PRESERVES the original `created_at` so the TTL anchor
+ * stays put — a daemon re-POSTing won't reset its expiry.
+ *
+ * All hex inputs MUST already be normalized (lowercased, no `0x`,
+ * correct length). The route layer does that before calling this.
+ */
+export function upsertMultisigSig(
+  row: Omit<MultisigSigRow, "created_at">,
+): { stored: boolean; created_at: number } {
+  const now = Math.floor(Date.now() / 1000);
+  const h = getMultisigSigsDb();
+  // Two-step so we can preserve created_at on update.
+  const existing = h
+    .prepare(
+      `SELECT created_at FROM multisig_sigs
+        WHERE kind = ? AND key_hex = ? AND digest_hex = ? AND pubkey_hex = ?`,
+    )
+    .get(row.kind, row.key_hex, row.digest_hex, row.pubkey_hex) as
+    | { created_at: number }
+    | undefined;
+  if (existing) {
+    h.prepare(
+      `UPDATE multisig_sigs SET sig_hex = ?
+        WHERE kind = ? AND key_hex = ? AND digest_hex = ? AND pubkey_hex = ?`,
+    ).run(
+      row.sig_hex,
+      row.kind,
+      row.key_hex,
+      row.digest_hex,
+      row.pubkey_hex,
+    );
+    return { stored: true, created_at: existing.created_at };
+  }
+  h.prepare(
+    `INSERT INTO multisig_sigs
+      (kind, key_hex, digest_hex, pubkey_hex, sig_hex, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(row.kind, row.key_hex, row.digest_hex, row.pubkey_hex, row.sig_hex, now);
+  return { stored: true, created_at: now };
+}
+
+/**
+ * List sigs for a given (kind, key). When `digest_hex` is provided, restricts
+ * to rows matching that digest — the daemon use case (only pull peer sigs
+ * over the digest we just computed locally).
+ */
+export function listMultisigSigs(
+  kind: MultisigKind,
+  key_hex: string,
+  digest_hex?: string,
+): MultisigSigRow[] {
+  const h = getMultisigSigsDb();
+  if (digest_hex !== undefined) {
+    return h
+      .prepare(
+        `SELECT kind, key_hex, digest_hex, pubkey_hex, sig_hex, created_at
+           FROM multisig_sigs
+          WHERE kind = ? AND key_hex = ? AND digest_hex = ?
+          ORDER BY pubkey_hex ASC`,
+      )
+      .all(kind, key_hex, digest_hex) as MultisigSigRow[];
+  }
+  return h
+    .prepare(
+      `SELECT kind, key_hex, digest_hex, pubkey_hex, sig_hex, created_at
+         FROM multisig_sigs
+        WHERE kind = ? AND key_hex = ?
+        ORDER BY digest_hex ASC, pubkey_hex ASC`,
+    )
+    .all(kind, key_hex) as MultisigSigRow[];
+}
+
+/**
+ * Delete rows older than `maxAgeSeconds` (default 24h). Returns the
+ * number of rows removed.
+ */
+export function cleanupMultisigSigs(maxAgeSeconds = 86400): number {
+  const cutoff = Math.floor(Date.now() / 1000) - maxAgeSeconds;
+  const h = getMultisigSigsDb();
+  const res = h
+    .prepare(`DELETE FROM multisig_sigs WHERE created_at < ?`)
+    .run(cutoff);
+  return res.changes;
+}
+
+/** Periodic cleanup loop. Returns a stop function (mainly for tests). */
+export function startMultisigSigsCleanup(
+  intervalMs = 5 * 60 * 1000,
+): () => void {
+  const tick = (): void => {
+    try {
+      const removed = cleanupMultisigSigs();
+      if (removed > 0) {
+        console.log(`[multisig_sigs] cleanup: removed ${removed} expired rows`);
+      }
+    } catch (err) {
+      console.warn(`[multisig_sigs] cleanup error: ${err}`);
+    }
+  };
+  // Run once at start, then on a timer.
+  tick();
+  const handle = setInterval(tick, intervalMs);
+  return () => clearInterval(handle);
+}
+
+/** Helper for the route — exported for tests too. */
+export function parseAndValidatePayload(
+  body: unknown,
+): { pubkey_hex: string; sig_hex: string; digest_hex: string } | { error: string } {
+  if (typeof body !== "object" || body === null) {
+    return { error: "body_must_be_object" };
+  }
+  const b = body as Record<string, unknown>;
+  const pubkey_hex = normalizeHex(b.pubkey, 32);
+  const sig_hex = normalizeHex(b.sig, 64);
+  const digest_hex = normalizeHex(b.digest, 32);
+  if (!pubkey_hex) return { error: "pubkey_must_be_32_byte_hex" };
+  if (!sig_hex) return { error: "sig_must_be_64_byte_hex" };
+  if (!digest_hex) return { error: "digest_must_be_32_byte_hex" };
+  return { pubkey_hex, sig_hex, digest_hex };
+}
+
+/** Helper for the route — validates the {kind}/{key} path segments. */
+export function parsePathSegments(
+  kindRaw: string,
+  keyRaw: string,
+): { kind: MultisigKind; key_hex: string } | { error: string } {
+  if (!isMultisigKind(kindRaw)) {
+    return { error: "kind_must_be_settle_or_expire" };
+  }
+  const key_hex = normalizeHex(keyRaw, 32);
+  if (!key_hex) return { error: "key_must_be_32_byte_hex" };
+  return { kind: kindRaw, key_hex };
+}

--- a/services/blob-gateway/src/routes/multisig_sigs.ts
+++ b/services/blob-gateway/src/routes/multisig_sigs.ts
@@ -1,0 +1,128 @@
+/**
+ * `POST /v2/multisig_sigs/{kind}/{key}` — cert-daemon publishes its
+ * (pubkey, sig) over the canonical STCA / EXPP digest for a claim or
+ * intent. Gateway verifies sr25519 + stores. Idempotent on (kind, key,
+ * digest, pubkey).
+ *
+ * `GET  /v2/multisig_sigs/{kind}/{key}` — peer cert-daemons (or anyone)
+ * fetch the union of sigs published so far. Optional `?digest=` filter.
+ *
+ * Closes the M-of-N coordination gap (task #286). See design memo
+ * at /home/deci/work/settle-sig-aggregation-design.md.
+ *
+ * Trust model:
+ *   - Each row is self-authenticating (gateway runs sr25519Verify(pubkey,
+ *     sig, digest) before storing). Forged rows can't pass.
+ *   - Pubkey is NOT checked against the on-chain committee here —
+ *     that's `ensure_threshold_signatures`'s job at submit-time. Keeping
+ *     it gateway-stateless means the endpoint stays up if the RPC is
+ *     degraded.
+ *   - No bearer-auth on POST: a daemon's sig over the digest is itself
+ *     the credential. Spam is bounded by the periodic 24h TTL cleanup.
+ *
+ * Failure-mode mapping:
+ *   400 — body shape / hex length / unknown kind / unknown key format
+ *   401 — signature invalid (sr25519 verify failed)
+ *   500 — storage error
+ */
+
+import type { Application, Request, Response } from "express";
+import { sr25519Verify } from "@polkadot/util-crypto";
+import { hexToU8a } from "@polkadot/util";
+import {
+  listMultisigSigs,
+  parseAndValidatePayload,
+  parsePathSegments,
+  upsertMultisigSig,
+} from "../multisig_sigs_store.js";
+
+export function registerMultisigSigsRoutes(app: Application): void {
+  app.post(
+    "/v2/multisig_sigs/:kind/:key",
+    (req: Request, res: Response): void => {
+      const path = parsePathSegments(req.params.kind, req.params.key);
+      if ("error" in path) {
+        res.status(400).json({ error: path.error });
+        return;
+      }
+      const payload = parseAndValidatePayload(req.body);
+      if ("error" in payload) {
+        res.status(400).json({ error: payload.error });
+        return;
+      }
+      // sr25519 verify — the bytes signed are EXACTLY the 32-byte digest.
+      // No envelope/preimage wrapping at this layer: the daemon already
+      // hashed (STCA or EXPP preimage) → 32-byte digest.
+      let valid = false;
+      try {
+        valid = sr25519Verify(
+          hexToU8a("0x" + payload.digest_hex),
+          hexToU8a("0x" + payload.sig_hex),
+          hexToU8a("0x" + payload.pubkey_hex),
+        );
+      } catch {
+        valid = false;
+      }
+      if (!valid) {
+        res.status(401).json({ error: "invalid_sig" });
+        return;
+      }
+      try {
+        const result = upsertMultisigSig({
+          kind: path.kind,
+          key_hex: path.key_hex,
+          digest_hex: payload.digest_hex,
+          pubkey_hex: payload.pubkey_hex,
+          sig_hex: payload.sig_hex,
+        });
+        const expires_at_unix = result.created_at + 86400;
+        res.status(200).json({
+          ok: true,
+          stored: result.stored,
+          expires_at_unix,
+        });
+      } catch (err) {
+        console.warn(`[multisig_sigs POST] storage error: ${err}`);
+        res.status(500).json({ error: "storage_error" });
+      }
+    },
+  );
+
+  app.get(
+    "/v2/multisig_sigs/:kind/:key",
+    (req: Request, res: Response): void => {
+      const path = parsePathSegments(req.params.kind, req.params.key);
+      if ("error" in path) {
+        res.status(400).json({ error: path.error });
+        return;
+      }
+      const digestQ = req.query.digest;
+      let digestFilter: string | undefined;
+      if (typeof digestQ === "string" && digestQ.length > 0) {
+        const raw = digestQ.startsWith("0x") ? digestQ.slice(2) : digestQ;
+        if (raw.length !== 64 || !/^[0-9a-fA-F]+$/.test(raw)) {
+          res.status(400).json({ error: "digest_query_must_be_32_byte_hex" });
+          return;
+        }
+        digestFilter = raw.toLowerCase();
+      }
+      try {
+        const rows = listMultisigSigs(path.kind, path.key_hex, digestFilter);
+        res.status(200).json({
+          kind: path.kind,
+          key: path.key_hex,
+          sigs: rows.map((r) => ({
+            pubkey: r.pubkey_hex,
+            sig: r.sig_hex,
+            digest: r.digest_hex,
+            created_at: r.created_at,
+          })),
+          count: rows.length,
+        });
+      } catch (err) {
+        console.warn(`[multisig_sigs GET] storage error: ${err}`);
+        res.status(500).json({ error: "storage_error" });
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- New `POST` + `GET /v2/multisig_sigs/{kind}/{key}` endpoints (kind ∈ `settle` | `expire`)
- SQLite-backed ephemeral bulletin board (24h TTL) for cert-daemon to publish + collect peer sigs over canonical STCA / EXPP digests
- sr25519 verify gates every POST (self-authenticating, no bearer-auth needed)
- 24 unit tests (in-memory sqlite + ephemeral express server)

## Why
Today's e2e-06 autonomous demo run surfaced that `pallet-intent-settlement::ensure_threshold_signatures` requires M sigs in **one envelope** — no cross-call accumulation. Each cert-daemon was submitting a 1-sig envelope so every `attest_settle` rejected with `InsufficientSignatures`. Manual aggregator (`e2e-04`) was the only path to settle. This PR closes the autopilot coordination gap (task #286).

## Trust model
- sr25519Verify(pubkey, sig, digest) gates every POST — forged rows can't enter
- Gateway does NOT check on-chain committee membership; pallet does at submit-time
- Composite PK `(kind, key, digest, pubkey)` — daemons that derive divergent digests never collide silently
- 24h hard TTL via 5min cleanup tick; on-chain `SettlementRequestTtl` is ~4h so this leaves margin for post-mortem

## Companion PR
Operator-kit PR (next) wires the daemon side:
- `daemon/multisig_aggregator.py` (POST/GET helpers)
- `substrate_client.submit_attest_settle_envelope` + `submit_attest_expire_policy_envelope` (multi-sig variants)
- `settle_claim_attestor` + `expire_policy_attestor` integration

Design memo at `/home/deci/work/settle-sig-aggregation-design.md`.

## Test plan
- [x] Unit tests pass: 24/24
- [x] TypeScript compile clean
- [ ] Sec-review surfaces no findings ≥0.8 confidence
- [ ] After daemon companion deploys, re-run `e2e-06-autonomous.py` end-to-end and confirm `ClaimSettled` event fires WITHOUT invoking `e2e-04-manual-attest-settle.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)