### PR TITLE
feat(blob-gateway): GET /preprod-explorer/api/validators (#337)

### DIFF
--- a/services/blob-gateway/src/data/operators.json
+++ b/services/blob-gateway/src/data/operators.json
@@ -1,0 +1,9 @@
+{
+  "0x03477fc2a5b7b287ed89ec47556e0002aa0d7cf88b1fbd6fbe1722eb1ef7873599": { "label": "Gemtek", "trust": "permissioned" },
+  "0x034f293c281c59b8200ea316d1c8d7154c1b06a9ed2603251049b9fda63f2ed6ce": { "label": "Node-2", "trust": "permissioned" },
+  "0x03f2c1c50d62f023c637afe79996843157c6914e929605cde3c53de47a6896fc0e": { "label": "Node-3", "trust": "permissioned" },
+  "0x02ec64822300713585d9b0c3eb1456bb99c3cc42d79f4ab8e53538e50c9bed0a61": { "label": "MacBook", "trust": "permissioned" },
+  "0x0316acb17138d708413136b2b30b665bf7ac4a7bf4b6c215c3ea6279bb50e77494": { "label": "Hetzner", "trust": "spo" },
+  "0x03fd3eebfad926c785f8ffe4b960e4565dd0b6a6ddd649f691e430358596a1cad7": { "label": "TrueAiData", "trust": "spo" },
+  "0x0369bf6533d1e58b853a5972c042dee640199313dee0f20177b17702ccfe31d7d0": { "label": "Runir", "trust": "spo" }
+}

--- a/services/blob-gateway/src/index.ts
+++ b/services/blob-gateway/src/index.ts
@@ -21,6 +21,7 @@ import { startReceiptIndexer } from "./receipt-indexer.js";
 import { initApiTokensDb } from "./api-tokens.js";
 import { registerTokenRoutes } from "./routes/tokens.js";
 import { chainInfoRouter, initChainInfoPoller } from "./routes/chain-info.js";
+import { explorerValidatorsRouter } from "./routes/explorer-validators.js";
 import { faucetRouter } from "./routes/faucet.js";
 import { registerAdminKeysRoutes } from "./routes/admin-keys.js";
 import { meteringRouter } from "./routes/metering.js";
@@ -103,6 +104,7 @@ app.use(batchesRouter);     // Write: resolveAuth(). Read: public.
 app.use(heartbeatsRouter);  // Handles own dual-mode auth (Phase 2)
 app.use(operatorsRouter);   // Invite-only operator registration
 app.use(chainInfoRouter);   // Public: /chain-info — used by flux1 explorer + cert-daemon auto-discovery
+app.use(explorerValidatorsRouter); // Task #337: GET /preprod-explorer/api/validators — public committee snapshot for SPO operators.
 app.use(faucetRouter);      // Public: /faucet/drip — operator onboarding (MATRA + MOTRA bootstrap). Volume-mounted overrides accepted; see ops compose templates.
 app.use(meteringRouter);    // Task #109: POST /metering/submit — compute_metering_v1 ingestion + sponsored-receipt forwarding.
 app.use(billingRouter);     // Task #112: GET /billing/usage — verifiable compute-metering billing query.

--- a/services/blob-gateway/src/routes/__tests__/explorer-validators.test.ts
+++ b/services/blob-gateway/src/routes/__tests__/explorer-validators.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for GET /preprod-explorer/api/validators (task #337).
+ *
+ * The route is injected with a fake `apiFactory` so we never have to stand
+ * up a real WS RPC. Each test wires the shapes returned by the storage
+ * queries explicitly — that way regressions in the response shape get
+ * caught here, and a real RPC outage in CI doesn't flake the suite.
+ */
+
+import { describe, test, expect, beforeAll } from "vitest";
+import express from "express";
+import {
+  createExplorerValidatorsRouter,
+  type ExplorerApiFactory,
+} from "../explorer-validators.js";
+
+interface CallResult {
+  status: number;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+async function callApp(
+  app: express.Express,
+  path: string,
+): Promise<CallResult> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr === "string" || addr === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      fetch(url)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: unknown;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          const headers: Record<string, string> = {};
+          res.headers.forEach((v, k) => {
+            headers[k] = v;
+          });
+          server.close();
+          resolve({ status: res.status, body: parsed, headers });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+// Known operator pubkeys from src/data/operators.json — we use the real
+// values so the loader is also exercised. Slot-encoding helper below
+// produces a digest log that decodes to a specific slot via @polkadot/api.
+const GEMTEK = "0x03477fc2a5b7b287ed89ec47556e0002aa0d7cf88b1fbd6fbe1722eb1ef7873599";
+const NODE2 = "0x034f293c281c59b8200ea316d1c8d7154c1b06a9ed2603251049b9fda63f2ed6ce";
+const NODE3 = "0x03f2c1c50d62f023c637afe79996843157c6914e929605cde3c53de47a6896fc0e";
+const UNKNOWN_PUBKEY =
+  "0x" + "ab".repeat(33); // 33-byte secp256k1 compressed-pubkey shape, not in operators.json
+
+const AURA_GEMTEK = "0x" + "11".repeat(32);
+const AURA_NODE2 = "0x" + "22".repeat(32);
+const AURA_NODE3 = "0x" + "33".repeat(32);
+
+const GRANDPA_GEMTEK = "0x" + "aa".repeat(32);
+const GRANDPA_NODE2 = "0x" + "bb".repeat(32);
+const GRANDPA_NODE3 = "0x" + "cc".repeat(32);
+
+// AURA pre-runtime log identifier is the 4-byte little-endian "aura" tag
+// in the polkadot.js engine name. The api factory mock returns a digest
+// log directly via the logs accessor, so the route just reads `.asPreRuntime[1]`.
+function makeDigest(slot: bigint): unknown[] {
+  // u64 LE-encoded slot — exactly what @polkadot/api gives back when you
+  // call AuraPreDigest::decode on a real header.
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64LE(slot);
+  return [
+    {
+      isPreRuntime: true,
+      asPreRuntime: [{ toString: () => "aura" }, { toU8a: () => new Uint8Array(buf) }],
+    },
+  ];
+}
+
+interface FakeChainConfig {
+  headNumber: number;
+  /**
+   * For each block height 0..headNumber, the slot to encode in the digest.
+   * If missing, no aura preruntime is emitted (treated as "no author").
+   */
+  slotByHeight?: Map<number, bigint>;
+  currentCommittee: Array<[string, { aura: string; grandpa: string }]>;
+  nextCommittee:
+    | { epoch: number; committee: Array<[string, { aura: string; grandpa: string }]> }
+    | null;
+  // Override the head timestamp for stable golden checks
+  asOfIso: string;
+  scEpoch: number;
+}
+
+function makeFakeApi(cfg: FakeChainConfig): ReturnType<ExplorerApiFactory> {
+  const headHash = "0xHEAD";
+  const headerFor = (n: number) => ({
+    number: { toNumber: () => n },
+    hash: { toHex: () => `0x${n.toString(16).padStart(64, "0")}` },
+    digest: {
+      logs: cfg.slotByHeight?.has(n)
+        ? makeDigest(cfg.slotByHeight.get(n)!)
+        : [],
+    },
+  });
+
+  const api = {
+    rpc: {
+      chain: {
+        getHeader: async (hash?: unknown) => {
+          if (hash === undefined) return headerFor(cfg.headNumber);
+          const hex = String((hash as { toHex?: () => string }).toHex?.() ?? hash);
+          const n = parseInt(hex.replace(/^0x/, ""), 16);
+          return headerFor(n);
+        },
+        getBlockHash: async (n: number) => ({
+          toHex: () => `0x${n.toString(16).padStart(64, "0")}`,
+        }),
+      },
+    },
+    query: {
+      sessionCommitteeManagement: {
+        currentCommittee: async () => ({
+          toJSON: () => ({ committee: cfg.currentCommittee }),
+        }),
+        nextCommittee: async () => ({
+          isNone: cfg.nextCommittee === null,
+          unwrapOr: (def: unknown) =>
+            cfg.nextCommittee === null
+              ? def
+              : { toJSON: () => cfg.nextCommittee },
+          toJSON: () => cfg.nextCommittee,
+        }),
+      },
+      session: {
+        currentIndex: async () => ({ toNumber: () => cfg.scEpoch }),
+      },
+    },
+    consts: {
+      // No-op; the route reads minAttestationThreshold via runtime call if
+      // available, falls back to a constant.
+    },
+    disconnect: async () => undefined,
+  };
+
+  return Promise.resolve(api as unknown as Awaited<ReturnType<ExplorerApiFactory>>);
+}
+
+beforeAll(() => {
+  // no-op — every test builds its own app + factory
+});
+
+describe("GET /preprod-explorer/api/validators", () => {
+  test("happy path: returns 200 with parseable JSON and non-empty currentCommittee", async () => {
+    // 3-member committee, head=10, slots assigned so author = index 0,1,2 spread
+    const slotByHeight = new Map<number, bigint>();
+    for (let n = 1; n <= 10; n++) slotByHeight.set(n, BigInt(n));
+    const cfg: FakeChainConfig = {
+      headNumber: 10,
+      slotByHeight,
+      currentCommittee: [
+        [GEMTEK, { aura: AURA_GEMTEK, grandpa: GRANDPA_GEMTEK }],
+        [NODE2, { aura: AURA_NODE2, grandpa: GRANDPA_NODE2 }],
+        [NODE3, { aura: AURA_NODE3, grandpa: GRANDPA_NODE3 }],
+      ],
+      nextCommittee: null,
+      asOfIso: "2026-05-21T14:30:00Z",
+      scEpoch: 494271,
+    };
+    const app = express();
+    app.use(createExplorerValidatorsRouter({ apiFactory: () => makeFakeApi(cfg) }));
+
+    const res = await callApp(app, "/preprod-explorer/api/validators");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+
+    const body = res.body as Record<string, unknown>;
+    expect(body.head).toBe(10);
+    expect(typeof body.asOf).toBe("string");
+    expect(body.scEpoch).toBe(494271);
+    expect(Array.isArray(body.currentCommittee)).toBe(true);
+    expect((body.currentCommittee as unknown[]).length).toBe(3);
+    expect(body.nextCommittee).toEqual([]);
+    expect(typeof body.minAttestationThreshold).toBe("number");
+
+    const cc = body.currentCommittee as Array<Record<string, unknown>>;
+    const gem = cc.find((c) => c.sidechain === GEMTEK)!;
+    expect(gem.label).toBe("Gemtek");
+    expect(gem.trust).toBe("permissioned");
+    expect(gem.aura).toBe(AURA_GEMTEK);
+    expect(gem.grandpa).toBe(GRANDPA_GEMTEK);
+    expect(typeof gem.producing).toBe("boolean");
+    expect(typeof gem.blocksInLast60).toBe("number");
+    // With slots 1..10 across 3 members, every member should have authored
+    // at least one block (round-robin slot % 3).
+    expect(gem.producing).toBe(true);
+    expect(gem.blocksInLast60).toBeGreaterThan(0);
+  });
+
+  test("unknown sidechain pubkey: returns label:null, trust:'unknown' (no 500)", async () => {
+    const cfg: FakeChainConfig = {
+      headNumber: 5,
+      slotByHeight: new Map([
+        [1, 0n],
+        [2, 1n],
+        [3, 0n],
+        [4, 1n],
+        [5, 0n],
+      ]),
+      currentCommittee: [
+        [GEMTEK, { aura: AURA_GEMTEK, grandpa: GRANDPA_GEMTEK }],
+        [UNKNOWN_PUBKEY, { aura: "0x" + "44".repeat(32), grandpa: "0x" + "55".repeat(32) }],
+      ],
+      nextCommittee: {
+        epoch: 494272,
+        committee: [
+          [UNKNOWN_PUBKEY, { aura: "0x" + "44".repeat(32), grandpa: "0x" + "55".repeat(32) }],
+        ],
+      },
+      asOfIso: "2026-05-21T14:30:00Z",
+      scEpoch: 494271,
+    };
+    const app = express();
+    app.use(createExplorerValidatorsRouter({ apiFactory: () => makeFakeApi(cfg) }));
+
+    const res = await callApp(app, "/preprod-explorer/api/validators");
+    expect(res.status).toBe(200);
+
+    const body = res.body as Record<string, unknown>;
+    const cc = body.currentCommittee as Array<Record<string, unknown>>;
+    const unk = cc.find((c) => c.sidechain === UNKNOWN_PUBKEY)!;
+    expect(unk.label).toBeNull();
+    expect(unk.trust).toBe("unknown");
+
+    const nc = body.nextCommittee as Array<Record<string, unknown>>;
+    expect(nc.length).toBe(1);
+    expect(nc[0].label).toBeNull();
+    expect(nc[0].trust).toBe("unknown");
+  });
+
+  test("WS unreachable: returns 503 + error code (does NOT 500)", async () => {
+    const app = express();
+    app.use(
+      createExplorerValidatorsRouter({
+        apiFactory: () => Promise.reject(new Error("connect ECONNREFUSED")),
+      }),
+    );
+
+    const res = await callApp(app, "/preprod-explorer/api/validators");
+    expect(res.status).toBe(503);
+    expect((res.body as Record<string, unknown>).error).toBe("chain_unreachable");
+  });
+
+  test("nextCommittee == null is serialized as []", async () => {
+    const cfg: FakeChainConfig = {
+      headNumber: 3,
+      slotByHeight: new Map([[1, 0n], [2, 1n], [3, 0n]]),
+      currentCommittee: [
+        [GEMTEK, { aura: AURA_GEMTEK, grandpa: GRANDPA_GEMTEK }],
+        [NODE2, { aura: AURA_NODE2, grandpa: GRANDPA_NODE2 }],
+      ],
+      nextCommittee: null,
+      asOfIso: "2026-05-21T14:30:00Z",
+      scEpoch: 494271,
+    };
+    const app = express();
+    app.use(createExplorerValidatorsRouter({ apiFactory: () => makeFakeApi(cfg) }));
+    const res = await callApp(app, "/preprod-explorer/api/validators");
+    expect(res.status).toBe(200);
+    expect((res.body as Record<string, unknown>).nextCommittee).toEqual([]);
+  });
+
+  test("producing:false when committee member authored zero of the last 60 blocks", async () => {
+    // Committee has 3 members, but only slot%3 == 0 ever appears — only member[0]
+    // is producing; member[1] and member[2] should report producing:false.
+    const slotByHeight = new Map<number, bigint>();
+    for (let n = 1; n <= 12; n++) slotByHeight.set(n, BigInt((n - 1) * 3)); // 0,3,6,9...
+    const cfg: FakeChainConfig = {
+      headNumber: 12,
+      slotByHeight,
+      currentCommittee: [
+        [GEMTEK, { aura: AURA_GEMTEK, grandpa: GRANDPA_GEMTEK }],
+        [NODE2, { aura: AURA_NODE2, grandpa: GRANDPA_NODE2 }],
+        [NODE3, { aura: AURA_NODE3, grandpa: GRANDPA_NODE3 }],
+      ],
+      nextCommittee: null,
+      asOfIso: "2026-05-21T14:30:00Z",
+      scEpoch: 494271,
+    };
+    const app = express();
+    app.use(createExplorerValidatorsRouter({ apiFactory: () => makeFakeApi(cfg) }));
+
+    const res = await callApp(app, "/preprod-explorer/api/validators");
+    expect(res.status).toBe(200);
+    const cc = (res.body as { currentCommittee: Array<Record<string, unknown>> })
+      .currentCommittee;
+    const gem = cc.find((c) => c.sidechain === GEMTEK)!;
+    const node2 = cc.find((c) => c.sidechain === NODE2)!;
+    const node3 = cc.find((c) => c.sidechain === NODE3)!;
+    expect(gem.producing).toBe(true);
+    expect(gem.blocksInLast60).toBeGreaterThan(0);
+    expect(node2.producing).toBe(false);
+    expect(node2.blocksInLast60).toBe(0);
+    expect(node3.producing).toBe(false);
+    expect(node3.blocksInLast60).toBe(0);
+  });
+});

--- a/services/blob-gateway/src/routes/explorer-validators.ts
+++ b/services/blob-gateway/src/routes/explorer-validators.ts
@@ -1,0 +1,414 @@
+/**
+ * GET /preprod-explorer/api/validators (task #337).
+ *
+ * Public JSON snapshot of the Materios committee — current + next session,
+ * with each member resolved to a human label and a "producing" probe over
+ * the last 60 blocks. Used by external SPO candidates (Runir, TrueAiData,
+ * Hetzner, ...) to verify they're in the committee without ssh-ing into a
+ * home-lab node.
+ *
+ * Why a separate route from `/chain-info`:
+ *   `/chain-info` is a 30s-cached pre-warmed object scraped by the flux1
+ *   explorer overview AND cert-daemon auto-discovery — every shape change
+ *   forces both downstreams to re-deploy. This route is explorer-only and
+ *   evolves at explorer cadence.
+ *
+ * Cache TTL is 6s — slightly above block-time so a hot-loop hits the cache
+ * but operators see fresh data on every refresh.
+ *
+ * The api factory is injected so tests can drive arbitrary chain state
+ * without standing up a real WS RPC.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { config } from "../config.js";
+import operatorsData from "../data/operators.json" with { type: "json" };
+
+const CACHE_TTL_MS = 6_000;
+const SCAN_WINDOW_BLOCKS = 60;
+const DEFAULT_MIN_ATTESTATION_THRESHOLD = 3;
+// Substrate metadata download over WS is multi-megabyte on a cold cache;
+// 8s is too tight (we saw timeouts against a local Materios node). 25s
+// leaves margin for a cold pod cold-call without keeping a hung request
+// pinned indefinitely if the WS really is dead.
+const API_CONNECT_TIMEOUT_MS = 25_000;
+
+interface OperatorMeta {
+  label: string;
+  trust: "permissioned" | "spo";
+}
+
+type OperatorRegistry = Record<string, OperatorMeta>;
+
+// Loaded once at module init. Static asset, no hot-reload requirement —
+// new operator → ship + redeploy. Centralising the file load keeps the
+// per-request hot path allocation-free.
+const OPERATORS: OperatorRegistry = operatorsData as OperatorRegistry;
+
+interface CommitteeMember {
+  sidechain: string;
+  aura: string;
+  grandpa: string;
+  label: string | null;
+  trust: "permissioned" | "spo" | "unknown";
+  producing: boolean;
+  blocksInLast60: number;
+}
+
+interface ValidatorsSnapshot {
+  head: number;
+  asOf: string;
+  scEpoch: number;
+  currentCommittee: CommitteeMember[];
+  nextCommittee: CommitteeMember[];
+  minAttestationThreshold: number;
+}
+
+export type ExplorerApiFactory = () => Promise<ApiPromise>;
+
+interface RouterDeps {
+  apiFactory?: ExplorerApiFactory;
+  // Override cache for tests that want fresh reads
+  disableCache?: boolean;
+}
+
+// Module-scoped lazy ApiPromise — mirrors `rpc-client.ts` lifecycle. We
+// reuse one WS connection across requests because the metadata fetch on
+// connect is multi-MB and re-establishing it per cache miss would burn
+// hundreds of ms per request. When the WS errors or disconnects we clear
+// the singleton so the next call rebuilds it.
+let defaultApiSingleton: Promise<ApiPromise> | null = null;
+let defaultApiLastAttempt = 0;
+const DEFAULT_API_RECONNECT_COOLDOWN_MS = 30_000;
+
+function defaultApiFactory(): Promise<ApiPromise> {
+  if (defaultApiSingleton) return defaultApiSingleton;
+  if (Date.now() - defaultApiLastAttempt < DEFAULT_API_RECONNECT_COOLDOWN_MS) {
+    return Promise.reject(new Error("api recently failed, in cooldown"));
+  }
+  defaultApiLastAttempt = Date.now();
+
+  const provider = new WsProvider(config.materiosRpcUrl, /* autoConnectMs */ 5000);
+  const racing = Promise.race<ApiPromise>([
+    ApiPromise.create({ provider, noInitWarn: true, throwOnConnect: true }),
+    new Promise<ApiPromise>((_resolve, reject) =>
+      setTimeout(
+        () => reject(new Error("api connect timeout")),
+        API_CONNECT_TIMEOUT_MS,
+      ),
+    ),
+  ]);
+
+  defaultApiSingleton = racing;
+  racing
+    .then((api) => {
+      api.on("disconnected", () => {
+        console.warn("[explorer-validators] RPC disconnected");
+        defaultApiSingleton = null;
+      });
+      api.on("error", (err) => {
+        console.warn(`[explorer-validators] RPC error: ${err}`);
+        defaultApiSingleton = null;
+      });
+    })
+    .catch(() => {
+      defaultApiSingleton = null;
+    });
+  return racing;
+}
+
+interface CommitteeEntry {
+  sidechainPubkey: string;
+  aura: string;
+  grandpa: string;
+}
+
+/**
+ * Normalize the polkadot.js toJSON() shape of
+ * `MainChainScripts::CommitteeEntry` into a flat tuple.
+ *
+ * On chain the shape is roughly:
+ *   { committee: Array<[ sidechain_pubkey, { aura, grandpa } ]> }
+ *
+ * toJSON() flattens the SCALE codec into JSON. We accept multiple shapes
+ * defensively since the runtime metadata has shifted between specs (the
+ * inner record sometimes serialises with snake_case keys, sometimes
+ * camelCase — depends on whether `RuntimeApi` derived names landed).
+ */
+function parseCommittee(raw: unknown): CommitteeEntry[] {
+  if (raw === null || raw === undefined) return [];
+  // Most common shape: { committee: [[pk, {aura, grandpa}], ...] }
+  let pairs: unknown[] | null = null;
+  if (Array.isArray(raw)) {
+    pairs = raw;
+  } else if (typeof raw === "object" && raw !== null) {
+    const obj = raw as Record<string, unknown>;
+    const list = obj.committee ?? obj.Committee;
+    if (Array.isArray(list)) pairs = list;
+  }
+  if (!pairs) return [];
+
+  const out: CommitteeEntry[] = [];
+  for (const pair of pairs) {
+    if (!Array.isArray(pair) || pair.length !== 2) continue;
+    const [pkRaw, keysRaw] = pair;
+    if (typeof pkRaw !== "string") continue;
+    if (typeof keysRaw !== "object" || keysRaw === null) continue;
+    const keys = keysRaw as Record<string, unknown>;
+    const aura = String(keys.aura ?? keys.Aura ?? "");
+    const grandpa = String(keys.grandpa ?? keys.Grandpa ?? "");
+    out.push({ sidechainPubkey: pkRaw, aura, grandpa });
+  }
+  return out;
+}
+
+function resolveOperator(sidechainPubkey: string): {
+  label: string | null;
+  trust: "permissioned" | "spo" | "unknown";
+} {
+  const meta = OPERATORS[sidechainPubkey.toLowerCase()];
+  if (!meta) return { label: null, trust: "unknown" };
+  return { label: meta.label, trust: meta.trust };
+}
+
+/**
+ * Decode the aura pre-runtime slot from a header's digest logs.
+ *
+ * The aura authoring slot is u64 little-endian, stored in the first
+ * PreRuntime log whose engine ID is "aura". Returns null if no aura log is
+ * present (which can legitimately happen for the genesis block).
+ */
+function readAuraSlot(header: unknown): bigint | null {
+  if (typeof header !== "object" || header === null) return null;
+  const h = header as { digest?: { logs?: unknown[] } };
+  const logs = h.digest?.logs ?? [];
+  for (const log of logs) {
+    if (typeof log !== "object" || log === null) continue;
+    const l = log as {
+      isPreRuntime?: boolean;
+      asPreRuntime?: [unknown, unknown];
+    };
+    if (!l.isPreRuntime || !l.asPreRuntime) continue;
+    const engine = String((l.asPreRuntime[0] as { toString?: () => string })?.toString?.() ?? "");
+    if (engine !== "aura") continue;
+    const payload = l.asPreRuntime[1] as { toU8a?: () => Uint8Array };
+    const bytes = payload.toU8a?.();
+    if (!bytes || bytes.length < 8) continue;
+    let slot = 0n;
+    for (let i = 0; i < 8; i++) {
+      slot |= BigInt(bytes[i]) << BigInt(8 * i);
+    }
+    return slot;
+  }
+  return null;
+}
+
+/**
+ * Best-effort head-number extractor. polkadot.js gives a Codec-shaped
+ * number — `.toNumber()` is the canonical accessor; `.toJSON()` returns
+ * a hex string. We tolerate both for test ergonomics.
+ */
+function headerNumber(header: unknown): number {
+  if (typeof header !== "object" || header === null) return 0;
+  const h = header as { number?: { toNumber?: () => number; toJSON?: () => unknown } };
+  const n = h.number?.toNumber?.();
+  if (typeof n === "number" && Number.isFinite(n)) return n;
+  const j = h.number?.toJSON?.();
+  if (typeof j === "string") return parseInt(j, 16);
+  if (typeof j === "number") return j;
+  return 0;
+}
+
+async function scanBlockAuthorCounts(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  api: any,
+  headNumber: number,
+  committeeSize: number,
+): Promise<Map<number, number>> {
+  const counts = new Map<number, number>();
+  if (committeeSize === 0) return counts;
+  const startHeight = Math.max(1, headNumber - SCAN_WINDOW_BLOCKS + 1);
+  // Fetch hashes + headers in parallel so a 60-block scan completes in two
+  // RTTs rather than 120 serial round-trips. WS multiplexing handles the
+  // fan-out cheaply.
+  const heights: number[] = [];
+  for (let n = startHeight; n <= headNumber; n++) heights.push(n);
+  const hashes = await Promise.all(heights.map((n) => api.rpc.chain.getBlockHash(n)));
+  const headers = await Promise.all(hashes.map((h: unknown) => api.rpc.chain.getHeader(h)));
+  for (const h of headers) {
+    const slot = readAuraSlot(h);
+    if (slot === null) continue;
+    const authorIdx = Number(slot % BigInt(committeeSize));
+    counts.set(authorIdx, (counts.get(authorIdx) ?? 0) + 1);
+  }
+  return counts;
+}
+
+async function readScEpoch(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  api: any,
+): Promise<number> {
+  // Try sidechain-specific epoch first (sessionCommitteeManagement), fall
+  // back to the standard session pallet, fall back to 0 — never throw.
+  try {
+    const cur = await api.query.sessionCommitteeManagement?.currentEpoch?.();
+    if (cur !== undefined) {
+      const n = (cur as { toNumber?: () => number }).toNumber?.();
+      if (typeof n === "number" && Number.isFinite(n)) return n;
+    }
+  } catch {
+    // ignore — fall through
+  }
+  try {
+    const idx = await api.query.session?.currentIndex?.();
+    if (idx !== undefined) {
+      const n = (idx as { toNumber?: () => number }).toNumber?.();
+      if (typeof n === "number" && Number.isFinite(n)) return n;
+    }
+  } catch {
+    // ignore — final fallback below
+  }
+  return 0;
+}
+
+async function buildSnapshot(api: ApiPromise): Promise<ValidatorsSnapshot> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const a = api as any;
+  const [headHeader, currentRaw, nextRaw, scEpoch] = await Promise.all([
+    a.rpc.chain.getHeader(),
+    a.query.sessionCommitteeManagement.currentCommittee(),
+    a.query.sessionCommitteeManagement.nextCommittee(),
+    readScEpoch(a),
+  ]);
+
+  const head = headerNumber(headHeader);
+  const currentEntries = parseCommittee(currentRaw?.toJSON?.() ?? currentRaw);
+
+  // `nextCommittee()` returns Option<{epoch, committee}> — we accept the
+  // unwrapped shape, the Option-style shape, or null. The toJSON path
+  // covers polkadot.js's normal serialisation; the isNone path is a
+  // defensive belt-and-braces for tests using fake codecs.
+  let nextEntries: CommitteeEntry[] = [];
+  if (nextRaw !== null && nextRaw !== undefined) {
+    const nextJson =
+      (nextRaw as { isNone?: boolean }).isNone === true
+        ? null
+        : (nextRaw as { toJSON?: () => unknown }).toJSON?.() ?? nextRaw;
+    if (nextJson !== null && nextJson !== undefined) {
+      // Strip the {epoch, committee} wrapper if present.
+      const inner =
+        typeof nextJson === "object" &&
+        nextJson !== null &&
+        "committee" in (nextJson as Record<string, unknown>)
+          ? (nextJson as { committee: unknown }).committee
+          : nextJson;
+      nextEntries = parseCommittee(inner);
+    }
+  }
+
+  const counts = await scanBlockAuthorCounts(a, head, currentEntries.length);
+
+  const currentCommittee: CommitteeMember[] = currentEntries.map((entry, idx) => {
+    const op = resolveOperator(entry.sidechainPubkey);
+    const blocksInLast60 = counts.get(idx) ?? 0;
+    return {
+      sidechain: entry.sidechainPubkey,
+      aura: entry.aura,
+      grandpa: entry.grandpa,
+      label: op.label,
+      trust: op.trust,
+      producing: blocksInLast60 > 0,
+      blocksInLast60,
+    };
+  });
+
+  const nextCommittee: CommitteeMember[] = nextEntries.map((entry) => {
+    const op = resolveOperator(entry.sidechainPubkey);
+    return {
+      sidechain: entry.sidechainPubkey,
+      aura: entry.aura,
+      grandpa: entry.grandpa,
+      label: op.label,
+      trust: op.trust,
+      // Next-session "producing" isn't meaningful before rotation; report
+      // a deterministic placeholder so clients don't conditionally render
+      // based on field presence.
+      producing: false,
+      blocksInLast60: 0,
+    };
+  });
+
+  return {
+    head,
+    asOf: new Date().toISOString(),
+    scEpoch,
+    currentCommittee,
+    nextCommittee,
+    minAttestationThreshold: DEFAULT_MIN_ATTESTATION_THRESHOLD,
+  };
+}
+
+export function createExplorerValidatorsRouter(deps: RouterDeps = {}): Router {
+  const router = Router();
+  const apiFactory = deps.apiFactory ?? defaultApiFactory;
+
+  let cached: ValidatorsSnapshot | null = null;
+  let cachedAt = 0;
+
+  router.get(
+    "/preprod-explorer/api/validators",
+    async (_req: Request, res: Response) => {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+
+      const now = Date.now();
+      if (!deps.disableCache && cached && now - cachedAt < CACHE_TTL_MS) {
+        res.status(200).end(JSON.stringify(cached));
+        return;
+      }
+
+      let api: ApiPromise;
+      try {
+        api = await apiFactory();
+      } catch (err) {
+        console.warn(
+          `[explorer-validators] chain unreachable: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        res.status(503).end(JSON.stringify({ error: "chain_unreachable" }));
+        return;
+      }
+
+      try {
+        const snapshot = await buildSnapshot(api);
+        cached = snapshot;
+        cachedAt = now;
+        res.status(200).end(JSON.stringify(snapshot));
+      } catch (err) {
+        // Any per-query failure after we successfully connected is also
+        // surfaced as 503 — the route's contract is "either fresh chain
+        // state or an honest unavailability signal". A 500 here would
+        // imply a route bug, which it usually isn't (it's runtime metadata
+        // shape drift or a transient RPC). Logging the underlying error
+        // keeps ops debuggable without leaking it on the wire.
+        console.error(
+          `[explorer-validators] build failed: ${
+            err instanceof Error ? err.stack ?? err.message : String(err)
+          }`,
+        );
+        res.status(503).end(JSON.stringify({ error: "chain_unreachable" }));
+      }
+      // NOTE: the default factory is module-singleton, so we do NOT
+      // disconnect the api here. Tests inject their own ephemeral factories
+      // whose objects are GC-collected once the request completes.
+    },
+  );
+
+  return router;
+}
+
+// Convenience default-mount export so `index.ts` can `app.use(explorerValidatorsRouter)`
+// without invoking the factory creator. Mirrors the chainInfoRouter pattern.
+export const explorerValidatorsRouter = createExplorerValidatorsRouter();


### PR DESCRIPTION
## Summary

Public JSON endpoint at `GET /preprod-explorer/api/validators` that returns Materios chain committee state — current + next session, with each member resolved to a human label and a producing / blocks-in-last-60 probe. Lets external SPO candidates verify committee membership without ssh-ing into a home-lab node.

- **New route**: `/preprod-explorer/api/validators` (public, CORS `*`, content-type `application/json; charset=utf-8`).
- **Operator registry**: `src/data/operators.json` — 7 entries today (4 permissioned + 3 SPO including yesterday-onboarded Runir). Unknown sidechain pubkey degrades to `label:null, trust:"unknown"` — never 500s.
- **WS unreachable** → 503 with `{"error":"chain_unreachable"}`. Per-route module-singleton `ApiPromise` with 30s reconnect cooldown, mirroring `rpc-client.ts`.
- **6s response cache** (one block) so the explorer can hot-poll.
- **Injectable api factory** keeps the route fully unit-testable without a real WS RPC.

## Test plan

- [x] `npm test` — `Test Files 36 passed | 3 skipped (39)`, `Tests 715 passed | 3 skipped (718)`. 5 new vitest cases:
  - happy-path: 200 + parseable JSON + non-empty `currentCommittee`
  - unknown sidechain pubkey → `label:null, trust:"unknown"`
  - WS down → 503 (factory rejection mocked)
  - `nextCommittee == null` → serialised as `[]`
  - `producing:false` when a committee member authored zero of the last 60 blocks
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Real runtime: `MATERIOS_RPC_URL=ws://127.0.0.1:9945` against live preprod node, `HTTP=200` in 265ms, `head=273404`, `scEpoch=552`, 7 members resolved (including Hetzner correctly showing `producing:false, blocksInLast60:0`).

## Coordination

Concurrent sibling branch `feat/trace-detail-page-task271` will independently add a single mount line to `src/index.ts` for `traceRouter` — that conflict at merge is expected per task spec.

Resolves task #337.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>