### PR TITLE
fix(anchor-worker): pin pnpm@9.15.0 so the image builds on node:20

### DIFF
--- a/services/anchor-worker/package.json
+++ b/services/anchor-worker/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "main": "dist/index.js",
+  "packageManager": "pnpm@9.15.0",
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
corepack was pulling pnpm 11.5.2 (needs Node>=22.13) on a node:20 base -> `node:sqlite` error, every build failing. Pin pnpm to Node-20-compatible 9.15.0 via packageManager. Unblocks the @lucid-evolution/lucid anchor fix (#74). 🤖 Generated with [Claude Code](https://claude.com/claude-code)