### PR TITLE
fix(schemas): skip cross-lang test when tsx unreachable in Python-only CI

### DIFF
--- a/python/tests/test_ai_capability_observation_v1_cross_lang.py
+++ b/python/tests/test_ai_capability_observation_v1_cross_lang.py
@@ -47,20 +47,28 @@ HARNESS_PATH = (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _have_tsx() -> bool:
-    return shutil.which("tsx") is not None or shutil.which("npx") is not None
+def _tsx_command() -> List[str] | None:
+    """Resolve a runnable `tsx <script>` command, or return None to skip.
+
+    Two paths are accepted: tsx on PATH, or the workspace's
+    `node_modules/.bin/tsx`. Python-only CI jobs that skip `pnpm install`
+    lack both and the test skips cleanly.
+    """
+    if shutil.which("tsx") is not None:
+        return ["tsx"]
+    local = REPO_ROOT / "node_modules" / ".bin" / "tsx"
+    if local.exists():
+        return [str(local)]
+    return None
 
 
 def _run_ts_harness(record: Dict) -> Dict[str, str]:
-    if not _have_tsx():
+    base = _tsx_command()
+    if base is None:
         pytest.skip(
-            "tsx/npx not available — install node deps to run cross-lang tests"
+            "tsx not reachable — install node deps (pnpm install) to run cross-lang tests"
         )
-    cmd: List[str]
-    if shutil.which("tsx") is not None:
-        cmd = ["tsx", str(HARNESS_PATH)]
-    else:
-        cmd = ["npx", "--no-install", "tsx", str(HARNESS_PATH)]
+    cmd: List[str] = [*base, str(HARNESS_PATH)]
 
     proc = subprocess.run(
         cmd,


### PR DESCRIPTION
## Summary

Main is red on `python-test` after #69 landed because the CI Python-only job
runs pytest without `pnpm install`, so `npx --no-install tsx` errors out
mid-test. Detect tsx more strictly (`shutil.which(\"tsx\")` OR a workspace
`node_modules/.bin/tsx`) and skip cleanly when neither is reachable.

## Test plan

- [x] Local: 13/13 cross-lang assertions pass under \`pnpm install\` + pytest.
- [x] Simulated Python-only env: tests skip cleanly with reason \"tsx not reachable\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)