### PR TITLE
feat(blob-gateway): add "slash" to MULTISIG_KINDS for spec-225 FRAU channel

### DIFF
--- a/services/blob-gateway/src/__tests__/multisig_sigs.test.ts
+++ b/services/blob-gateway/src/__tests__/multisig_sigs.test.ts
@@ -267,9 +267,12 @@ describe("multisig_sigs store", () => {
 });
 
 describe("isMultisigKind", () => {
-  test("settle + expire only", () => {
+  test("settle + expire + slash only", () => {
     expect(isMultisigKind("settle")).toBe(true);
     expect(isMultisigKind("expire")).toBe(true);
+    // spec-225 / task #84-watcher: FRAU channel for the
+    // slash_bad_settlement_evidence watcher path on cert-daemon.
+    expect(isMultisigKind("slash")).toBe(true);
     expect(isMultisigKind("batch")).toBe(false);
     expect(isMultisigKind("")).toBe(false);
   });

--- a/services/blob-gateway/src/multisig_sigs_store.ts
+++ b/services/blob-gateway/src/multisig_sigs_store.ts
@@ -32,14 +32,26 @@ import Database from "better-sqlite3";
 import { join } from "path";
 import { config } from "./config.js";
 
-/** Settle vs expire — the two M-of-N flows that share this storage. */
-export const MULTISIG_KINDS = ["settle", "expire"] as const;
+/**
+ * The M-of-N flows that share this storage:
+ *  - `settle` — STCA attestation sigs over a `settle_claim`-bound digest
+ *    (cert-daemon's settle_claim_attestor path, spec-220).
+ *  - `expire` — EXPP attestation sigs over an `expire_policy_mirror`-bound
+ *    digest (cert-daemon's expire_policy_attestor path, spec-221).
+ *  - `slash` — FRAU attestation sigs over a `slash_bad_settlement_evidence`-
+ *    bound digest (cert-daemon's slash_watcher path, spec-225 / task #84).
+ * Each channel uses byte-distinct domain tags (STCA/EXPP/FRAU) so per-
+ * channel sigs cannot replay across channels — the gateway only namespaces
+ * the storage; payload-level domain separation is the on-chain pallet's
+ * job.
+ */
+export const MULTISIG_KINDS = ["settle", "expire", "slash"] as const;
 export type MultisigKind = (typeof MULTISIG_KINDS)[number];
 
 /** Stored sig entry. All hex fields lowercase, no `0x` prefix. */
 export interface MultisigSigRow {
   kind: MultisigKind;
-  key_hex: string;        // 64 hex (claim_id for settle, intent_id for expire)
+  key_hex: string;        // 64 hex (claim_id for settle/slash, intent_id for expire)
   digest_hex: string;     // 64 hex (the 32 bytes that were signed)
   pubkey_hex: string;     // 64 hex
   sig_hex: string;        // 128 hex


### PR DESCRIPTION
## Summary

- Adds `"slash"` to `MULTISIG_KINDS` in `services/blob-gateway/src/multisig_sigs_store.ts` so the gateway accepts FRAU peer-sig POST/GET on the `/v2/multisig_sigs/slash/{claim_id}` endpoint. Unblocks the cert-daemon's `slash_watcher` module (operator-kit PR #34, merged 2026-05-15).
- Single-line widen of an existing tuple + corresponding test extension. No schema migration, no new endpoint surface.

## Why this change is needed

The cert-daemon's spec-225 slash watcher (PR #34 on materios-operator-kit) coordinates `slash_bad_settlement_evidence` peer sigs through this gateway's existing `/v2/multisig_sigs/{kind}/{key}` shared-storage route. Before this PR, the gateway whitelisted only `"settle"` and `"expire"` channels — every slash-channel POST silently rejects with `isMultisigKind() === false`. The cert-daemon defers gracefully (loud `logger.error` per round-1 sec-review fix on PR #34) but the slash channel never actually round-trips peer sigs in production.

## Channel semantics

| kind | domain tag | pallet flow | key field |
|---|---|---|---|
| settle | STCA | `settle_claim` attestation (spec-220) | claim_id |
| expire | EXPP | `expire_policy_mirror` attestation (spec-221) | intent_id |
| **slash** | **FRAU** | **`slash_bad_settlement_evidence` (spec-225 / task #84)** | **claim_id** |

Cross-channel domain separation is enforced on chain: each digest pre-image starts with its own 4-byte tag (`STCA` / `EXPP` / `FRAU`), so per-channel sigs cannot replay across channels regardless of gateway namespacing. The gateway only partitions the storage; payload-level safety lives in the pallet at `pallets/intent-settlement/src/lib.rs:622-633` and equivalent.

## Test plan

- [x] `pnpm vitest run services/blob-gateway/src/__tests__/multisig_sigs.test.ts` — 24/24 green
- [x] `pnpm vitest run services/blob-gateway` (full gateway suite) — 704 passed / 3 skipped
- [x] Test extended: `isMultisigKind` now asserts `slash` is accepted alongside `settle` + `expire`
- [x] No other source file in `services/blob-gateway/src/` hardcodes the 2-kinds assumption (grep clean)

## Deploy ordering

1. Merge this PR → rebuild + deploy blob-gateway container.
2. Rebuild operator-kit cert-daemon container with PR #34 included.
3. Bounce cert-daemon on Gemtek / Node-2 / Node-3.
4. End-to-end smoke: post deliberately bad settlement evidence + bond, watch slash watcher fire `slash_bad_settlement_evidence` within `BondReleaseDelayBlocks = 30` (~3min @ 6s/block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)