### PR TITLE
fix(anchor-worker): lucid-cardano -> @lucid-evolution/lucid (fixes CostModel 166 / offline anchor)

### DIFF
--- a/services/anchor-worker/package.json
+++ b/services/anchor-worker/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "@fluxpointstudios/orynq-sdk-anchors-cardano": "^0.1.0",
-    "lucid-cardano": "^0.10.7"
+    "@lucid-evolution/lucid": "^0.4.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/services/anchor-worker/src/anchor.ts
+++ b/services/anchor-worker/src/anchor.ts
@@ -4,7 +4,7 @@
  * Location: services/anchor-worker/src/anchor.ts
  */
 
-import { Lucid, Blockfrost } from "lucid-cardano";
+import { Lucid, Blockfrost, type LucidEvolution } from "@lucid-evolution/lucid";
 import {
   buildAnchorMetadata,
   serializeForCbor,
@@ -27,12 +27,12 @@ const POI_METADATA_LABEL = 2222;
 /**
  * Lucid instance singleton.
  */
-let lucidInstance: Awaited<ReturnType<typeof Lucid.new>> | null = null;
+let lucidInstance: LucidEvolution | null = null;
 
 /**
  * Get or create Lucid instance.
  */
-async function getLucid(): Promise<Awaited<ReturnType<typeof Lucid.new>>> {
+async function getLucid(): Promise<LucidEvolution> {
   if (lucidInstance) {
     return lucidInstance;
   }
@@ -48,12 +48,12 @@ async function getLucid(): Promise<Awaited<ReturnType<typeof Lucid.new>>> {
     throw new Error(`Unsupported network: ${CARDANO_NETWORK}`);
   }
 
-  lucidInstance = await Lucid.new(
+  lucidInstance = await Lucid(
     new Blockfrost(baseUrl, BLOCKFROST_PROJECT_ID!),
     CARDANO_NETWORK === "mainnet" ? "Mainnet" : "Preprod"
   );
 
-  lucidInstance.selectWalletFromSeed(WALLET_SEED_PHRASE!);
+  lucidInstance.selectWallet.fromSeed(WALLET_SEED_PHRASE!);
 
   return lucidInstance;
 }
@@ -166,7 +166,7 @@ export async function anchorProcessTrace(
     .attachMetadata(POI_METADATA_LABEL, metadataPayload)
     .complete();
 
-  const signedTx = await tx.sign().complete();
+  const signedTx = await tx.sign.withWallet().complete();
   const txHash = await signedTx.submit();
 
   console.log(`[anchor] Transaction submitted: ${txHash}`);


### PR DESCRIPTION
Materios L1 anchor offline — every request failed `CostModel operation 166 out of bounds. Max is 166`. lucid-cardano@0.10.7 is abandoned/pre-Conway (caps PlutusV1 at 166 ops); preprod now has Conway cost models (V1/V2=332, V3=350), so `.complete()` blows the WASM CostModel bound. Migrated to maintained @lucid-evolution/lucid (Conway-ready); metadata-only tx, ~5 API call changes. anchor-worker-materios has the same latent dep (not deployed; noted). CI builds the image; redeploy on .230 (Docker compose, not the dead K8s deploy job) + preprod anchor test to follow. 🤖 Generated with [Claude Code](https://claude.com/claude-code)