### PR TITLE
feat(schemas): add ai_capability_observation_v1 schema for attested AI observations

### DIFF
--- a/fixtures/ai_capability_observation_v1.schema.json
+++ b/fixtures/ai_capability_observation_v1.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://orynq.io/schemas/ai_capability_observation_v1.json",
+  "title": "AI Capability Observation v1",
+  "description": "Cryptographically-verifiable schema for attested AI model observations. The canonical CBOR encoder and content_hash semantics are documented in packages/anchors-materios/src/schemas/ai_capability_observation_v1.ts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "model", "capability", "observation", "observer"],
+  "properties": {
+    "schemaVersion": {
+      "const": "ai_capability_observation_v1"
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "hash"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "hash": {
+          "oneOf": [
+            { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            { "type": "null" }
+          ],
+          "description": "Hex (sha256) of the model-weights hash, or null when unknown."
+        }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["taxonomyId", "severity"],
+      "properties": {
+        "taxonomyId": {
+          "type": "string",
+          "pattern": "^[A-Z0-9_-]{1,64}$"
+        },
+        "severity": {
+          "enum": ["low", "medium", "high", "critical"]
+        }
+      }
+    },
+    "observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["promptHash", "responseHash", "artifactRef", "occurredAt"],
+      "properties": {
+        "promptHash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "responseHash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "artifactRef": {
+          "oneOf": [
+            { "type": "string", "minLength": 1, "maxLength": 2048 },
+            { "type": "null" }
+          ],
+          "description": "URL / IPFS CID / blob hash for the full transcript, or null when absent."
+        },
+        "occurredAt": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,9})?Z$",
+          "description": "ISO 8601 UTC timestamp."
+        }
+      }
+    },
+    "observer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ss58", "context", "teeAttestation"],
+      "properties": {
+        "ss58": {
+          "type": "string",
+          "pattern": "^[1-9A-HJ-NP-Za-km-z]{46,50}$",
+          "description": "Materios SS58 address (base58, 46-50 chars depending on prefix)."
+        },
+        "context": {
+          "type": "string",
+          "maxLength": 280
+        },
+        "teeAttestation": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["tier", "evidence"],
+              "properties": {
+                "tier": {
+                  "enum": ["ARM-TZ", "Acurast", "SEV-SNP", "build"]
+                },
+                "evidence": {
+                  "type": "string",
+                  "pattern": "^(?:[0-9a-f]{2})+$",
+                  "description": "Hex-encoded TEE evidence blob (non-empty, even length)."
+                }
+              }
+            },
+            { "type": "null" }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/packages/anchors-materios/src/__tests__/ai_capability_observation_v1.test.ts
+++ b/packages/anchors-materios/src/__tests__/ai_capability_observation_v1.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  SCHEMA_VERSION,
+  SCHEMA_HASH_HEX,
+  TEE_TIERS,
+  SEVERITIES,
+  canonicalCborPreImage,
+  canonicalContentHash,
+  validateAiCapabilityObservationV1,
+  type AiCapabilityObservationV1,
+} from "../schemas/ai_capability_observation_v1.js";
+
+const PUBKEY = "11".repeat(32); // 32 zero-ish bytes for prompt hash
+const PROMPT_HASH = "a".repeat(64);
+const RESPONSE_HASH = "b".repeat(64);
+const MODEL_HASH = "c".repeat(64);
+const TEE_EVIDENCE_HEX = "de".repeat(48); // 96 bytes of evidence
+const OBSERVER_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+const BASELINE: AiCapabilityObservationV1 = {
+  schemaVersion: "ai_capability_observation_v1",
+  model: {
+    name: "claude-opus-4-7",
+    version: "20260201",
+    hash: MODEL_HASH,
+  },
+  capability: {
+    taxonomyId: "AUTO-MONEY-001",
+    severity: "high",
+  },
+  observation: {
+    promptHash: PROMPT_HASH,
+    responseHash: RESPONSE_HASH,
+    artifactRef: "ipfs://QmSomeCidHere",
+    occurredAt: "2026-01-15T12:34:56Z",
+  },
+  observer: {
+    ss58: OBSERVER_SS58,
+    context: "scripted regression run",
+    teeAttestation: {
+      tier: "Acurast",
+      evidence: TEE_EVIDENCE_HEX,
+    },
+  },
+};
+
+const NULL_FIELDS: AiCapabilityObservationV1 = {
+  schemaVersion: "ai_capability_observation_v1",
+  model: {
+    name: "anon-model",
+    version: "v0",
+    hash: null,
+  },
+  capability: {
+    taxonomyId: "TEST-001",
+    severity: "low",
+  },
+  observation: {
+    promptHash: PROMPT_HASH,
+    responseHash: RESPONSE_HASH,
+    artifactRef: null,
+    occurredAt: "2026-05-27T00:00:00Z",
+  },
+  observer: {
+    ss58: OBSERVER_SS58,
+    context: "no tee, no artifact, no model hash",
+    teeAttestation: null,
+  },
+};
+
+describe("ai_capability_observation_v1 schema constants", () => {
+  it("schema version is the pinned literal", () => {
+    expect(SCHEMA_VERSION).toBe("ai_capability_observation_v1");
+  });
+
+  it("schema hash is sha256 of the version string", () => {
+    const expected = createHash("sha256")
+      .update("ai_capability_observation_v1", "utf-8")
+      .digest("hex");
+    expect(SCHEMA_HASH_HEX).toBe(expected);
+  });
+
+  it("enumerates the four TEE tiers in pinned order", () => {
+    expect([...TEE_TIERS]).toEqual(["ARM-TZ", "Acurast", "SEV-SNP", "build"]);
+  });
+
+  it("enumerates the four severity levels in pinned order", () => {
+    expect([...SEVERITIES]).toEqual(["low", "medium", "high", "critical"]);
+  });
+});
+
+describe("canonical CBOR pre-image", () => {
+  it("is deterministic across repeated encoding", () => {
+    const a = canonicalCborPreImage(BASELINE);
+    const b = canonicalCborPreImage(BASELINE);
+    expect(Buffer.from(a).toString("hex")).toBe(Buffer.from(b).toString("hex"));
+  });
+
+  it("is deterministic when input dict key order is shuffled", () => {
+    const a = canonicalCborPreImage(BASELINE);
+    const reordered: AiCapabilityObservationV1 = {
+      // top-level fields in reverse order — pre-image MUST not care
+      observer: BASELINE.observer,
+      observation: BASELINE.observation,
+      capability: BASELINE.capability,
+      model: BASELINE.model,
+      schemaVersion: BASELINE.schemaVersion,
+    };
+    const b = canonicalCborPreImage(reordered);
+    expect(Buffer.from(a).toString("hex")).toBe(Buffer.from(b).toString("hex"));
+  });
+
+  it("differs when any single field changes", () => {
+    const a = canonicalCborPreImage(BASELINE);
+    const mutated: AiCapabilityObservationV1 = {
+      ...BASELINE,
+      capability: { ...BASELINE.capability, severity: "critical" },
+    };
+    const b = canonicalCborPreImage(mutated);
+    expect(Buffer.from(a).toString("hex")).not.toBe(
+      Buffer.from(b).toString("hex"),
+    );
+  });
+
+  it("handles all-null optional fields and differs from the non-null record", () => {
+    const nullPre = canonicalCborPreImage(NULL_FIELDS);
+    expect(nullPre.length).toBeGreaterThan(0);
+    // The non-null record differs from the null-field record in three places
+    // (model.hash, observation.artifactRef, observer.teeAttestation) so the
+    // encoded bytes must differ end-to-end.
+    const fullPre = canonicalCborPreImage(BASELINE);
+    expect(Buffer.from(nullPre).toString("hex")).not.toBe(
+      Buffer.from(fullPre).toString("hex"),
+    );
+  });
+
+  it("null teeAttestation encodes as the CBOR null primitive (0xf6)", () => {
+    // Smallest, surgical test: in NULL_FIELDS the only sub-tree directly
+    // beneath an `teeAttestation` key is `null`, so the byte that immediately
+    // follows the text-encoded key "teeAttestation" (major 3 + len 14 head
+    // = 0x6e) MUST be 0xf6. The key is unique in the document.
+    const pre = canonicalCborPreImage(NULL_FIELDS);
+    const hex = Buffer.from(pre).toString("hex");
+    const keyText = Buffer.from("teeAttestation", "utf-8").toString("hex");
+    const keyHead = "6e" + keyText; // major-3 + length 14
+    const idx = hex.indexOf(keyHead);
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const valueByte = hex.slice(idx + keyHead.length, idx + keyHead.length + 2);
+    expect(valueByte).toBe("f6");
+  });
+
+  it("encodes the schema version literal as the first array element", () => {
+    const pre = canonicalCborPreImage(BASELINE);
+    // CBOR array head major-4 with 5 elements: 0x85. Then text-string major-3
+    // length-28 (the schema-version literal is 28 bytes): 0x78 0x1c, followed
+    // by the UTF-8 bytes of "ai_capability_observation_v1".
+    expect(pre[0]).toBe(0x85);
+    const literalBytes = Buffer.from(SCHEMA_VERSION, "utf-8");
+    expect(literalBytes.length).toBe(28);
+    expect(pre[1]).toBe(0x78); // major 3 + additional 24
+    expect(pre[2]).toBe(0x1c); // length 28
+    expect(Buffer.from(pre.subarray(3, 3 + 28)).toString("utf-8")).toBe(SCHEMA_VERSION);
+  });
+});
+
+describe("content_hash", () => {
+  it("equals sha256 of the canonical CBOR pre-image", () => {
+    const pre = canonicalCborPreImage(BASELINE);
+    const expected = createHash("sha256").update(pre).digest("hex");
+    expect(canonicalContentHash(BASELINE)).toBe(expected);
+  });
+
+  it("is stable across re-encoding of the same input", () => {
+    const a = canonicalContentHash(BASELINE);
+    const b = canonicalContentHash(BASELINE);
+    expect(a).toBe(b);
+  });
+
+  it("changes when capability.severity changes", () => {
+    const a = canonicalContentHash(BASELINE);
+    const b = canonicalContentHash({
+      ...BASELINE,
+      capability: { ...BASELINE.capability, severity: "critical" },
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("validateAiCapabilityObservationV1", () => {
+  it("accepts a fully-populated baseline record", () => {
+    const r = validateAiCapabilityObservationV1(BASELINE);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.record.schemaVersion).toBe(SCHEMA_VERSION);
+      expect(r.contentHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(r.schemaHash).toBe(SCHEMA_HASH_HEX);
+    }
+  });
+
+  it("accepts a record with all optional fields null", () => {
+    const r = validateAiCapabilityObservationV1(NULL_FIELDS);
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects an unknown schemaVersion", () => {
+    const r = validateAiCapabilityObservationV1({
+      ...BASELINE,
+      schemaVersion: "ai_capability_observation_v2",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("WRONG_SCHEMA_VERSION");
+  });
+
+  it("rejects an invalid TEE tier", () => {
+    const r = validateAiCapabilityObservationV1({
+      ...BASELINE,
+      observer: {
+        ...BASELINE.observer,
+        teeAttestation: { tier: "TPM" as never, evidence: TEE_EVIDENCE_HEX },
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("TEE_TIER_INVALID");
+  });
+
+  it("rejects an invalid severity", () => {
+    const r = validateAiCapabilityObservationV1({
+      ...BASELINE,
+      capability: {
+        ...BASELINE.capability,
+        severity: "extreme" as never,
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("SEVERITY_INVALID");
+  });
+
+  it("rejects observer.context longer than 280 chars", () => {
+    const r = validateAiCapabilityObservationV1({
+      ...BASELINE,
+      observer: { ...BASELINE.observer, context: "x".repeat(281) },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("CONTEXT_TOO_LONG");
+  });
+
+  it("rejects a non-hex promptHash", () => {
+    const r = validateAiCapabilityObservationV1({
+      ...BASELINE,
+      observation: { ...BASELINE.observation, promptHash: "not-hex" },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("HEX_FORMAT");
+  });
+
+  it("rejects a non-ISO8601 occurredAt", () => {
+    const r = validateAiCapabilityObservationV1({
+      ...BASELINE,
+      observation: { ...BASELINE.observation, occurredAt: "2026/01/15 12:34" },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("OCCURRED_AT_INVALID");
+  });
+
+  it("rejects a missing model.name", () => {
+    const broken = JSON.parse(JSON.stringify(BASELINE));
+    delete broken.model.name;
+    const r = validateAiCapabilityObservationV1(broken);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("MISSING_FIELD");
+  });
+});

--- a/packages/anchors-materios/src/index.ts
+++ b/packages/anchors-materios/src/index.ts
@@ -58,6 +58,30 @@ export { stripPrefix, ensureHex, zeroHash, isZeroHash } from "./hex.js";
 // Merkle tree utilities
 export { merkleRoot, merkleInclusionProof, verifyMerkleProof } from "./merkle.js";
 
+// Schemas — canonical encoders + validators for receipt-class semantic roots.
+// Discriminator hash `SCHEMA_HASH_HEX` is the value caller passes as
+// `schemaHash` to `submitReceipt` for the matching receipt class.
+export {
+  SCHEMA_VERSION as AI_CAPABILITY_OBSERVATION_V1_SCHEMA_VERSION,
+  SCHEMA_HASH_HEX as AI_CAPABILITY_OBSERVATION_V1_SCHEMA_HASH_HEX,
+  TEE_TIERS,
+  SEVERITIES,
+  MAX_CONTEXT_LEN as AI_CAPABILITY_OBSERVATION_V1_MAX_CONTEXT_LEN,
+  canonicalCborPreImage as canonicalCborPreImageAiCapabilityObservationV1,
+  canonicalContentHash as canonicalContentHashAiCapabilityObservationV1,
+  validateAiCapabilityObservationV1,
+} from "./schemas/ai_capability_observation_v1.js";
+export type {
+  AiCapabilityObservationV1,
+  ModelV1,
+  CapabilityV1,
+  ObservationV1,
+  TeeAttestationV1,
+  ObserverV1,
+  TeeTier,
+  Severity,
+} from "./schemas/ai_capability_observation_v1.js";
+
 // Types
 export type {
   // Anchor types

--- a/packages/anchors-materios/src/receipt.ts
+++ b/packages/anchors-materios/src/receipt.ts
@@ -55,8 +55,8 @@ export async function submitReceipt(
   const manifestHex = assertHex32(input.manifestHash, "manifestHash");
   // schemaHash defaults to legacy (32 zero bytes) when caller omits it,
   // preserving the prior behaviour for plain blob receipts. Callers using
-  // semantic-root receipt classes (compute_metering_v2*, orynq_trace_v1)
-  // MUST pass the matching discriminator from
+  // semantic-root receipt classes (compute_metering_v2*, orynq_trace_v1,
+  // ai_capability_observation_v1) MUST pass the matching discriminator from
   // operator-kit daemon/schemas/, otherwise cert-daemon rejects the
   // receipt with a Merkle mismatch.
   const schemaHex = input.schemaHash
@@ -498,9 +498,10 @@ export async function submitCertifiedReceipt(
 
   // 3. Submit receipt on-chain. Forward `schemaHash` and `receiptId`
   // from the caller's input so semantic-root receipt classes
-  // (compute_metering_v2*, orynq_trace_v1) land on chain with the right
-  // discriminator. Omitting schemaHash falls back to legacy (zero bytes)
-  // = chunk-Merkle path, preserving pre-existing behaviour.
+  // (compute_metering_v2*, orynq_trace_v1, ai_capability_observation_v1)
+  // land on chain with the right discriminator. Omitting schemaHash falls
+  // back to legacy (zero bytes) = chunk-Merkle path, preserving
+  // pre-existing behaviour.
   const receiptInput: ReceiptInput = {
     contentHash: effectiveContentHash,
     rootHash: input.rootHash || contentHashHex,

--- a/packages/anchors-materios/src/schemas/ai_capability_observation_v1.ts
+++ b/packages/anchors-materios/src/schemas/ai_capability_observation_v1.ts
@@ -1,0 +1,726 @@
+/**
+ * `ai_capability_observation_v1` — cryptographically-verifiable schema for
+ * attested AI model observations.
+ *
+ * An observation captures: which model, which observed capability, hashes of
+ * the prompt + response that triggered the observation, who observed it, and
+ * (optionally) a TEE attestation binding the observation to attested hardware.
+ *
+ * --- Wire format vs canonical pre-image ---
+ *
+ * The HTTP wire format is JSON with hex strings for hashes/evidence and base58
+ * SS58 for observer identity. The CANONICAL CBOR pre-image used for signing /
+ * anchoring uses RAW BYTES (CBOR major type 2) for hashes and TEE evidence,
+ * UTF-8 text for IDs and SS58 strings, and CBOR null (`0xf6`) for nullable
+ * fields explicitly set to null.
+ *
+ * --- Canonical CBOR rules (RFC 8949 §4.2.1, distilled to what we use) ---
+ *
+ *   - Definite-length encoding only.
+ *   - Shortest possible integer head per RFC 8949 §3.1.
+ *   - Map keys sorted by encoded-byte lexicographic order.
+ *   - Strings: UTF-8, major type 3.
+ *   - Byte strings: major type 2 (hashes, TEE evidence in pre-images).
+ *   - Arrays: major type 4 (top-level positional pre-image tuple).
+ *   - Maps: major type 5.
+ *   - Null: major type 7, additional 22 (single byte `0xf6`). Encodes a
+ *     nullable field set to `null`. Required for cross-language byte-equality
+ *     when an optional sub-tree (model.hash, observation.artifactRef, or
+ *     observer.teeAttestation) is absent.
+ *
+ * --- Pre-image (PINNED — coordinated with the Python encoder) ---
+ *
+ *   [ "ai_capability_observation_v1", model_map, capability_map,
+ *     observation_map, observer_map ]
+ *
+ *   model_map         { hash: bytes32 | null, name: text, version: text }
+ *   capability_map    { severity: text, taxonomyId: text }
+ *   observation_map   { artifactRef: text | null, occurredAt: text,
+ *                       promptHash: bytes32, responseHash: bytes32 }
+ *   observer_map      { context: text, ss58: text,
+ *                       teeAttestation: { evidence: bytes, tier: text } | null }
+ *
+ * Cross-language byte-equality with the Python encoder is enforced by
+ * `python/tests/test_ai_capability_observation_v1_cross_lang.py`.
+ */
+
+import { createHash } from "node:crypto";
+import { hexToU8a } from "@polkadot/util";
+
+/** Exact schema-version literal. Anything else = reject. */
+export const SCHEMA_VERSION = "ai_capability_observation_v1";
+
+/** sha256 of the schema-version string — used as `schema_hash` upstream. */
+export const SCHEMA_HASH_HEX = createHash("sha256")
+  .update(SCHEMA_VERSION, "utf-8")
+  .digest("hex");
+
+/** Permitted TEE tiers. Order is informational; comparison is by membership. */
+export const TEE_TIERS = ["ARM-TZ", "Acurast", "SEV-SNP", "build"] as const;
+export type TeeTier = (typeof TEE_TIERS)[number];
+const TEE_TIER_SET: ReadonlySet<string> = new Set<string>(TEE_TIERS);
+
+/** Permitted severity levels (ascending). */
+export const SEVERITIES = ["low", "medium", "high", "critical"] as const;
+export type Severity = (typeof SEVERITIES)[number];
+const SEVERITY_SET: ReadonlySet<string> = new Set<string>(SEVERITIES);
+
+/** observer.context length ceiling (chars, not bytes — matches the spec). */
+export const MAX_CONTEXT_LEN = 280;
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const HEX_EVIDENCE = /^[0-9a-f]+$/;
+/**
+ * RFC 3339 / ISO 8601 with a `Z` UTC suffix. Optional fractional seconds.
+ * Examples: `2026-01-15T12:34:56Z`, `2026-01-15T12:34:56.789Z`.
+ * Local-time offsets are intentionally NOT accepted — observations are
+ * recorded in UTC end-to-end so anchored timestamps don't depend on the
+ * observer's local clock format.
+ */
+const OCCURRED_AT_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/;
+/**
+ * SS58 addresses are base58 over a {prefix-byte || 32-byte pubkey || 2-byte
+ * checksum} payload. Length depends on prefix size; for the network prefixes
+ * we use (1 byte) the encoded length is 47-48 chars. This regex is a loose
+ * sanity check on the alphabet + length; cryptographic verification is the
+ * cert-daemon's job.
+ */
+const SS58_RE = /^[1-9A-HJ-NP-Za-km-z]{46,50}$/;
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+export interface ModelV1 {
+  name: string;
+  version: string;
+  /** sha256 hex of the model-weights hash; null if unknown. */
+  hash: string | null;
+}
+
+export interface CapabilityV1 {
+  taxonomyId: string;
+  severity: Severity;
+}
+
+export interface ObservationV1 {
+  /** sha256 hex of the prompt. */
+  promptHash: string;
+  /** sha256 hex of the model response. */
+  responseHash: string;
+  /** URL / IPFS CID / blob hash referencing the full transcript; null if absent. */
+  artifactRef: string | null;
+  /** ISO 8601 UTC timestamp (e.g. "2026-01-15T12:34:56Z"). */
+  occurredAt: string;
+}
+
+export interface TeeAttestationV1 {
+  tier: TeeTier;
+  /** Hex-encoded TEE evidence blob (variable length). */
+  evidence: string;
+}
+
+export interface ObserverV1 {
+  /** Materios SS58 address. */
+  ss58: string;
+  /** Brief human-readable context (≤ 280 chars). */
+  context: string;
+  teeAttestation: TeeAttestationV1 | null;
+}
+
+export interface AiCapabilityObservationV1 {
+  schemaVersion: typeof SCHEMA_VERSION;
+  model: ModelV1;
+  capability: CapabilityV1;
+  observation: ObservationV1;
+  observer: ObserverV1;
+}
+
+// ---------------------------------------------------------------------------
+// Validation result types
+// ---------------------------------------------------------------------------
+
+export type ValidateErrorCode =
+  | "WRONG_TYPE"
+  | "MISSING_FIELD"
+  | "WRONG_SCHEMA_VERSION"
+  | "HEX_FORMAT"
+  | "TEE_TIER_INVALID"
+  | "SEVERITY_INVALID"
+  | "CONTEXT_TOO_LONG"
+  | "OCCURRED_AT_INVALID"
+  | "SS58_FORMAT"
+  | "TAXONOMY_ID_FORMAT"
+  | "MODEL_NAME_FORMAT";
+
+export interface ValidateOk {
+  ok: true;
+  record: AiCapabilityObservationV1;
+  /** SHA-256 hex of the canonical CBOR pre-image. */
+  contentHash: string;
+  /** SHA-256 hex of the schema-version literal. */
+  schemaHash: string;
+  /** Canonical CBOR bytes the cert-daemon committee signs. */
+  preImage: Uint8Array;
+}
+
+export interface ValidateErr {
+  ok: false;
+  code: ValidateErrorCode;
+  message: string;
+  field?: string;
+}
+
+export type ValidateResult = ValidateOk | ValidateErr;
+
+// ---------------------------------------------------------------------------
+// Canonical CBOR encoder.
+//
+// Same primitives as `services` schemas (RFC 8949 §4.2.1) with one extension:
+// CBOR null (major 7 additional 22) for nullable sub-trees.
+// ---------------------------------------------------------------------------
+
+function encodeUint(major: number, n: number): Uint8Array {
+  if (n < 0 || !Number.isFinite(n)) {
+    throw new TypeError(`encodeUint: out of range: ${n}`);
+  }
+  if (n <= 23) return Uint8Array.of((major << 5) | n);
+  if (n <= 0xff) return Uint8Array.of((major << 5) | 24, n);
+  if (n <= 0xffff) {
+    return Uint8Array.of((major << 5) | 25, (n >> 8) & 0xff, n & 0xff);
+  }
+  if (n <= 0xffffffff) {
+    return Uint8Array.of(
+      (major << 5) | 26,
+      (n >>> 24) & 0xff,
+      (n >>> 16) & 0xff,
+      (n >>> 8) & 0xff,
+      n & 0xff,
+    );
+  }
+  if (n > Number.MAX_SAFE_INTEGER) {
+    throw new TypeError(`encodeUint: exceeds JS-safe int: ${n}`);
+  }
+  const bn = BigInt(n);
+  const out = new Uint8Array(9);
+  out[0] = (major << 5) | 27;
+  for (let i = 0; i < 8; i++) {
+    out[8 - i] = Number((bn >> BigInt(i * 8)) & 0xffn);
+  }
+  return out;
+}
+
+function encodeText(s: string): Uint8Array {
+  const bytes = new TextEncoder().encode(s);
+  const head = encodeUint(3, bytes.length);
+  const out = new Uint8Array(head.length + bytes.length);
+  out.set(head, 0);
+  out.set(bytes, head.length);
+  return out;
+}
+
+function encodeBytes(b: Uint8Array): Uint8Array {
+  const head = encodeUint(2, b.length);
+  const out = new Uint8Array(head.length + b.length);
+  out.set(head, 0);
+  out.set(b, head.length);
+  return out;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+function cmpBytes(a: Uint8Array, b: Uint8Array): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const av = a[i] as number;
+    const bv = b[i] as number;
+    if (av !== bv) return av - bv;
+  }
+  return a.length - b.length;
+}
+
+/** CBOR null primitive (major 7, additional 22). */
+const CBOR_NULL = Uint8Array.of(0xf6);
+
+type CborValue =
+  | { type: "text"; v: string }
+  | { type: "bytes"; v: Uint8Array }
+  | { type: "null" }
+  | { type: "array"; v: CborValue[] }
+  | { type: "map"; v: Array<[string, CborValue]> };
+
+const cText = (v: string): CborValue => ({ type: "text", v });
+const cBytes = (v: Uint8Array): CborValue => ({ type: "bytes", v });
+const cNull = (): CborValue => ({ type: "null" });
+const cArray = (v: CborValue[]): CborValue => ({ type: "array", v });
+const cMap = (v: Array<[string, CborValue]>): CborValue => ({ type: "map", v });
+
+function encodeCbor(val: CborValue): Uint8Array {
+  switch (val.type) {
+    case "text":
+      return encodeText(val.v);
+    case "bytes":
+      return encodeBytes(val.v);
+    case "null":
+      return CBOR_NULL;
+    case "array": {
+      const head = encodeUint(4, val.v.length);
+      const parts: Uint8Array[] = [head];
+      for (const item of val.v) parts.push(encodeCbor(item));
+      return concat(parts);
+    }
+    case "map": {
+      const encoded = val.v.map(([k, v]) => ({
+        keyBytes: encodeText(k),
+        valueBytes: encodeCbor(v),
+      }));
+      encoded.sort((a, b) => cmpBytes(a.keyBytes, b.keyBytes));
+      const head = encodeUint(5, encoded.length);
+      const parts: Uint8Array[] = [head];
+      for (const { keyBytes, valueBytes } of encoded) {
+        parts.push(keyBytes, valueBytes);
+      }
+      return concat(parts);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pre-image builders
+// ---------------------------------------------------------------------------
+
+function hexOrNullToCbor(hex: string | null): CborValue {
+  return hex === null ? cNull() : cBytes(hexToU8a("0x" + hex));
+}
+
+function textOrNullToCbor(s: string | null): CborValue {
+  return s === null ? cNull() : cText(s);
+}
+
+function modelToCbor(m: ModelV1): CborValue {
+  return cMap([
+    ["hash", hexOrNullToCbor(m.hash)],
+    ["name", cText(m.name)],
+    ["version", cText(m.version)],
+  ]);
+}
+
+function capabilityToCbor(c: CapabilityV1): CborValue {
+  return cMap([
+    ["severity", cText(c.severity)],
+    ["taxonomyId", cText(c.taxonomyId)],
+  ]);
+}
+
+function observationToCbor(o: ObservationV1): CborValue {
+  return cMap([
+    ["artifactRef", textOrNullToCbor(o.artifactRef)],
+    ["occurredAt", cText(o.occurredAt)],
+    ["promptHash", cBytes(hexToU8a("0x" + o.promptHash))],
+    ["responseHash", cBytes(hexToU8a("0x" + o.responseHash))],
+  ]);
+}
+
+function teeToCbor(t: TeeAttestationV1 | null): CborValue {
+  if (t === null) return cNull();
+  return cMap([
+    ["evidence", cBytes(hexToU8a("0x" + t.evidence))],
+    ["tier", cText(t.tier)],
+  ]);
+}
+
+function observerToCbor(o: ObserverV1): CborValue {
+  return cMap([
+    ["context", cText(o.context)],
+    ["ss58", cText(o.ss58)],
+    ["teeAttestation", teeToCbor(o.teeAttestation)],
+  ]);
+}
+
+/**
+ * Build the canonical CBOR bytes for an `ai_capability_observation_v1`
+ * record. These bytes are what the cert-daemon committee signs and what
+ * downstream verifiers reproduce locally to check signatures.
+ */
+export function canonicalCborPreImage(
+  rec: AiCapabilityObservationV1,
+): Uint8Array {
+  return encodeCbor(
+    cArray([
+      cText(SCHEMA_VERSION),
+      modelToCbor(rec.model),
+      capabilityToCbor(rec.capability),
+      observationToCbor(rec.observation),
+      observerToCbor(rec.observer),
+    ]),
+  );
+}
+
+/** SHA-256 hex of the canonical CBOR pre-image. */
+export function canonicalContentHash(rec: AiCapabilityObservationV1): string {
+  return createHash("sha256").update(canonicalCborPreImage(rec)).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+function err(
+  code: ValidateErrorCode,
+  message: string,
+  field?: string,
+): ValidateErr {
+  return field !== undefined
+    ? { ok: false, code, message, field }
+    : { ok: false, code, message };
+}
+
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  return x !== null && typeof x === "object" && !Array.isArray(x);
+}
+
+function validateString(
+  raw: Record<string, unknown>,
+  key: string,
+  fieldPath: string,
+): { ok: true; value: string } | ValidateErr {
+  if (!(key in raw)) {
+    return err("MISSING_FIELD", `${fieldPath} is required`, fieldPath);
+  }
+  const v = raw[key];
+  if (typeof v !== "string") {
+    return err("WRONG_TYPE", `${fieldPath} must be a string`, fieldPath);
+  }
+  return { ok: true, value: v };
+}
+
+function validateHex64(
+  raw: Record<string, unknown>,
+  key: string,
+  fieldPath: string,
+): { ok: true; value: string } | ValidateErr {
+  const r = validateString(raw, key, fieldPath);
+  if (!r.ok) return r;
+  if (!HEX64.test(r.value)) {
+    return err(
+      "HEX_FORMAT",
+      `${fieldPath} must be 64 lowercase hex chars, got length ${r.value.length}`,
+      fieldPath,
+    );
+  }
+  return r;
+}
+
+function validateModel(
+  raw: unknown,
+): { ok: true; value: ModelV1 } | ValidateErr {
+  if (!isPlainObject(raw)) {
+    return err("WRONG_TYPE", "model must be a JSON object", "model");
+  }
+  const nameRes = validateString(raw, "name", "model.name");
+  if (!nameRes.ok) return nameRes;
+  if (nameRes.value.length === 0 || nameRes.value.length > 128) {
+    return err(
+      "MODEL_NAME_FORMAT",
+      "model.name must be 1-128 chars",
+      "model.name",
+    );
+  }
+  const versionRes = validateString(raw, "version", "model.version");
+  if (!versionRes.ok) return versionRes;
+  if (!("hash" in raw)) {
+    return err("MISSING_FIELD", "model.hash is required", "model.hash");
+  }
+  const hashRaw = raw.hash;
+  let hash: string | null;
+  if (hashRaw === null) {
+    hash = null;
+  } else if (typeof hashRaw !== "string") {
+    return err(
+      "WRONG_TYPE",
+      "model.hash must be a string or null",
+      "model.hash",
+    );
+  } else if (!HEX64.test(hashRaw)) {
+    return err(
+      "HEX_FORMAT",
+      `model.hash must be 64 lowercase hex chars, got length ${hashRaw.length}`,
+      "model.hash",
+    );
+  } else {
+    hash = hashRaw;
+  }
+  return {
+    ok: true,
+    value: { name: nameRes.value, version: versionRes.value, hash },
+  };
+}
+
+const TAXONOMY_ID_RE = /^[A-Z0-9_-]{1,64}$/;
+
+function validateCapability(
+  raw: unknown,
+): { ok: true; value: CapabilityV1 } | ValidateErr {
+  if (!isPlainObject(raw)) {
+    return err("WRONG_TYPE", "capability must be a JSON object", "capability");
+  }
+  const taxRes = validateString(raw, "taxonomyId", "capability.taxonomyId");
+  if (!taxRes.ok) return taxRes;
+  if (!TAXONOMY_ID_RE.test(taxRes.value)) {
+    return err(
+      "TAXONOMY_ID_FORMAT",
+      "capability.taxonomyId must match [A-Z0-9_-]{1,64}",
+      "capability.taxonomyId",
+    );
+  }
+  const sevRes = validateString(raw, "severity", "capability.severity");
+  if (!sevRes.ok) return sevRes;
+  if (!SEVERITY_SET.has(sevRes.value)) {
+    return err(
+      "SEVERITY_INVALID",
+      `capability.severity must be one of [${SEVERITIES.join(", ")}], got "${sevRes.value}"`,
+      "capability.severity",
+    );
+  }
+  return {
+    ok: true,
+    value: {
+      taxonomyId: taxRes.value,
+      severity: sevRes.value as Severity,
+    },
+  };
+}
+
+function validateObservation(
+  raw: unknown,
+): { ok: true; value: ObservationV1 } | ValidateErr {
+  if (!isPlainObject(raw)) {
+    return err(
+      "WRONG_TYPE",
+      "observation must be a JSON object",
+      "observation",
+    );
+  }
+  const promptRes = validateHex64(raw, "promptHash", "observation.promptHash");
+  if (!promptRes.ok) return promptRes;
+  const responseRes = validateHex64(
+    raw,
+    "responseHash",
+    "observation.responseHash",
+  );
+  if (!responseRes.ok) return responseRes;
+  if (!("artifactRef" in raw)) {
+    return err(
+      "MISSING_FIELD",
+      "observation.artifactRef is required",
+      "observation.artifactRef",
+    );
+  }
+  const refRaw = raw.artifactRef;
+  let artifactRef: string | null;
+  if (refRaw === null) {
+    artifactRef = null;
+  } else if (typeof refRaw !== "string") {
+    return err(
+      "WRONG_TYPE",
+      "observation.artifactRef must be a string or null",
+      "observation.artifactRef",
+    );
+  } else if (refRaw.length === 0 || refRaw.length > 2048) {
+    return err(
+      "WRONG_TYPE",
+      "observation.artifactRef must be 1-2048 chars when non-null",
+      "observation.artifactRef",
+    );
+  } else {
+    artifactRef = refRaw;
+  }
+  const occRes = validateString(raw, "occurredAt", "observation.occurredAt");
+  if (!occRes.ok) return occRes;
+  if (!OCCURRED_AT_RE.test(occRes.value)) {
+    return err(
+      "OCCURRED_AT_INVALID",
+      "observation.occurredAt must be ISO 8601 UTC (suffix Z)",
+      "observation.occurredAt",
+    );
+  }
+  return {
+    ok: true,
+    value: {
+      promptHash: promptRes.value,
+      responseHash: responseRes.value,
+      artifactRef,
+      occurredAt: occRes.value,
+    },
+  };
+}
+
+function validateTee(
+  raw: unknown,
+): { ok: true; value: TeeAttestationV1 } | ValidateErr {
+  if (!isPlainObject(raw)) {
+    return err(
+      "WRONG_TYPE",
+      "observer.teeAttestation must be a JSON object or null",
+      "observer.teeAttestation",
+    );
+  }
+  const tierRes = validateString(raw, "tier", "observer.teeAttestation.tier");
+  if (!tierRes.ok) return tierRes;
+  if (!TEE_TIER_SET.has(tierRes.value)) {
+    return err(
+      "TEE_TIER_INVALID",
+      `observer.teeAttestation.tier must be one of [${TEE_TIERS.join(", ")}], got "${tierRes.value}"`,
+      "observer.teeAttestation.tier",
+    );
+  }
+  const evRes = validateString(
+    raw,
+    "evidence",
+    "observer.teeAttestation.evidence",
+  );
+  if (!evRes.ok) return evRes;
+  if (
+    evRes.value.length === 0 ||
+    evRes.value.length % 2 !== 0 ||
+    !HEX_EVIDENCE.test(evRes.value)
+  ) {
+    return err(
+      "HEX_FORMAT",
+      "observer.teeAttestation.evidence must be non-empty lowercase hex with even length",
+      "observer.teeAttestation.evidence",
+    );
+  }
+  return {
+    ok: true,
+    value: { tier: tierRes.value as TeeTier, evidence: evRes.value },
+  };
+}
+
+function validateObserver(
+  raw: unknown,
+): { ok: true; value: ObserverV1 } | ValidateErr {
+  if (!isPlainObject(raw)) {
+    return err("WRONG_TYPE", "observer must be a JSON object", "observer");
+  }
+  const ss58Res = validateString(raw, "ss58", "observer.ss58");
+  if (!ss58Res.ok) return ss58Res;
+  if (!SS58_RE.test(ss58Res.value)) {
+    return err(
+      "SS58_FORMAT",
+      "observer.ss58 must be a base58 SS58 address",
+      "observer.ss58",
+    );
+  }
+  const ctxRes = validateString(raw, "context", "observer.context");
+  if (!ctxRes.ok) return ctxRes;
+  if (ctxRes.value.length > MAX_CONTEXT_LEN) {
+    return err(
+      "CONTEXT_TOO_LONG",
+      `observer.context must be <= ${MAX_CONTEXT_LEN} chars, got ${ctxRes.value.length}`,
+      "observer.context",
+    );
+  }
+  if (!("teeAttestation" in raw)) {
+    return err(
+      "MISSING_FIELD",
+      "observer.teeAttestation is required (use null when absent)",
+      "observer.teeAttestation",
+    );
+  }
+  let teeAttestation: TeeAttestationV1 | null;
+  if (raw.teeAttestation === null) {
+    teeAttestation = null;
+  } else {
+    const teeRes = validateTee(raw.teeAttestation);
+    if (!teeRes.ok) return teeRes;
+    teeAttestation = teeRes.value;
+  }
+  return {
+    ok: true,
+    value: {
+      ss58: ss58Res.value,
+      context: ctxRes.value,
+      teeAttestation,
+    },
+  };
+}
+
+/**
+ * Validate a parsed JSON object against the `ai_capability_observation_v1`
+ * schema. On success, returns the typed record, the canonical content hash,
+ * the schema hash, and the canonical CBOR pre-image bytes (so callers can
+ * sign / anchor without re-running the encoder).
+ */
+export function validateAiCapabilityObservationV1(
+  raw: unknown,
+): ValidateResult {
+  if (!isPlainObject(raw)) {
+    return err("WRONG_TYPE", "expected JSON object at root");
+  }
+  if (!("schemaVersion" in raw)) {
+    return err("MISSING_FIELD", "schemaVersion is required", "schemaVersion");
+  }
+  if (typeof raw.schemaVersion !== "string") {
+    return err(
+      "WRONG_TYPE",
+      "schemaVersion must be a string",
+      "schemaVersion",
+    );
+  }
+  if (raw.schemaVersion !== SCHEMA_VERSION) {
+    return err(
+      "WRONG_SCHEMA_VERSION",
+      `schemaVersion must be "${SCHEMA_VERSION}", got "${raw.schemaVersion}"`,
+      "schemaVersion",
+    );
+  }
+  if (!("model" in raw)) {
+    return err("MISSING_FIELD", "model is required", "model");
+  }
+  const modelRes = validateModel(raw.model);
+  if (!modelRes.ok) return modelRes;
+  if (!("capability" in raw)) {
+    return err("MISSING_FIELD", "capability is required", "capability");
+  }
+  const capRes = validateCapability(raw.capability);
+  if (!capRes.ok) return capRes;
+  if (!("observation" in raw)) {
+    return err("MISSING_FIELD", "observation is required", "observation");
+  }
+  const obsRes = validateObservation(raw.observation);
+  if (!obsRes.ok) return obsRes;
+  if (!("observer" in raw)) {
+    return err("MISSING_FIELD", "observer is required", "observer");
+  }
+  const observerRes = validateObserver(raw.observer);
+  if (!observerRes.ok) return observerRes;
+
+  const record: AiCapabilityObservationV1 = {
+    schemaVersion: SCHEMA_VERSION,
+    model: modelRes.value,
+    capability: capRes.value,
+    observation: obsRes.value,
+    observer: observerRes.value,
+  };
+  const preImage = canonicalCborPreImage(record);
+  const contentHash = createHash("sha256").update(preImage).digest("hex");
+  return {
+    ok: true,
+    record,
+    contentHash,
+    schemaHash: SCHEMA_HASH_HEX,
+    preImage,
+  };
+}

--- a/packages/anchors-materios/src/types.ts
+++ b/packages/anchors-materios/src/types.ts
@@ -79,9 +79,10 @@ export interface ReceiptInput {
    * `base_root_sha256` is a *semantic* root (not the chunk-Merkle of the
    * uploaded bytes):
    *
-   *   sha256("compute_metering_v2")    — Wave 1+2 metering envelopes
-   *   sha256("compute_metering_v2_1")  — Wave 3 Phase 2 (with attestation_evidence)
-   *   sha256("orynq_trace_v1")         — orynq trace receipts (drain.mjs)
+   *   sha256("compute_metering_v2")          — Wave 1+2 metering envelopes
+   *   sha256("compute_metering_v2_1")        — Wave 3 Phase 2 (with attestation_evidence)
+   *   sha256("orynq_trace_v1")               — orynq trace receipts (drain.mjs)
+   *   sha256("ai_capability_observation_v1") — attested AI model observations
    *
    * The cert-daemon's TRUSTED_DISCRIMINATOR_SCHEMAS set (operator-kit
    * daemon/schemas/__init__.py) enumerates accepted values. Receipts with

--- a/python/orynq_sdk/__init__.py
+++ b/python/orynq_sdk/__init__.py
@@ -50,6 +50,7 @@ from .transport_flux import FLUX_HEADERS, is_flux_402, parse_flux_invoice
 # also live alongside but are imported on-demand so substrate-interface
 # is not pulled in unless someone actually calls into them.
 from . import trace  # noqa: F401  (re-export module)
+from . import schemas  # noqa: F401  (re-export module)
 
 __version__ = "0.2.0"
 
@@ -84,4 +85,5 @@ __all__ = [
     "parse_flux_invoice",
     # New in 0.2.0
     "trace",
+    "schemas",
 ]

--- a/python/orynq_sdk/schemas/__init__.py
+++ b/python/orynq_sdk/schemas/__init__.py
@@ -1,0 +1,15 @@
+"""Canonical schemas for receipt-class semantic roots.
+
+Each submodule defines:
+  * `SCHEMA_VERSION` — pinned literal.
+  * `SCHEMA_HASH_HEX` — sha256(SCHEMA_VERSION), the upstream `schema_hash`
+    discriminator the cert-daemon committee uses to dispatch verifiers.
+  * `canonical_cbor_pre_image(record)` — deterministic CBOR bytes for the
+    record (sha256 of these bytes is `contentHash`).
+  * `canonical_content_hash(record)` — convenience: sha256 hex of the
+    pre-image.
+  * `validate_*` — wire-shape validator.
+"""
+from . import ai_capability_observation_v1
+
+__all__ = ["ai_capability_observation_v1"]

--- a/python/orynq_sdk/schemas/ai_capability_observation_v1.py
+++ b/python/orynq_sdk/schemas/ai_capability_observation_v1.py
@@ -1,0 +1,583 @@
+"""`ai_capability_observation_v1` — canonical encoder, content_hash, validator.
+
+Python lockstep of `packages/anchors-materios/src/schemas/ai_capability_observation_v1.ts`.
+Cross-language byte-equality is enforced by
+`python/tests/test_ai_capability_observation_v1_cross_lang.py`.
+
+--- Canonical CBOR rules (RFC 8949 §4.2.1) ---
+
+  * Definite-length encoding only.
+  * Shortest possible integer head per RFC 8949 §3.1.
+  * Map keys sorted by encoded-byte lexicographic order.
+  * Strings: UTF-8, major type 3.
+  * Byte strings: major type 2 (hashes, TEE evidence in pre-images).
+  * Arrays: major type 4.
+  * Maps: major type 5.
+  * Null: major type 7, additional 22 (single byte 0xf6).
+
+--- Pre-image (PINNED — coordinated with the TS encoder) ---
+
+  [ "ai_capability_observation_v1", model_map, capability_map,
+    observation_map, observer_map ]
+
+  model_map         { hash: bytes32 | null, name: text, version: text }
+  capability_map    { severity: text, taxonomyId: text }
+  observation_map   { artifactRef: text | null, occurredAt: text,
+                      promptHash: bytes32, responseHash: bytes32 }
+  observer_map      { context: text, ss58: text,
+                      teeAttestation: { evidence: bytes, tier: text } | null }
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple, Union
+
+# --- Schema constants ---
+
+SCHEMA_VERSION = "ai_capability_observation_v1"
+SCHEMA_HASH_HEX = hashlib.sha256(SCHEMA_VERSION.encode("utf-8")).hexdigest()
+
+TEE_TIERS: Tuple[str, ...] = ("ARM-TZ", "Acurast", "SEV-SNP", "build")
+_TEE_TIER_SET = frozenset(TEE_TIERS)
+
+SEVERITIES: Tuple[str, ...] = ("low", "medium", "high", "critical")
+_SEVERITY_SET = frozenset(SEVERITIES)
+
+MAX_CONTEXT_LEN = 280
+
+_HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+_HEX_EVIDENCE_RE = re.compile(r"^[0-9a-f]+$")
+_OCCURRED_AT_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$"
+)
+_SS58_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{46,50}$")
+_TAXONOMY_ID_RE = re.compile(r"^[A-Z0-9_-]{1,64}$")
+
+
+# --- Tagged CBOR value types ---
+
+
+@dataclass(frozen=True)
+class _CborText:
+    v: str
+
+
+@dataclass(frozen=True)
+class _CborBytes:
+    v: bytes
+
+
+@dataclass(frozen=True)
+class _CborNull:
+    pass
+
+
+@dataclass(frozen=True)
+class _CborArray:
+    v: Tuple["_CborValue", ...]
+
+
+@dataclass(frozen=True)
+class _CborMap:
+    v: Tuple[Tuple[str, "_CborValue"], ...]
+
+
+_CborValue = Union[_CborText, _CborBytes, _CborNull, _CborArray, _CborMap]
+
+
+def _cbor_text(v: str) -> _CborValue:
+    return _CborText(v)
+
+
+def _cbor_bytes(v: bytes) -> _CborValue:
+    return _CborBytes(bytes(v))
+
+
+def _cbor_null() -> _CborValue:
+    return _CborNull()
+
+
+def _cbor_array(items: List[_CborValue]) -> _CborValue:
+    return _CborArray(tuple(items))
+
+
+def _cbor_map(pairs: List[Tuple[str, _CborValue]]) -> _CborValue:
+    return _CborMap(tuple(pairs))
+
+
+# --- Low-level primitives ---
+
+
+def _encode_uint(major: int, n: int) -> bytes:
+    if n < 0:
+        raise TypeError(f"_encode_uint: out of range: {n}")
+    if n <= 23:
+        return bytes(((major << 5) | n,))
+    if n <= 0xFF:
+        return bytes(((major << 5) | 24, n))
+    if n <= 0xFFFF:
+        return bytes(((major << 5) | 25,)) + n.to_bytes(2, "big")
+    if n <= 0xFFFFFFFF:
+        return bytes(((major << 5) | 26,)) + n.to_bytes(4, "big")
+    if n > (1 << 64) - 1:
+        raise TypeError(f"_encode_uint: exceeds 64-bit unsigned: {n}")
+    return bytes(((major << 5) | 27,)) + n.to_bytes(8, "big")
+
+
+def _encode_text(s: str) -> bytes:
+    b = s.encode("utf-8")
+    return _encode_uint(3, len(b)) + b
+
+
+def _encode_bytes(b: bytes) -> bytes:
+    return _encode_uint(2, len(b)) + b
+
+
+_CBOR_NULL_BYTE = bytes((0xF6,))
+
+
+def _encode_cbor(val: _CborValue) -> bytes:
+    if isinstance(val, _CborText):
+        return _encode_text(val.v)
+    if isinstance(val, _CborBytes):
+        return _encode_bytes(val.v)
+    if isinstance(val, _CborNull):
+        return _CBOR_NULL_BYTE
+    if isinstance(val, _CborArray):
+        head = _encode_uint(4, len(val.v))
+        return head + b"".join(_encode_cbor(item) for item in val.v)
+    if isinstance(val, _CborMap):
+        pairs = [(_encode_text(k), _encode_cbor(v)) for k, v in val.v]
+        pairs.sort(key=lambda kv: kv[0])
+        head = _encode_uint(5, len(pairs))
+        return head + b"".join(k + v for k, v in pairs)
+    raise TypeError(
+        f"_encode_cbor: unsupported tagged value type {type(val).__name__}"
+    )
+
+
+# --- Pre-image builders ---
+
+
+def _hex_to_bytes(value: Union[str, bytes, bytearray]) -> bytes:
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        cleaned = value[2:] if value.startswith("0x") else value
+        return bytes.fromhex(cleaned)
+    raise TypeError(f"expected bytes or hex str, got {type(value).__name__}")
+
+
+def _hex_or_null_to_cbor(hex_or_none: Any) -> _CborValue:
+    if hex_or_none is None:
+        return _cbor_null()
+    return _cbor_bytes(_hex_to_bytes(hex_or_none))
+
+
+def _text_or_null_to_cbor(s_or_none: Any) -> _CborValue:
+    if s_or_none is None:
+        return _cbor_null()
+    return _cbor_text(s_or_none)
+
+
+def _model_to_cbor(m: Dict[str, Any]) -> _CborValue:
+    return _cbor_map(
+        [
+            ("hash", _hex_or_null_to_cbor(m["hash"])),
+            ("name", _cbor_text(m["name"])),
+            ("version", _cbor_text(m["version"])),
+        ]
+    )
+
+
+def _capability_to_cbor(c: Dict[str, Any]) -> _CborValue:
+    return _cbor_map(
+        [
+            ("severity", _cbor_text(c["severity"])),
+            ("taxonomyId", _cbor_text(c["taxonomyId"])),
+        ]
+    )
+
+
+def _observation_to_cbor(o: Dict[str, Any]) -> _CborValue:
+    return _cbor_map(
+        [
+            ("artifactRef", _text_or_null_to_cbor(o["artifactRef"])),
+            ("occurredAt", _cbor_text(o["occurredAt"])),
+            ("promptHash", _cbor_bytes(_hex_to_bytes(o["promptHash"]))),
+            ("responseHash", _cbor_bytes(_hex_to_bytes(o["responseHash"]))),
+        ]
+    )
+
+
+def _tee_to_cbor(t: Any) -> _CborValue:
+    if t is None:
+        return _cbor_null()
+    return _cbor_map(
+        [
+            ("evidence", _cbor_bytes(_hex_to_bytes(t["evidence"]))),
+            ("tier", _cbor_text(t["tier"])),
+        ]
+    )
+
+
+def _observer_to_cbor(o: Dict[str, Any]) -> _CborValue:
+    return _cbor_map(
+        [
+            ("context", _cbor_text(o["context"])),
+            ("ss58", _cbor_text(o["ss58"])),
+            ("teeAttestation", _tee_to_cbor(o["teeAttestation"])),
+        ]
+    )
+
+
+def canonical_cbor_pre_image(record: Dict[str, Any]) -> bytes:
+    """Build canonical CBOR bytes for an `ai_capability_observation_v1` record.
+
+    Mirrors `canonicalCborPreImage` in the TS encoder. The output is the
+    bytes the cert-daemon committee signs and downstream verifiers
+    reproduce locally.
+    """
+    return _encode_cbor(
+        _cbor_array(
+            [
+                _cbor_text(SCHEMA_VERSION),
+                _model_to_cbor(record["model"]),
+                _capability_to_cbor(record["capability"]),
+                _observation_to_cbor(record["observation"]),
+                _observer_to_cbor(record["observer"]),
+            ]
+        )
+    )
+
+
+def canonical_content_hash(record: Dict[str, Any]) -> str:
+    """SHA-256 hex of the canonical CBOR pre-image."""
+    return hashlib.sha256(canonical_cbor_pre_image(record)).hexdigest()
+
+
+# --- Validator ---
+
+
+def _err(code: str, message: str, field: str = "") -> Dict[str, Any]:
+    out: Dict[str, Any] = {"ok": False, "code": code, "message": message}
+    if field:
+        out["field"] = field
+    return out
+
+
+def _is_plain_object(x: Any) -> bool:
+    return isinstance(x, dict)
+
+
+def _validate_string(
+    raw: Dict[str, Any], key: str, field_path: str
+) -> Dict[str, Any]:
+    if key not in raw:
+        return _err("MISSING_FIELD", f"{field_path} is required", field_path)
+    v = raw[key]
+    if not isinstance(v, str):
+        return _err("WRONG_TYPE", f"{field_path} must be a string", field_path)
+    return {"ok": True, "value": v}
+
+
+def _validate_hex64(
+    raw: Dict[str, Any], key: str, field_path: str
+) -> Dict[str, Any]:
+    r = _validate_string(raw, key, field_path)
+    if not r["ok"]:
+        return r
+    v = r["value"]
+    if not _HEX64_RE.match(v):
+        return _err(
+            "HEX_FORMAT",
+            f"{field_path} must be 64 lowercase hex chars, got length {len(v)}",
+            field_path,
+        )
+    return r
+
+
+def _validate_model(raw: Any) -> Dict[str, Any]:
+    if not _is_plain_object(raw):
+        return _err("WRONG_TYPE", "model must be a JSON object", "model")
+    name_res = _validate_string(raw, "name", "model.name")
+    if not name_res["ok"]:
+        return name_res
+    if not (1 <= len(name_res["value"]) <= 128):
+        return _err(
+            "MODEL_NAME_FORMAT",
+            "model.name must be 1-128 chars",
+            "model.name",
+        )
+    version_res = _validate_string(raw, "version", "model.version")
+    if not version_res["ok"]:
+        return version_res
+    if "hash" not in raw:
+        return _err("MISSING_FIELD", "model.hash is required", "model.hash")
+    hash_raw = raw["hash"]
+    if hash_raw is None:
+        hash_v = None
+    elif not isinstance(hash_raw, str):
+        return _err(
+            "WRONG_TYPE",
+            "model.hash must be a string or null",
+            "model.hash",
+        )
+    elif not _HEX64_RE.match(hash_raw):
+        return _err(
+            "HEX_FORMAT",
+            f"model.hash must be 64 lowercase hex chars, got length {len(hash_raw)}",
+            "model.hash",
+        )
+    else:
+        hash_v = hash_raw
+    return {
+        "ok": True,
+        "value": {
+            "name": name_res["value"],
+            "version": version_res["value"],
+            "hash": hash_v,
+        },
+    }
+
+
+def _validate_capability(raw: Any) -> Dict[str, Any]:
+    if not _is_plain_object(raw):
+        return _err(
+            "WRONG_TYPE", "capability must be a JSON object", "capability"
+        )
+    tax_res = _validate_string(raw, "taxonomyId", "capability.taxonomyId")
+    if not tax_res["ok"]:
+        return tax_res
+    if not _TAXONOMY_ID_RE.match(tax_res["value"]):
+        return _err(
+            "TAXONOMY_ID_FORMAT",
+            "capability.taxonomyId must match [A-Z0-9_-]{1,64}",
+            "capability.taxonomyId",
+        )
+    sev_res = _validate_string(raw, "severity", "capability.severity")
+    if not sev_res["ok"]:
+        return sev_res
+    if sev_res["value"] not in _SEVERITY_SET:
+        return _err(
+            "SEVERITY_INVALID",
+            f"capability.severity must be one of {list(SEVERITIES)}, got "
+            f"\"{sev_res['value']}\"",
+            "capability.severity",
+        )
+    return {
+        "ok": True,
+        "value": {
+            "taxonomyId": tax_res["value"],
+            "severity": sev_res["value"],
+        },
+    }
+
+
+def _validate_observation(raw: Any) -> Dict[str, Any]:
+    if not _is_plain_object(raw):
+        return _err(
+            "WRONG_TYPE",
+            "observation must be a JSON object",
+            "observation",
+        )
+    prompt_res = _validate_hex64(raw, "promptHash", "observation.promptHash")
+    if not prompt_res["ok"]:
+        return prompt_res
+    response_res = _validate_hex64(
+        raw, "responseHash", "observation.responseHash"
+    )
+    if not response_res["ok"]:
+        return response_res
+    if "artifactRef" not in raw:
+        return _err(
+            "MISSING_FIELD",
+            "observation.artifactRef is required",
+            "observation.artifactRef",
+        )
+    ref_raw = raw["artifactRef"]
+    if ref_raw is None:
+        artifact_ref = None
+    elif not isinstance(ref_raw, str):
+        return _err(
+            "WRONG_TYPE",
+            "observation.artifactRef must be a string or null",
+            "observation.artifactRef",
+        )
+    elif not (1 <= len(ref_raw) <= 2048):
+        return _err(
+            "WRONG_TYPE",
+            "observation.artifactRef must be 1-2048 chars when non-null",
+            "observation.artifactRef",
+        )
+    else:
+        artifact_ref = ref_raw
+    occ_res = _validate_string(raw, "occurredAt", "observation.occurredAt")
+    if not occ_res["ok"]:
+        return occ_res
+    if not _OCCURRED_AT_RE.match(occ_res["value"]):
+        return _err(
+            "OCCURRED_AT_INVALID",
+            "observation.occurredAt must be ISO 8601 UTC (suffix Z)",
+            "observation.occurredAt",
+        )
+    return {
+        "ok": True,
+        "value": {
+            "promptHash": prompt_res["value"],
+            "responseHash": response_res["value"],
+            "artifactRef": artifact_ref,
+            "occurredAt": occ_res["value"],
+        },
+    }
+
+
+def _validate_tee(raw: Any) -> Dict[str, Any]:
+    if not _is_plain_object(raw):
+        return _err(
+            "WRONG_TYPE",
+            "observer.teeAttestation must be a JSON object or null",
+            "observer.teeAttestation",
+        )
+    tier_res = _validate_string(raw, "tier", "observer.teeAttestation.tier")
+    if not tier_res["ok"]:
+        return tier_res
+    if tier_res["value"] not in _TEE_TIER_SET:
+        return _err(
+            "TEE_TIER_INVALID",
+            f"observer.teeAttestation.tier must be one of {list(TEE_TIERS)}, "
+            f"got \"{tier_res['value']}\"",
+            "observer.teeAttestation.tier",
+        )
+    ev_res = _validate_string(
+        raw, "evidence", "observer.teeAttestation.evidence"
+    )
+    if not ev_res["ok"]:
+        return ev_res
+    ev = ev_res["value"]
+    if len(ev) == 0 or len(ev) % 2 != 0 or not _HEX_EVIDENCE_RE.match(ev):
+        return _err(
+            "HEX_FORMAT",
+            "observer.teeAttestation.evidence must be non-empty lowercase hex "
+            "with even length",
+            "observer.teeAttestation.evidence",
+        )
+    return {
+        "ok": True,
+        "value": {"tier": tier_res["value"], "evidence": ev},
+    }
+
+
+def _validate_observer(raw: Any) -> Dict[str, Any]:
+    if not _is_plain_object(raw):
+        return _err("WRONG_TYPE", "observer must be a JSON object", "observer")
+    ss58_res = _validate_string(raw, "ss58", "observer.ss58")
+    if not ss58_res["ok"]:
+        return ss58_res
+    if not _SS58_RE.match(ss58_res["value"]):
+        return _err(
+            "SS58_FORMAT",
+            "observer.ss58 must be a base58 SS58 address",
+            "observer.ss58",
+        )
+    ctx_res = _validate_string(raw, "context", "observer.context")
+    if not ctx_res["ok"]:
+        return ctx_res
+    if len(ctx_res["value"]) > MAX_CONTEXT_LEN:
+        return _err(
+            "CONTEXT_TOO_LONG",
+            f"observer.context must be <= {MAX_CONTEXT_LEN} chars, got "
+            f"{len(ctx_res['value'])}",
+            "observer.context",
+        )
+    if "teeAttestation" not in raw:
+        return _err(
+            "MISSING_FIELD",
+            "observer.teeAttestation is required (use null when absent)",
+            "observer.teeAttestation",
+        )
+    if raw["teeAttestation"] is None:
+        tee = None
+    else:
+        tee_res = _validate_tee(raw["teeAttestation"])
+        if not tee_res["ok"]:
+            return tee_res
+        tee = tee_res["value"]
+    return {
+        "ok": True,
+        "value": {
+            "ss58": ss58_res["value"],
+            "context": ctx_res["value"],
+            "teeAttestation": tee,
+        },
+    }
+
+
+def validate_ai_capability_observation_v1(raw: Any) -> Dict[str, Any]:
+    """Validate a parsed JSON object against `ai_capability_observation_v1`.
+
+    Returns:
+        On success:
+            {"ok": True, "record": <typed dict>, "contentHash": <hex>,
+             "schemaHash": <hex>, "preImage": <bytes>}
+        On failure:
+            {"ok": False, "code": <code>, "message": <message>,
+             "field"?: <field>}
+    """
+    if not _is_plain_object(raw):
+        return _err("WRONG_TYPE", "expected JSON object at root")
+    if "schemaVersion" not in raw:
+        return _err(
+            "MISSING_FIELD", "schemaVersion is required", "schemaVersion"
+        )
+    if not isinstance(raw["schemaVersion"], str):
+        return _err(
+            "WRONG_TYPE",
+            "schemaVersion must be a string",
+            "schemaVersion",
+        )
+    if raw["schemaVersion"] != SCHEMA_VERSION:
+        return _err(
+            "WRONG_SCHEMA_VERSION",
+            f'schemaVersion must be "{SCHEMA_VERSION}", got "{raw["schemaVersion"]}"',
+            "schemaVersion",
+        )
+    if "model" not in raw:
+        return _err("MISSING_FIELD", "model is required", "model")
+    model_res = _validate_model(raw["model"])
+    if not model_res["ok"]:
+        return model_res
+    if "capability" not in raw:
+        return _err("MISSING_FIELD", "capability is required", "capability")
+    cap_res = _validate_capability(raw["capability"])
+    if not cap_res["ok"]:
+        return cap_res
+    if "observation" not in raw:
+        return _err("MISSING_FIELD", "observation is required", "observation")
+    obs_res = _validate_observation(raw["observation"])
+    if not obs_res["ok"]:
+        return obs_res
+    if "observer" not in raw:
+        return _err("MISSING_FIELD", "observer is required", "observer")
+    observer_res = _validate_observer(raw["observer"])
+    if not observer_res["ok"]:
+        return observer_res
+
+    record = {
+        "schemaVersion": SCHEMA_VERSION,
+        "model": model_res["value"],
+        "capability": cap_res["value"],
+        "observation": obs_res["value"],
+        "observer": observer_res["value"],
+    }
+    pre_image = canonical_cbor_pre_image(record)
+    content_hash = hashlib.sha256(pre_image).hexdigest()
+    return {
+        "ok": True,
+        "record": record,
+        "contentHash": content_hash,
+        "schemaHash": SCHEMA_HASH_HEX,
+        "preImage": pre_image,
+    }

--- a/python/tests/_ai_capability_observation_v1_ts_encoder.mts
+++ b/python/tests/_ai_capability_observation_v1_ts_encoder.mts
@@ -1,0 +1,46 @@
+/**
+ * Cross-language byte-pinning harness for ai_capability_observation_v1.
+ *
+ * Reads a JSON record from stdin, prints to stdout (one line each):
+ *   PRE_IMAGE_HEX <hex>
+ *   CONTENT_HASH <hex>
+ *   SCHEMA_HASH <hex>
+ *
+ * The Python test in `test_ai_capability_observation_v1_cross_lang.py`
+ * invokes this script via tsx and asserts byte-equality against the
+ * Python encoder's output. The TS encoder is the single source of truth
+ * for the wire format; this harness exposes it as a stdin/stdout filter
+ * so pytest can call it without npm-resolving the package.
+ *
+ * NOT shipped as a runtime artefact — strictly a tests harness invoked by
+ * pytest. No network I/O, no side effects beyond stdout.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  SCHEMA_HASH_HEX,
+  canonicalCborPreImage,
+} from "../../packages/anchors-materios/src/schemas/ai_capability_observation_v1.ts";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+async function main(): Promise<void> {
+  const raw = await readStdin();
+  const record = JSON.parse(raw);
+  const pre = canonicalCborPreImage(record);
+  const contentHash = createHash("sha256").update(pre).digest("hex");
+  process.stdout.write(`PRE_IMAGE_HEX ${Buffer.from(pre).toString("hex")}\n`);
+  process.stdout.write(`CONTENT_HASH ${contentHash}\n`);
+  process.stdout.write(`SCHEMA_HASH ${SCHEMA_HASH_HEX}\n`);
+}
+
+main().catch((e) => {
+  process.stderr.write(
+    `harness error: ${e instanceof Error ? e.stack : String(e)}\n`,
+  );
+  process.exit(1);
+});

--- a/python/tests/test_ai_capability_observation_v1.py
+++ b/python/tests/test_ai_capability_observation_v1.py
@@ -1,0 +1,300 @@
+"""Self-tests for the ai_capability_observation_v1 canonical CBOR encoder.
+
+Determinism + nullable handling + validator surface — all in pure Python.
+Cross-language byte-equality with the TS encoder is covered separately by
+`test_ai_capability_observation_v1_cross_lang.py`.
+"""
+from __future__ import annotations
+
+import hashlib
+from copy import deepcopy
+
+import pytest
+
+from orynq_sdk.schemas.ai_capability_observation_v1 import (
+    MAX_CONTEXT_LEN,
+    SCHEMA_HASH_HEX,
+    SCHEMA_VERSION,
+    SEVERITIES,
+    TEE_TIERS,
+    canonical_cbor_pre_image,
+    canonical_content_hash,
+    validate_ai_capability_observation_v1,
+)
+
+
+PROMPT_HASH = "a" * 64
+RESPONSE_HASH = "b" * 64
+MODEL_HASH = "c" * 64
+TEE_EVIDENCE_HEX = "de" * 48
+OBSERVER_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+
+
+def _baseline() -> dict:
+    return {
+        "schemaVersion": "ai_capability_observation_v1",
+        "model": {
+            "name": "claude-opus-4-7",
+            "version": "20260201",
+            "hash": MODEL_HASH,
+        },
+        "capability": {
+            "taxonomyId": "AUTO-MONEY-001",
+            "severity": "high",
+        },
+        "observation": {
+            "promptHash": PROMPT_HASH,
+            "responseHash": RESPONSE_HASH,
+            "artifactRef": "ipfs://QmSomeCidHere",
+            "occurredAt": "2026-01-15T12:34:56Z",
+        },
+        "observer": {
+            "ss58": OBSERVER_SS58,
+            "context": "scripted regression run",
+            "teeAttestation": {
+                "tier": "Acurast",
+                "evidence": TEE_EVIDENCE_HEX,
+            },
+        },
+    }
+
+
+def _null_fields() -> dict:
+    return {
+        "schemaVersion": "ai_capability_observation_v1",
+        "model": {"name": "anon-model", "version": "v0", "hash": None},
+        "capability": {"taxonomyId": "TEST-001", "severity": "low"},
+        "observation": {
+            "promptHash": PROMPT_HASH,
+            "responseHash": RESPONSE_HASH,
+            "artifactRef": None,
+            "occurredAt": "2026-05-27T00:00:00Z",
+        },
+        "observer": {
+            "ss58": OBSERVER_SS58,
+            "context": "no tee, no artifact, no model hash",
+            "teeAttestation": None,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema constants
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_is_pinned_literal() -> None:
+    assert SCHEMA_VERSION == "ai_capability_observation_v1"
+
+
+def test_schema_hash_is_sha256_of_version_string() -> None:
+    expected = hashlib.sha256(SCHEMA_VERSION.encode("utf-8")).hexdigest()
+    assert SCHEMA_HASH_HEX == expected
+
+
+def test_tee_tiers_pinned_order() -> None:
+    assert TEE_TIERS == ("ARM-TZ", "Acurast", "SEV-SNP", "build")
+
+
+def test_severities_pinned_order() -> None:
+    assert SEVERITIES == ("low", "medium", "high", "critical")
+
+
+# ---------------------------------------------------------------------------
+# Canonical CBOR encoder
+# ---------------------------------------------------------------------------
+
+
+def test_pre_image_is_deterministic_across_repeated_encoding() -> None:
+    rec = _baseline()
+    a = canonical_cbor_pre_image(rec)
+    b = canonical_cbor_pre_image(rec)
+    assert a == b
+
+
+def test_pre_image_is_deterministic_under_dict_key_reorder() -> None:
+    rec_a = _baseline()
+    a = canonical_cbor_pre_image(rec_a)
+    # Rebuild every nested map with reversed insertion order to prove the
+    # encoder doesn't depend on dict iteration order.
+    rec_b = _baseline()
+    for key in ("model", "capability", "observation", "observer"):
+        sub = rec_b[key]
+        rec_b[key] = {k: sub[k] for k in reversed(list(sub.keys()))}
+    # Also reverse the top-level dict.
+    rec_b = {k: rec_b[k] for k in reversed(list(rec_b.keys()))}
+    b = canonical_cbor_pre_image(rec_b)
+    assert a == b
+
+
+def test_pre_image_differs_when_any_field_changes() -> None:
+    rec = _baseline()
+    a = canonical_cbor_pre_image(rec)
+    mutated = deepcopy(rec)
+    mutated["capability"]["severity"] = "critical"
+    b = canonical_cbor_pre_image(mutated)
+    assert a != b
+
+
+def test_pre_image_starts_with_schema_version_literal() -> None:
+    pre = canonical_cbor_pre_image(_baseline())
+    # CBOR array head major-4 length-5 = 0x85; then text major-3 with length-28
+    # head = 0x78 0x1c; then 28 UTF-8 bytes of the schema version.
+    assert pre[0] == 0x85
+    assert pre[1] == 0x78
+    assert pre[2] == 0x1C
+    assert pre[3 : 3 + 28].decode("utf-8") == SCHEMA_VERSION
+
+
+def test_pre_image_handles_all_null_optional_fields() -> None:
+    rec = _null_fields()
+    pre = canonical_cbor_pre_image(rec)
+    assert len(pre) > 0
+    # The non-null variant must differ end-to-end.
+    full = canonical_cbor_pre_image(_baseline())
+    assert pre != full
+
+
+def test_null_tee_attestation_encodes_as_cbor_null_primitive() -> None:
+    pre = canonical_cbor_pre_image(_null_fields())
+    # Locate the key "teeAttestation" (14 chars; major-3 length-14 head = 0x6e).
+    key_text = b"teeAttestation"
+    key_head = bytes([0x6E]) + key_text
+    idx = pre.find(key_head)
+    assert idx >= 0
+    value_byte = pre[idx + len(key_head)]
+    assert value_byte == 0xF6
+
+
+def test_pre_image_keys_appear_in_sorted_order() -> None:
+    """RFC 8949 §4.2.1: map keys sorted by encoded-key bytes.
+
+    The `model_map` has keys [hash, name, version]; sorted-by-encoded-bytes
+    this remains [hash, name, version]. Locate each key's text representation
+    in the encoded bytes and check positional order.
+    """
+    pre = canonical_cbor_pre_image(_baseline())
+    pos_hash = pre.find(b"\x64hash")  # text length 4
+    pos_name = pre.find(b"\x64name")
+    pos_version = pre.find(b"\x67version")  # text length 7
+    assert 0 < pos_hash < pos_name < pos_version
+
+
+# ---------------------------------------------------------------------------
+# content_hash
+# ---------------------------------------------------------------------------
+
+
+def test_content_hash_equals_sha256_of_pre_image() -> None:
+    rec = _baseline()
+    pre = canonical_cbor_pre_image(rec)
+    expected = hashlib.sha256(pre).hexdigest()
+    assert canonical_content_hash(rec) == expected
+
+
+def test_content_hash_is_stable_across_re_encoding() -> None:
+    rec = _baseline()
+    assert canonical_content_hash(rec) == canonical_content_hash(rec)
+
+
+def test_content_hash_changes_when_capability_severity_changes() -> None:
+    rec_a = _baseline()
+    rec_b = deepcopy(rec_a)
+    rec_b["capability"]["severity"] = "critical"
+    assert canonical_content_hash(rec_a) != canonical_content_hash(rec_b)
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_baseline() -> None:
+    res = validate_ai_capability_observation_v1(_baseline())
+    assert res["ok"] is True
+    assert res["record"]["schemaVersion"] == SCHEMA_VERSION
+    assert len(res["contentHash"]) == 64
+    assert res["schemaHash"] == SCHEMA_HASH_HEX
+
+
+def test_validate_accepts_all_nulls() -> None:
+    res = validate_ai_capability_observation_v1(_null_fields())
+    assert res["ok"] is True
+
+
+def test_validate_rejects_unknown_schema_version() -> None:
+    bad = _baseline()
+    bad["schemaVersion"] = "ai_capability_observation_v2"
+    res = validate_ai_capability_observation_v1(bad)
+    assert res["ok"] is False
+    assert res["code"] == "WRONG_SCHEMA_VERSION"
+
+
+def test_validate_rejects_invalid_tee_tier() -> None:
+    bad = _baseline()
+    bad["observer"]["teeAttestation"]["tier"] = "TPM"
+    res = validate_ai_capability_observation_v1(bad)
+    assert res["ok"] is False
+    assert res["code"] == "TEE_TIER_INVALID"
+
+
+def test_validate_rejects_invalid_severity() -> None:
+    bad = _baseline()
+    bad["capability"]["severity"] = "extreme"
+    res = validate_ai_capability_observation_v1(bad)
+    assert res["ok"] is False
+    assert res["code"] == "SEVERITY_INVALID"
+
+
+def test_validate_rejects_long_context() -> None:
+    bad = _baseline()
+    bad["observer"]["context"] = "x" * (MAX_CONTEXT_LEN + 1)
+    res = validate_ai_capability_observation_v1(bad)
+    assert res["ok"] is False
+    assert res["code"] == "CONTEXT_TOO_LONG"
+
+
+def test_validate_rejects_non_hex_prompt_hash() -> None:
+    bad = _baseline()
+    bad["observation"]["promptHash"] = "not-hex"
+    res = validate_ai_capability_observation_v1(bad)
+    assert res["ok"] is False
+    assert res["code"] == "HEX_FORMAT"
+
+
+def test_validate_rejects_non_iso_occurred_at() -> None:
+    bad = _baseline()
+    bad["observation"]["occurredAt"] = "2026/01/15 12:34"
+    res = validate_ai_capability_observation_v1(bad)
+    assert res["ok"] is False
+    assert res["code"] == "OCCURRED_AT_INVALID"
+
+
+def test_validate_rejects_missing_model_name() -> None:
+    bad = _baseline()
+    del bad["model"]["name"]
+    res = validate_ai_capability_observation_v1(bad)
+    assert res["ok"] is False
+    assert res["code"] == "MISSING_FIELD"
+
+
+def test_validate_rejects_non_object_root() -> None:
+    res = validate_ai_capability_observation_v1("not a dict")  # type: ignore[arg-type]
+    assert res["ok"] is False
+    assert res["code"] == "WRONG_TYPE"
+
+
+@pytest.mark.parametrize("sev", list(SEVERITIES))
+def test_every_severity_value_is_accepted(sev: str) -> None:
+    rec = _baseline()
+    rec["capability"]["severity"] = sev
+    res = validate_ai_capability_observation_v1(rec)
+    assert res["ok"] is True
+
+
+@pytest.mark.parametrize("tier", list(TEE_TIERS))
+def test_every_tee_tier_is_accepted(tier: str) -> None:
+    rec = _baseline()
+    rec["observer"]["teeAttestation"]["tier"] = tier
+    res = validate_ai_capability_observation_v1(rec)
+    assert res["ok"] is True

--- a/python/tests/test_ai_capability_observation_v1_cross_lang.py
+++ b/python/tests/test_ai_capability_observation_v1_cross_lang.py
@@ -1,0 +1,301 @@
+"""Cross-language byte-pinning tests for ai_capability_observation_v1.
+
+Real bytes — not mocks. For each fixed test vector:
+
+  1. Python encoder produces canonical CBOR via `canonical_cbor_pre_image`.
+  2. The TS encoder is invoked via `tsx` against the same JSON input.
+  3. Outputs are asserted byte-identical (hex-equal).
+
+If these tests fail, the schema contract has drifted between languages and
+downstream verifiers (cert-daemon committee, anchor-worker, SDK consumers)
+will disagree on which records are valid.
+
+Six fixed vectors cover:
+
+  V1: Fully-populated baseline (every optional field present).
+  V2: All optional sub-trees set to null (3× CBOR null primitive).
+  V3: Worker / observer context with multi-byte UTF-8 chars.
+  V4: Long TEE evidence (1 KiB) — exercises CBOR major-2 length head growth.
+  V5: Minimal-length artifactRef + minimal-context observer.
+  V6: Edge severity / tier combinations (lowest severity, "build" TEE tier).
+
+Skips gracefully if `tsx` is not on PATH.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from orynq_sdk.schemas.ai_capability_observation_v1 import (  # noqa: E402
+    SCHEMA_HASH_HEX,
+    canonical_cbor_pre_image,
+    canonical_content_hash,
+)
+
+
+HARNESS_PATH = (
+    Path(__file__).resolve().parent / "_ai_capability_observation_v1_ts_encoder.mts"
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _have_tsx() -> bool:
+    return shutil.which("tsx") is not None or shutil.which("npx") is not None
+
+
+def _run_ts_harness(record: Dict) -> Dict[str, str]:
+    if not _have_tsx():
+        pytest.skip(
+            "tsx/npx not available — install node deps to run cross-lang tests"
+        )
+    cmd: List[str]
+    if shutil.which("tsx") is not None:
+        cmd = ["tsx", str(HARNESS_PATH)]
+    else:
+        cmd = ["npx", "--no-install", "tsx", str(HARNESS_PATH)]
+
+    proc = subprocess.run(
+        cmd,
+        input=json.dumps(record),
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"TS harness failed (exit {proc.returncode}):\n"
+            f"stderr:\n{proc.stderr}\n"
+            f"stdout:\n{proc.stdout}\n"
+        )
+    out: Dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        head, _, rest = line.partition(" ")
+        out[head.strip()] = rest.strip()
+    for required in ("PRE_IMAGE_HEX", "CONTENT_HASH", "SCHEMA_HASH"):
+        if required not in out:
+            raise AssertionError(
+                f"TS harness output missing {required}:\n{proc.stdout}"
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Fixed test vectors
+# ---------------------------------------------------------------------------
+
+PROMPT_HASH = "a" * 64
+RESPONSE_HASH = "b" * 64
+MODEL_HASH = "c" * 64
+TEE_EVIDENCE_HEX = "de" * 48
+OBSERVER_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+
+VECTOR_V1_BASELINE = {
+    "schemaVersion": "ai_capability_observation_v1",
+    "model": {
+        "name": "claude-opus-4-7",
+        "version": "20260201",
+        "hash": MODEL_HASH,
+    },
+    "capability": {
+        "taxonomyId": "AUTO-MONEY-001",
+        "severity": "high",
+    },
+    "observation": {
+        "promptHash": PROMPT_HASH,
+        "responseHash": RESPONSE_HASH,
+        "artifactRef": "ipfs://QmSomeCidHere",
+        "occurredAt": "2026-01-15T12:34:56Z",
+    },
+    "observer": {
+        "ss58": OBSERVER_SS58,
+        "context": "scripted regression run",
+        "teeAttestation": {
+            "tier": "Acurast",
+            "evidence": TEE_EVIDENCE_HEX,
+        },
+    },
+}
+
+VECTOR_V2_ALL_NULLS = {
+    "schemaVersion": "ai_capability_observation_v1",
+    "model": {"name": "anon-model", "version": "v0", "hash": None},
+    "capability": {"taxonomyId": "TEST-001", "severity": "low"},
+    "observation": {
+        "promptHash": PROMPT_HASH,
+        "responseHash": RESPONSE_HASH,
+        "artifactRef": None,
+        "occurredAt": "2026-05-27T00:00:00Z",
+    },
+    "observer": {
+        "ss58": OBSERVER_SS58,
+        "context": "no tee, no artifact, no model hash",
+        "teeAttestation": None,
+    },
+}
+
+# Multi-byte UTF-8: 1/2/3-byte chars to stress CBOR major-3 text length head.
+VECTOR_V3_UTF8 = {
+    "schemaVersion": "ai_capability_observation_v1",
+    "model": {
+        "name": "modèle-世界",
+        "version": "20260201-héllo",
+        "hash": MODEL_HASH,
+    },
+    "capability": {
+        "taxonomyId": "MULTI-LINGUAL-001",
+        "severity": "medium",
+    },
+    "observation": {
+        "promptHash": PROMPT_HASH,
+        "responseHash": RESPONSE_HASH,
+        "artifactRef": "ipfs://QmHéllo-世界",
+        "occurredAt": "2026-01-15T12:34:56.789Z",
+    },
+    "observer": {
+        "ss58": OBSERVER_SS58,
+        "context": "héllo-世界 context",
+        "teeAttestation": {
+            "tier": "ARM-TZ",
+            "evidence": TEE_EVIDENCE_HEX,
+        },
+    },
+}
+
+# 1 KiB of TEE evidence — pushes CBOR length head past 1 byte.
+VECTOR_V4_LONG_EVIDENCE = {
+    "schemaVersion": "ai_capability_observation_v1",
+    "model": {
+        "name": "long-evidence-model",
+        "version": "1.0.0",
+        "hash": MODEL_HASH,
+    },
+    "capability": {
+        "taxonomyId": "LONG-EVIDENCE",
+        "severity": "critical",
+    },
+    "observation": {
+        "promptHash": PROMPT_HASH,
+        "responseHash": RESPONSE_HASH,
+        "artifactRef": "https://example.com/transcripts/abc.txt",
+        "occurredAt": "2026-03-10T08:15:30Z",
+    },
+    "observer": {
+        "ss58": OBSERVER_SS58,
+        "context": "long-evidence soak test",
+        "teeAttestation": {
+            "tier": "SEV-SNP",
+            "evidence": "ab" * 512,  # 1 024 hex chars = 512 bytes
+        },
+    },
+}
+
+# Minimal-length fields where every optional present is at its smallest.
+VECTOR_V5_MINIMAL = {
+    "schemaVersion": "ai_capability_observation_v1",
+    "model": {
+        "name": "m",
+        "version": "v",
+        "hash": MODEL_HASH,
+    },
+    "capability": {
+        "taxonomyId": "X",
+        "severity": "low",
+    },
+    "observation": {
+        "promptHash": PROMPT_HASH,
+        "responseHash": RESPONSE_HASH,
+        "artifactRef": "x",
+        "occurredAt": "2026-01-01T00:00:00Z",
+    },
+    "observer": {
+        "ss58": OBSERVER_SS58,
+        "context": "x",
+        "teeAttestation": {
+            "tier": "build",
+            "evidence": "00",
+        },
+    },
+}
+
+# Boundary severity / tier combinations.
+VECTOR_V6_BOUNDARY = {
+    "schemaVersion": "ai_capability_observation_v1",
+    "model": {
+        "name": "boundary",
+        "version": "2026.5.27",
+        "hash": MODEL_HASH,
+    },
+    "capability": {
+        "taxonomyId": "BOUND_CASE_-_42",
+        "severity": "critical",
+    },
+    "observation": {
+        "promptHash": PROMPT_HASH,
+        "responseHash": RESPONSE_HASH,
+        "artifactRef": None,
+        "occurredAt": "2026-12-31T23:59:59.999Z",
+    },
+    "observer": {
+        "ss58": OBSERVER_SS58,
+        "context": "x" * 280,  # exact context-length cap
+        "teeAttestation": {
+            "tier": "build",
+            "evidence": TEE_EVIDENCE_HEX,
+        },
+    },
+}
+
+ALL_VECTORS = [
+    ("V1_baseline", VECTOR_V1_BASELINE),
+    ("V2_all_nulls", VECTOR_V2_ALL_NULLS),
+    ("V3_utf8", VECTOR_V3_UTF8),
+    ("V4_long_evidence", VECTOR_V4_LONG_EVIDENCE),
+    ("V5_minimal", VECTOR_V5_MINIMAL),
+    ("V6_boundary", VECTOR_V6_BOUNDARY),
+]
+
+
+@pytest.mark.parametrize(
+    "name,vector",
+    ALL_VECTORS,
+    ids=lambda x: x if isinstance(x, str) else "vec",
+)
+def test_cross_lang_pre_image_byte_equal(name: str, vector: Dict) -> None:
+    """Python and TS produce byte-identical canonical CBOR pre-images."""
+    py_bytes = canonical_cbor_pre_image(vector)
+    ts_out = _run_ts_harness(vector)
+    assert ts_out["PRE_IMAGE_HEX"] == py_bytes.hex(), (
+        f"[{name}] pre-image bytes differ between TS and Python"
+    )
+
+
+@pytest.mark.parametrize(
+    "name,vector",
+    ALL_VECTORS,
+    ids=lambda x: x if isinstance(x, str) else "vec",
+)
+def test_cross_lang_content_hash_equal(name: str, vector: Dict) -> None:
+    """Python and TS produce the same content_hash (sha256 of pre-image)."""
+    py_hash = canonical_content_hash(vector)
+    ts_out = _run_ts_harness(vector)
+    assert ts_out["CONTENT_HASH"] == py_hash, (
+        f"[{name}] content_hash differs: TS={ts_out['CONTENT_HASH']}, "
+        f"Python={py_hash}"
+    )
+
+
+def test_cross_lang_schema_hash_constant() -> None:
+    """SCHEMA_HASH_HEX is identical TS-side and Python-side."""
+    ts_out = _run_ts_harness(VECTOR_V1_BASELINE)
+    assert ts_out["SCHEMA_HASH"] == SCHEMA_HASH_HEX

--- a/python/tests/test_ai_capability_observation_v1_json_schema.py
+++ b/python/tests/test_ai_capability_observation_v1_json_schema.py
@@ -1,0 +1,153 @@
+"""Round-trip the JSON-Schema artefact against the same test vectors used by
+the byte-pin lockstep test. The JSON Schema is meant for downstream consumers
+that don't link the orynq-sdk codec but still need wire-shape validation —
+so the published artefact MUST accept every record the SDK validator accepts
+and reject every record it rejects (on the same wire-shape grounds).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from orynq_sdk.schemas.ai_capability_observation_v1 import (  # noqa: E402
+    validate_ai_capability_observation_v1,
+)
+
+
+jsonschema = pytest.importorskip("jsonschema")
+
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "ai_capability_observation_v1.schema.json"
+)
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+PROMPT_HASH = "a" * 64
+RESPONSE_HASH = "b" * 64
+MODEL_HASH = "c" * 64
+TEE_EVIDENCE_HEX = "de" * 48
+OBSERVER_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+
+
+def _baseline() -> dict:
+    return {
+        "schemaVersion": "ai_capability_observation_v1",
+        "model": {
+            "name": "claude-opus-4-7",
+            "version": "20260201",
+            "hash": MODEL_HASH,
+        },
+        "capability": {
+            "taxonomyId": "AUTO-MONEY-001",
+            "severity": "high",
+        },
+        "observation": {
+            "promptHash": PROMPT_HASH,
+            "responseHash": RESPONSE_HASH,
+            "artifactRef": "ipfs://QmSomeCidHere",
+            "occurredAt": "2026-01-15T12:34:56Z",
+        },
+        "observer": {
+            "ss58": OBSERVER_SS58,
+            "context": "scripted regression run",
+            "teeAttestation": {
+                "tier": "Acurast",
+                "evidence": TEE_EVIDENCE_HEX,
+            },
+        },
+    }
+
+
+def test_json_schema_accepts_baseline(schema: dict) -> None:
+    rec = _baseline()
+    jsonschema.validate(instance=rec, schema=schema)
+    assert validate_ai_capability_observation_v1(rec)["ok"] is True
+
+
+def test_json_schema_accepts_all_nulls(schema: dict) -> None:
+    rec = _baseline()
+    rec["model"]["hash"] = None
+    rec["observation"]["artifactRef"] = None
+    rec["observer"]["teeAttestation"] = None
+    jsonschema.validate(instance=rec, schema=schema)
+    assert validate_ai_capability_observation_v1(rec)["ok"] is True
+
+
+@pytest.mark.parametrize(
+    "mutator,key",
+    [
+        (
+            lambda r: r.update({"schemaVersion": "ai_capability_observation_v2"}),
+            "schemaVersion",
+        ),
+        (lambda r: r["capability"].update({"severity": "extreme"}), "severity"),
+        (
+            lambda r: r["observer"]["teeAttestation"].update({"tier": "TPM"}),
+            "tier",
+        ),
+        (
+            lambda r: r["observation"].update({"promptHash": "not-hex"}),
+            "promptHash",
+        ),
+        (
+            lambda r: r["observation"].update({"occurredAt": "2026/01/15"}),
+            "occurredAt",
+        ),
+        (lambda r: r["model"].update({"name": ""}), "model.name"),
+        (
+            lambda r: r["observer"].update({"context": "x" * 281}),
+            "context",
+        ),
+    ],
+)
+def test_json_schema_rejects_mutations(
+    schema: dict, mutator, key: str
+) -> None:
+    rec = _baseline()
+    mutator(rec)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=rec, schema=schema)
+    sdk = validate_ai_capability_observation_v1(rec)
+    assert sdk["ok"] is False, f"SDK validator unexpectedly accepted {key}={rec}"
+
+
+def test_json_schema_rejects_extra_top_level_property(schema: dict) -> None:
+    rec = _baseline()
+    rec["extraField"] = "unexpected"  # type: ignore[typeddict-item]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=rec, schema=schema)
+
+
+def test_json_schema_rejects_missing_required(schema: dict) -> None:
+    rec = _baseline()
+    del rec["observer"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=rec, schema=schema)
+
+
+def test_sdk_accepts_records_the_schema_accepts() -> None:
+    """The SDK validator is the byte-canonicaliser; the JSON schema is a
+    downstream wire check. Whenever the JSON schema accepts a record, the
+    SDK validator MUST also accept it (otherwise the SDK is stricter than
+    the published contract and consumers can't predict acceptance).
+    """
+    rec = _baseline()
+    rec2 = deepcopy(rec)
+    rec2["observer"]["teeAttestation"] = None
+    rec2["observation"]["artifactRef"] = None
+    rec2["model"]["hash"] = None
+    assert validate_ai_capability_observation_v1(rec)["ok"] is True
+    assert validate_ai_capability_observation_v1(rec2)["ok"] is True


### PR DESCRIPTION
## Summary

* Adds a byte-pinned canonical CBOR codec, validator, and cross-language test
  vectors for the `ai_capability_observation_v1` receipt-class schema —
  cryptographically-verifiable observation receipts for AI model outputs.
* Registers `sha256(\"ai_capability_observation_v1\")` as a
  `TRUSTED_DISCRIMINATOR_SCHEMAS` member alongside `compute_metering_v2` and
  `orynq_trace_v1` (caller passes it as `schemaHash` to `submitReceipt`).
* Publishes a JSON-Schema artefact at
  `fixtures/ai_capability_observation_v1.schema.json` for downstream
  consumers that need wire-shape validation without linking the SDK codec.

## Wire shape (locked)

```ts
interface AiCapabilityObservationV1 {
  schemaVersion: \"ai_capability_observation_v1\";
  model:        { name, version, hash:        string|null };
  capability:   { taxonomyId, severity: \"low\"|\"medium\"|\"high\"|\"critical\" };
  observation:  { promptHash, responseHash, artifactRef: string|null, occurredAt };
  observer:     { ss58, context,
                  teeAttestation: { tier: \"ARM-TZ\"|\"Acurast\"|\"SEV-SNP\"|\"build\",
                                    evidence } | null };
}
```

## Canonical pre-image

`content_hash = sha256(canonical_cbor([\"ai_capability_observation_v1\",
model_map, capability_map, observation_map, observer_map]))` — RFC 8949
§4.2.1 sorted keys, definite-length, CBOR null (`0xf6`) for nullable
sub-trees. Cert-daemon's M-of-N committee signs these bytes before anchoring
to Cardano L1.

## Test plan

* [x] TS self-tests: 22 vitest cases (constants, determinism, key-sort
      order, null primitive, validator surface). `pnpm --filter
      @fluxpointstudios/orynq-sdk-anchors-materios test`.
* [x] Python self-tests: 32 pytest cases (parametrised over every severity
      + every TEE tier). `pytest python/tests/test_ai_capability_observation_v1.py`.
* [x] Cross-language byte-pin: 13 pytest cases over 6 fixed vectors
      (baseline / all-null / multi-byte UTF-8 / 1 KiB TEE evidence /
      minimal-length / boundary). Asserts Python and TS produce identical
      `pre_image_hex`, `content_hash`, and `schema_hash`.
* [x] JSON-Schema round-trip: 12 pytest cases asserting the published
      schema accepts and rejects the same records the SDK validator does.
* [x] Full TS test suite (excluding pre-existing integration flake):
      1735 passed / 1 skipped.
* [x] Full Python test suite: 262 passed / 2 skipped.
* [x] `pnpm build` produces dist artefacts with the new exports
      (`canonicalCborPreImageAiCapabilityObservationV1`, types, constants).
* [x] `pnpm vectors:verify` passes (12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)