### PR TITLE
chore(spo-rewards): rename Runir → Draupnir in operator registry

### DIFF
--- a/services/blob-gateway/src/data/operators.json
+++ b/services/blob-gateway/src/data/operators.json
@@ -5,5 +5,5 @@
   "0x02ec64822300713585d9b0c3eb1456bb99c3cc42d79f4ab8e53538e50c9bed0a61": { "label": "MacBook", "trust": "permissioned" },
   "0x0316acb17138d708413136b2b30b665bf7ac4a7bf4b6c215c3ea6279bb50e77494": { "label": "Hetzner", "trust": "spo" },
   "0x03fd3eebfad926c785f8ffe4b960e4565dd0b6a6ddd649f691e430358596a1cad7": { "label": "TrueAiData", "trust": "spo" },
-  "0x0369bf6533d1e58b853a5972c042dee640199313dee0f20177b17702ccfe31d7d0": { "label": "Runir", "trust": "spo" }
+  "0x0369bf6533d1e58b853a5972c042dee640199313dee0f20177b17702ccfe31d7d0": { "label": "Draupnir", "trust": "spo" }
 }

--- a/services/blob-gateway/src/data/spo-pools.json
+++ b/services/blob-gateway/src/data/spo-pools.json
@@ -25,7 +25,7 @@
     "cardano_pool_id": "pool18cwl8hgnu2q6q9nr3sjmyys7xj0jzgka29k74lztdzp7qrfhaww"
   },
   "0xd2b8899dc82477cccd8ea2513fd426cbe672a6221050a9707a743c293f5b8e01": {
-    "label": "Runir",
+    "label": "Draupnir",
     "trust": "spo",
     "cardano_pool_id": null
   },

--- a/services/blob-gateway/src/routes/__tests__/explorer-spo-rewards-live-koios.test.ts
+++ b/services/blob-gateway/src/routes/__tests__/explorer-spo-rewards-live-koios.test.ts
@@ -6,7 +6,7 @@
  * Without this guard the rewards tab can silently degrade to "0 ADA" rows
  * whenever someone introduces a bech32 typo (Node-3 history) or links a
  * partner-chain candidate that never submitted a Cardano pool_registration
- * cert (Runir history).
+ * cert (Draupnir history).
  *
  * Gated on LIVE_KOIOS=1 to keep CI offline-deterministic; the route's
  * unit suite (explorer-spo-rewards.test.ts) still exercises every code
@@ -21,11 +21,11 @@
  *   - exactly one row returned matching the queried bech32
  *   - pool_status === "registered"  (not "retired" / "retiring")
  *
- * For `null` entries (Runir post-fix, all permissioned operators) we
+ * For `null` entries (Draupnir post-fix, all permissioned operators) we
  * assert the ROUTE-LAYER contract: the JSON sent to the frontend keeps
  * `cardano_pool_id: null` (the route does not invent a pool) and we do
  * NOT call Koios for them. This is the test that would have failed
- * before the fix — Runir's old ID `pool14jlfe9l…` returned `[]` from
+ * before the fix — Draupnir's old ID `pool14jlfe9l…` returned `[]` from
  * /pool_info, which the test below catches as a hard fail.
  */
 
@@ -121,7 +121,7 @@ describeMaybe("spo-pools.json roster — LIVE Koios resolution", () => {
 
       for (const r of results) {
         // Empty array = pool bech32 is well-formed but no pool registration
-        // cert exists on chain — the exact failure that flagged Runir.
+        // cert exists on chain — the exact failure that flagged Draupnir.
         expect(
           r.rows.length,
           `Koios returned 0 rows for ${r.meta.label} pool ${r.poolId} — ` +
@@ -166,10 +166,10 @@ describeMaybe("spo-pools.json roster — LIVE Koios resolution", () => {
 
   test("SPO rows with null pool_id are intentional, not data drift", () => {
     // Document each null SPO so removing one is a deliberate diff. As of the
-    // task #341 fix this is exactly {"Runir"} — partner-chain candidate
+    // task #341 fix this is exactly {"Draupnir"} — partner-chain candidate
     // registered (tx 2fb1533d…) but the tx carries zero certificates, so
     // no Cardano pool_registration was ever submitted.
     const labels = spoWithoutPool.map(([, m]) => m.label).sort();
-    expect(labels).toEqual(["Runir"]);
+    expect(labels).toEqual(["Draupnir"]);
   });
 });

--- a/services/blob-gateway/src/routes/__tests__/explorer-spo-rewards.test.ts
+++ b/services/blob-gateway/src/routes/__tests__/explorer-spo-rewards.test.ts
@@ -365,12 +365,12 @@ describe("GET /preprod-explorer/api/spo-rewards", () => {
     const ops = (res.body as { operators: Array<Record<string, unknown>> }).operators;
     const labels = ops.map((o) => o.label).sort();
     expect(labels).toEqual([
+      "Draupnir",
       "Gemtek",
       "Hetzner",
       "MacBook",
       "Node-2",
       "Node-3",
-      "Runir",
       "TrueAiData",
     ]);
     // No "unknown" trust rows
@@ -406,11 +406,11 @@ describe("GET /preprod-explorer/api/spo-rewards", () => {
         trust: "spo",
         pool: "pool1y36klnfa4kc3hyggc3fujrm3j6zlgf9r8jhtyufzmgufz3k5pt2",
       },
-      // Runir submitted partner-chain reg (Cardano tx 2fb1533d…) but the
+      // Draupnir submitted partner-chain reg (Cardano tx 2fb1533d…) but the
       // tx carried zero certificates — no Cardano pool_registration ever
       // landed on L1. Until they register, the route MUST return null
       // so the frontend renders "Not registered" instead of "0 ADA".
-      Runir: { trust: "spo", pool: null },
+      Draupnir: { trust: "spo", pool: null },
       Gemtek: { trust: "permissioned", pool: null },
       Node_2: { trust: "permissioned", pool: null },
       MacBook: { trust: "permissioned", pool: null },

--- a/services/blob-gateway/src/routes/explorer-validators.ts
+++ b/services/blob-gateway/src/routes/explorer-validators.ts
@@ -3,7 +3,7 @@
  *
  * Public JSON snapshot of the Materios committee — current + next session,
  * with each member resolved to a human label and a "producing" probe over
- * the last 60 blocks. Used by external SPO candidates (Runir, TrueAiData,
+ * the last 60 blocks. Used by external SPO candidates (Draupnir, TrueAiData,
  * Hetzner, ...) to verify they're in the committee without ssh-ing into a
  * home-lab node.
  *


### PR DESCRIPTION
## Summary
Operator runthulr selected "Draupnir" as their preferred validator label. Pure label-rename across the SPO roster — no key changes, no pool-state changes.

## Files
- `src/data/operators.json` — Validators tab label
- `src/data/spo-pools.json` — Rewards tab label
- `src/routes/explorer-validators.ts` — docblock example
- `src/routes/__tests__/explorer-spo-rewards.test.ts` — roster + assertion
- `src/routes/__tests__/explorer-spo-rewards-live-koios.test.ts` — roster + historical comments

## Test plan
- [x] `npm test` passes (test assertions updated to match)
- [x] `npm run build` + `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)