### PR TITLE
feat(observe): rename to @orynq/observe + bump anchors-materios to 0.4.0

### DIFF
--- a/.changeset/observe-rename-and-anchors-040.md
+++ b/.changeset/observe-rename-and-anchors-040.md
@@ -1,0 +1,16 @@
+---
+"@fluxpointstudios/orynq-sdk-anchors-materios": minor
+---
+
+Expose canonical CBOR helpers + `AiCapabilityObservationV1` type for downstream observe SDK. New named exports from the package entry point:
+
+- `canonicalCborPreImageAiCapabilityObservationV1`
+- `canonicalContentHashAiCapabilityObservationV1`
+- `validateAiCapabilityObservationV1`
+- `AI_CAPABILITY_OBSERVATION_V1_SCHEMA_HASH_HEX`
+- `AI_CAPABILITY_OBSERVATION_V1_SCHEMA_VERSION`
+- `AI_CAPABILITY_OBSERVATION_V1_MAX_CONTEXT_LEN`
+- `SEVERITIES`, `TEE_TIERS`
+- types: `AiCapabilityObservationV1`, `ModelV1`, `CapabilityV1`, `ObservationV1`, `TeeAttestationV1`, `ObserverV1`, `TeeTier`, `Severity`
+
+Additive — no existing API is removed or renamed.

--- a/packages/anchors-materios/package.json
+++ b/packages/anchors-materios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxpointstudios/orynq-sdk-anchors-materios",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Materios blockchain anchor support for Orynq SDK - submits and verifies anchors via Substrate extrinsics",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/orynq-observe-js/README.md
+++ b/packages/orynq-observe-js/README.md
@@ -1,4 +1,4 @@
-# @fluxpointstudios/orynq-observe
+# @orynq/observe
 
 SDK for publishing attested AI model capability observations to chain-anchored receipts.
 
@@ -10,7 +10,7 @@ either runtime verifies on the gateway and on chain.
 
 ```bash
 # 1. Install
-npm install @fluxpointstudios/orynq-observe
+npm install @orynq/observe
 
 # 2. Generate an observer keyfile
 npx orynq-observe keygen --out ./observer.json
@@ -37,7 +37,7 @@ npx orynq-observe submit \
 ## Library usage
 
 ```typescript
-import { Observation } from "@fluxpointstudios/orynq-observe";
+import { Observation } from "@orynq/observe";
 
 const obs = new Observation({
   modelName: "claude-opus-4-7",

--- a/packages/orynq-observe-js/package.json
+++ b/packages/orynq-observe-js/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@fluxpointstudios/orynq-observe",
+  "name": "@orynq/observe",
   "version": "0.1.0",
-  "description": "SDK for publishing attested AI model capability observations to Materios chain-anchored receipts.",
+  "description": "SDK for publishing attested AI model behavior observations to a chain-anchored public registry.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/Flux-Point-Studios/orynq-sdk/tree/main/packages/orynq-observe-js#readme",
   "bugs": "https://github.com/Flux-Point-Studios/orynq-sdk/issues",
   "dependencies": {
-    "@fluxpointstudios/orynq-sdk-anchors-materios": "workspace:*",
+    "@fluxpointstudios/orynq-sdk-anchors-materios": "^0.4.0",
     "@polkadot/util": "^13.5.0",
     "@polkadot/util-crypto": "^13.5.0",
     "@polkadot/keyring": "^13.5.0"

--- a/packages/orynq-observe-js/src/__tests__/canonical_lockstep.test.ts
+++ b/packages/orynq-observe-js/src/__tests__/canonical_lockstep.test.ts
@@ -4,7 +4,7 @@
  *
  * The SDK is a thin wrapper around the canonical
  * `@fluxpointstudios/orynq-sdk-anchors-materios` codec; this test is the
- * harness that decides when the alignment is correct.
+ * harness that decides when the byte-equality holds.
  */
 
 import { describe, expect, it } from "vitest";

--- a/packages/orynq-observe-js/src/cli.ts
+++ b/packages/orynq-observe-js/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Command-line interface for @fluxpointstudios/orynq-observe.
+ * Command-line interface for @orynq/observe.
  *
  * Subcommands:
  *   keygen  — generate an sr25519 observer keyfile.

--- a/packages/orynq-observe-js/src/index.ts
+++ b/packages/orynq-observe-js/src/index.ts
@@ -1,7 +1,7 @@
 /**
- * @fluxpointstudios/orynq-observe — SDK for attested AI model observations.
+ * @orynq/observe — SDK for attested AI model behavior observations.
  *
- *     import { Observation, ObserverKeypair } from "@fluxpointstudios/orynq-observe";
+ *     import { Observation, ObserverKeypair } from "@orynq/observe";
  *
  *     const obs = new Observation({
  *       modelName: "claude-opus-4-7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,7 +326,7 @@ importers:
   packages/orynq-observe-js:
     dependencies:
       '@fluxpointstudios/orynq-sdk-anchors-materios':
-        specifier: workspace:*
+        specifier: ^0.4.0
         version: link:../anchors-materios
       '@polkadot/keyring':
         specifier: ^13.5.0


### PR DESCRIPTION
## Summary

Publishes `@orynq/observe@0.1.0` and `@fluxpointstudios/orynq-sdk-anchors-materios@0.4.0` to npm. Bumps the anchors dep to consume the new canonical CBOR helpers required by observe.

- `anchors-materios` 0.3.2 → 0.4.0 (minor): exposes `canonicalCborPreImageAiCapabilityObservationV1`, `canonicalContentHashAiCapabilityObservationV1`, `validateAiCapabilityObservationV1`, `AiCapabilityObservationV1` type, and the `AI_CAPABILITY_OBSERVATION_V1_*` schema constants.
- `orynq-observe-js` renamed `@fluxpointstudios/orynq-observe` → `@orynq/observe`. The anchors-materios dep flips from `workspace:*` to `^0.4.0` so the published tarball resolves against the just-published version.
- Source-tree sed-pass: package.json, README, src/index.ts, src/cli.ts, lockstep test.
- 47/47 vitest tests still pass.
- Fresh-install probe (`npm install @orynq/observe` from /tmp) resolves and exports `Observation`, `ObserverKeypair`, `submitObservation`, `canonicalCbor`, etc.

Both packages are already live on npm; this PR source-controls the diff that matches what was published.

## Test plan

- [x] anchors-materios builds clean; `dist/index.d.ts` re-exports the new symbols
- [x] orynq-observe-js builds clean; 47/47 vitest tests pass
- [x] Tarball sanity: no /home/deci paths, no node_modules, no .env, no internal framing strings
- [x] Fresh-install probe: `mkdir /tmp/install-check-js && npm install @orynq/observe` resolves; `require('@orynq/observe')` exports expected symbols
- [ ] CI green on this branch